### PR TITLE
Change the port mapping in docker compose to 8080

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     image: "metadata_service:latest"
     container_name: "metadata_service"
     ports:
-      - "5004:5004"
+      - "8080:8080"
     volumes:
       - .:/code
     environment:


### PR DESCRIPTION
If you build the docker image from the docker file  HTTP port is exposed at 8080 however docker-compose maps the port to 5004.