### PR TITLE
Migration Tool and user provided ids

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -12,9 +12,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: build assets
-        working-directory: ${{ github.workspace }}
-        run: ls -la
       - uses: docker/build-push-action@v1
         with:
           username: ${{ secrets.DOCKER_USERNAME_NETFLIX_OSS }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN pip3 install virtualenv && pip3 install requests
 RUN virtualenv /opt/v_1_0_1 -p python3
 RUN virtualenv /opt/latest -p python3
 
-RUN /opt/v_1_0_1/bin/pip install https://github.com/Netflix/metaflow-service/archive/1.0.1.zip
+RUN /opt/v_1_0_1/bin/pip install https://github.com/ferras/metaflow-service-clone/archive/v1.0.2-alpha.zip
 
 ADD metadata_service /root/metadata_service
 ADD setup.py setup.cfg /root/

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN pip3 install virtualenv && pip3 install requests
 RUN virtualenv /opt/v_1_0_1 -p python3
 RUN virtualenv /opt/latest -p python3
 
-RUN /opt/v_1_0_1/bin/pip install https://github.com/ferras/metaflow-service-clone/archive/v1.0.2-alpha.zip
+RUN /opt/v_1_0_1/bin/pip install https://github.com/Netflix/metaflow-service/archive/1.0.1.zip
 
 ADD metadata_service /root/metadata_service
 ADD setup.py setup.cfg /root/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,24 @@
-FROM python:3.7
+FROM golang:latest
+
+RUN go get -u github.com/pressly/goose/cmd/goose
+
+RUN apt-get update && apt-get -y install python3.7 && apt-get -y install python3-pip && apt-get -y install libpq-dev
+
+RUN pip3 install virtualenv && pip3 install requests
+
+RUN virtualenv /opt/v_1_0_1 -p python3
+RUN virtualenv /opt/latest -p python3
+
+RUN /opt/v_1_0_1/bin/pip install https://github.com/Netflix/metaflow-service/archive/1.0.1.zip
+
 ADD metadata_service /root/metadata_service
 ADD setup.py setup.cfg /root/
 WORKDIR /root
-RUN pip install .
-CMD metadata_service
+RUN /opt/latest/bin/pip install .
+
+# Migration Service
+ADD migration_service /migration_service
+RUN pip3 install -r /migration_service/requirements.txt
+
+RUN chmod 777 /migration_service/run_script.py
+CMD python3 /migration_service/run_script.py

--- a/Dockerfile.metadata_service
+++ b/Dockerfile.metadata_service
@@ -1,0 +1,6 @@
+FROM python:3.7
+ADD metadata_service /root/metadata_service
+ADD setup.py setup.cfg /root/
+WORKDIR /root
+RUN pip install .
+CMD metadata_service

--- a/Dockerfile.migration_service
+++ b/Dockerfile.migration_service
@@ -1,0 +1,7 @@
+FROM python:3.7
+
+# Migration Service
+ADD migration_service /migration_service
+RUN pip3 install -r /migration_service/requirements.txt
+RUN cd /
+CMD python3 -m migration_service.migration_server

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,7 @@ services:
     restart: always
     container_name: "metadata_service"
     ports:
+      - "${MF_MIGRATION_PORT:-8082}:${MF_MIGRATION_PORT:-8082}"
       - "${MF_METADATA_PORT:-8080}:${MF_METADATA_PORT:-8080}"
     volumes:
       - .:/code
@@ -14,8 +15,10 @@ services:
       - MF_METADATA_DB_USER=postgres
       - MF_METADATA_DB_PSWD=postgres
       - MF_METADATA_DB_NAME=postgres
+      - MF_MIGRATION_ENDPOINTS_ENABLED=1
       - MF_METADATA_PORT=${MF_METADATA_PORT:-8080}
       - MF_METADATA_HOST=${MF_METADATA_HOST:-0.0.0.0}
+      - MF_MIGRATION_PORT=${MF_METADATA_PORT:-8082}
     links:
       - db
   db:

--- a/metadata_service/api/__init__.py
+++ b/metadata_service/api/__init__.py
@@ -1,2 +1,6 @@
-METADATA_SERVICE_VERSION = '1.0.1'
+import pkg_resources
+
+version = pkg_resources.require("metadata_service")[0].version
+
+METADATA_SERVICE_VERSION = version
 METADATA_SERVICE_HEADER = 'METADATA_SERVICE_VERSION'

--- a/metadata_service/api/admin.py
+++ b/metadata_service/api/admin.py
@@ -12,6 +12,24 @@ class AuthApi(object):
     def __init__(self, app):
         app.router.add_route("GET", "/auth/token", self.get_authorization_token)
         app.router.add_route("GET", "/ping", self.ping)
+        app.router.add_route("GET", "/version", self.version)
+
+
+    async def version(self, request):
+        """
+        ---
+        description: Returns the version of the metadata service
+        tags:
+        - Admin
+        produces:
+        - 'text/plain'
+        responses:
+            "200":
+                description: successful operation. Return the version number
+            "405":
+                description: invalid HTTP Method
+        """
+        return web.Response(text=str(METADATA_SERVICE_VERSION))
 
     async def ping(self, request):
         """

--- a/metadata_service/api/metadata.py
+++ b/metadata_service/api/metadata.py
@@ -26,7 +26,7 @@ class MetadataApi(object):
             "tasks/{task_id}/metadata",
             self.create_metadata,
         )
-
+        self._db = AsyncPostgresDB.get_instance()
         self._async_table = AsyncPostgresDB.get_instance().metadata_table_postgres
 
 
@@ -48,7 +48,7 @@ class MetadataApi(object):
           in: "path"
           description: "run_number"
           required: true
-          type: "integer"
+          type: "string"
         - name: "step_name"
           in: "path"
           description: "step_name"
@@ -58,7 +58,7 @@ class MetadataApi(object):
           in: "path"
           description: "task_id"
           required: true
-          type: "integer"
+          type: "string"
         produces:
         - text/plain
         responses:
@@ -93,7 +93,7 @@ class MetadataApi(object):
           in: "path"
           description: "run_number"
           required: true
-          type: "integer"
+          type: "string"
         produces:
         - text/plain
         responses:
@@ -124,7 +124,7 @@ class MetadataApi(object):
           in: "path"
           description: "run_number"
           required: true
-          type: "integer"
+          type: "string"
         - name: "step_name"
           in: "path"
           description: "step_name"
@@ -134,7 +134,7 @@ class MetadataApi(object):
           in: "path"
           description: "task_id"
           required: true
-          type: "integer"
+          type: "string"
         - name: "body"
           in: "body"
           description: "body"
@@ -171,12 +171,22 @@ class MetadataApi(object):
 
         body = await read_body(request.content)
         count = 0
+        try:
+            run_number, run_id = await self._db.get_run_ids(flow_name, run_number)
+            task_id, task_name = await self._db.get_task_ids(flow_name, run_number,
+                                                             step_name, task_id)
+        except Exception:
+            return web.Response(status=400, body=json.dumps(
+                {"message": "need to register run_id and task_id first"}))
+
         for datum in body:
             values = {
                 "flow_id": flow_name,
                 "run_number": run_number,
+                "run_id": run_id,
                 "step_name": step_name,
                 "task_id": task_id,
+                "task_name": task_name,
                 "field_name": datum.get("field_name", " "),
                 "value": datum.get("value", " "),
                 "type": datum.get("type", " "),

--- a/metadata_service/api/step.py
+++ b/metadata_service/api/step.py
@@ -20,6 +20,8 @@ class StepApi(object):
             self.create_step,
         )
         self._async_table = AsyncPostgresDB.get_instance().step_table_postgres
+        self._run_table = AsyncPostgresDB.get_instance().run_table_postgres
+        self._db = AsyncPostgresDB.get_instance()
 
     @format_response
     @handle_exceptions
@@ -39,7 +41,7 @@ class StepApi(object):
           in: "path"
           description: "run_number"
           required: true
-          type: "integer"
+          type: "string"
         produces:
         - text/plain
         responses:
@@ -70,7 +72,7 @@ class StepApi(object):
           in: "path"
           description: "run_number"
           required: true
-          type: "integer"
+          type: "string"
         - name: "step_name"
           in: "path"
           description: "step_name"
@@ -109,7 +111,7 @@ class StepApi(object):
           in: "path"
           description: "run_number"
           required: true
-          type: "integer"
+          type: "string"
         - name: "step_name"
           in: "path"
           description: "step_name"
@@ -145,8 +147,11 @@ class StepApi(object):
         tags = body.get("tags")
         system_tags = body.get("system_tags")
 
+        run_number, run_id = await self._db.get_run_ids(flow_name, run_number)
+
         step_row = StepRow(
-            flow_name, run_number, user, step_name, tags=tags, system_tags=system_tags
+            flow_name, run_number, run_id, user, step_name, tags=tags,
+            system_tags=system_tags
         )
 
         return await self._async_table.add_step(step_row)

--- a/metadata_service/api/task.py
+++ b/metadata_service/api/task.py
@@ -1,6 +1,9 @@
 from ..data.models import TaskRow
 from ..data.postgres_async_db import AsyncPostgresDB
 from .utils import read_body, format_response, handle_exceptions
+import json
+from aiohttp import web
+
 import asyncio
 
 
@@ -25,6 +28,7 @@ class TaskApi(object):
             self.create_task,
         )
         self._async_table = AsyncPostgresDB.get_instance().task_table_postgres
+        self._db = AsyncPostgresDB.get_instance()
 
     @format_response
     @handle_exceptions
@@ -44,7 +48,7 @@ class TaskApi(object):
           in: "path"
           description: "run_number"
           required: true
-          type: "integer"
+          type: "string"
         - name: "step_name"
           in: "path"
           description: "step_name"
@@ -82,7 +86,7 @@ class TaskApi(object):
           in: "path"
           description: "run_number"
           required: true
-          type: "integer"
+          type: "string"
         - name: "step_name"
           in: "path"
           description: "step_name"
@@ -127,7 +131,7 @@ class TaskApi(object):
           in: "path"
           description: "run_number"
           required: true
-          type: "integer"
+          type: "string"
         - name: "step_name"
           in: "path"
           description: "step_name"
@@ -146,11 +150,15 @@ class TaskApi(object):
                     type: object
                 system_tags:
                     type: object
+                task_id:
+                    type: string
         produces:
         - 'text/plain'
         responses:
             "202":
                 description: successful operation. Return newly registered task
+            "400":
+                description: invalid HTTP Request
             "405":
                 description: invalid HTTP Method
         """
@@ -162,10 +170,20 @@ class TaskApi(object):
         user = body.get("user_name")
         tags = body.get("tags")
         system_tags = body.get("system_tags")
+        task_name = body.get("task_id")
+
+        if task_name and task_name.isnumeric():
+            return web.Response(status=400, body=json.dumps(
+                {"message": "provided task_name may not be a numeric"}))
+
+        run_number, run_id = await self._db.get_run_ids(flow_id, run_number)
+
         task = TaskRow(
             flow_id=flow_id,
             run_number=run_number,
+            run_id=run_id,
             step_name=step_name,
+            task_name=task_name,
             user_name=user,
             tags=tags,
             system_tags=system_tags,

--- a/metadata_service/api/utils.py
+++ b/metadata_service/api/utils.py
@@ -1,10 +1,13 @@
 import json
 import sys
 import traceback
+import collections
 from multidict import MultiDict
 from aiohttp import web
 from functools import wraps
 from . import METADATA_SERVICE_VERSION, METADATA_SERVICE_HEADER
+
+Response = collections.namedtuple("Response", "response_code body")
 
 
 async def read_body(request_content):
@@ -42,7 +45,7 @@ def http_500(msg):
         'type': 'about:blank'
     }
 
-    return 500, body
+    return Response(response_code=500, body=body)
 
 
 def handle_exceptions(func):

--- a/metadata_service/api/utils.py
+++ b/metadata_service/api/utils.py
@@ -35,7 +35,6 @@ def get_traceback_str():
         ]
     )
 
-
 def http_500(msg):
     body = {
         'traceback': get_traceback_str(),
@@ -73,3 +72,4 @@ def format_response(func):
                                 {METADATA_SERVICE_HEADER: METADATA_SERVICE_VERSION}))
 
     return wrapper
+

--- a/metadata_service/data/db_utils.py
+++ b/metadata_service/data/db_utils.py
@@ -26,3 +26,37 @@ def aiopg_exception_handling(exception):
 
 def get_db_ts_epoch_str():
     return str(int(round(time.time() * 1000)))
+
+
+def translate_run_key(v: str):
+    key = "run_id"
+    value = "'{0}'".format(v)
+
+    if str(v).isnumeric():
+        key = "run_number"
+        value = str(value)
+
+    return key, value
+
+
+def translate_task_key(v: str):
+    key = "task_name"
+    value = "'{0}'".format(v)
+
+    if str(v).isnumeric():
+        key = "task_id"
+        value = str(value)
+
+    return key, value
+
+
+def get_exposed_run_id(run_number, run_id):
+    if run_id is not None:
+        return run_id
+    return run_number
+
+
+def get_exposed_task_id(task_id, task_name):
+    if task_name is not None:
+        return task_name
+    return task_id

--- a/metadata_service/data/models.py
+++ b/metadata_service/data/models.py
@@ -1,5 +1,5 @@
 import time
-
+from .db_utils import get_exposed_run_id, get_exposed_task_id
 
 class FlowRow(object):
     flow_id: str = None
@@ -15,7 +15,7 @@ class FlowRow(object):
         self.tags = tags
         self.system_tags = system_tags
 
-    def serialize(self):
+    def serialize(self, expanded: bool = False):
         return {
             "flow_id": self.flow_id,
             "user_name": self.user_name,
@@ -28,6 +28,7 @@ class FlowRow(object):
 class RunRow(object):
     flow_id: str = None
     run_number: int = None
+    run_id: str = None
     user_name: str = None
     ts_epoch: int = 0
 
@@ -36,13 +37,16 @@ class RunRow(object):
         flow_id,
         user_name,
         run_number=None,
+        run_id=None,
         ts_epoch=None,
         tags=None,
         system_tags=None,
+        last_heartbeat_ts=None,
     ):
         self.flow_id = flow_id
         self.user_name = user_name
         self.run_number = run_number
+        self.run_id = run_id
         self.tags = tags
         self.system_tags = system_tags
         if ts_epoch is None:
@@ -50,20 +54,32 @@ class RunRow(object):
 
         self.ts_epoch = ts_epoch
 
-    def serialize(self):
-        return {
-            "flow_id": self.flow_id,
-            "run_number": self.run_number,
-            "user_name": self.user_name,
-            "ts_epoch": self.ts_epoch,
-            "tags": self.tags,
-            "system_tags": self.system_tags,
-        }
+    def serialize(self, expanded: bool = False):
+        if expanded:
+            return {
+                "flow_id": self.flow_id,
+                "run_number": self.run_number,
+                "run_id": self.run_id,
+                "user_name": self.user_name,
+                "ts_epoch": self.ts_epoch,
+                "tags": self.tags,
+                "system_tags": self.system_tags
+            }
+        else:
+            return {
+                "flow_id": self.flow_id,
+                "run_number": get_exposed_run_id(self.run_number, self.run_id),
+                "user_name": self.user_name,
+                "ts_epoch": self.ts_epoch,
+                "tags": self.tags,
+                "system_tags": self.system_tags
+            }
 
 
 class StepRow(object):
     flow_id: str = None
     run_number: int = None
+    run_id: str = None
     step_name: str = None
     user_name: str = None
     ts_epoch: int = 0
@@ -74,6 +90,7 @@ class StepRow(object):
         self,
         flow_id,
         run_number,
+        run_id,
         user_name,
         step_name,
         ts_epoch=None,
@@ -82,6 +99,11 @@ class StepRow(object):
     ):
         self.flow_id = flow_id
         self.run_number = run_number
+
+        if run_id is None:
+            run_id = str(run_number)
+        self.run_id = run_id
+
         self.step_name = step_name
         self.user_name = user_name
         if ts_epoch is None:
@@ -91,23 +113,38 @@ class StepRow(object):
         self.tags = tags
         self.system_tags = system_tags
 
-    def serialize(self):
-        return {
-            "flow_id": self.flow_id,
-            "run_number": self.run_number,
-            "step_name": self.step_name,
-            "user_name": self.user_name,
-            "ts_epoch": self.ts_epoch,
-            "tags": self.tags,
-            "system_tags": self.system_tags,
-        }
+    def serialize(self, expanded: bool = False):
+        if expanded:
+            return {
+                "flow_id": self.flow_id,
+                "run_number": self.run_number,
+                "run_id": self.run_id,
+                "step_name": self.step_name,
+                "user_name": self.user_name,
+                "ts_epoch": self.ts_epoch,
+                "tags": self.tags,
+                "system_tags": self.system_tags,
+            }
+        else:
+            return {
+                "flow_id": self.flow_id,
+                "run_number": get_exposed_run_id(self.run_number, self.run_id),
+                "step_name": self.step_name,
+                "user_name": self.user_name,
+                "ts_epoch": self.ts_epoch,
+                "tags": self.tags,
+                "system_tags": self.system_tags,
+            }
+
 
 
 class TaskRow(object):
     flow_id: str = None
     run_number: int = None
+    run_id: str = None
     step_name: str = None
     task_id: int = None
+    task_name: str = None
     user_name: str = None
     ts_epoch: int = 0
     tags = None
@@ -117,17 +154,22 @@ class TaskRow(object):
         self,
         flow_id,
         run_number,
+        run_id,
         user_name,
         step_name,
         task_id=None,
+        task_name=None,
         ts_epoch=None,
         tags=None,
         system_tags=None,
+        last_heartbeat_ts=None,
     ):
         self.flow_id = flow_id
         self.run_number = run_number
+        self.run_id = run_id
         self.step_name = step_name
         self.task_id = task_id
+        self.task_name = task_name
         self.user_name = user_name
         if ts_epoch is not None:
             ts_epoch = int(round(time.time() * 1000))
@@ -136,24 +178,40 @@ class TaskRow(object):
         self.tags = tags
         self.system_tags = system_tags
 
-    def serialize(self):
-        return {
-            "flow_id": self.flow_id,
-            "run_number": self.run_number,
-            "step_name": self.step_name,
-            "task_id": self.task_id,
-            "user_name": self.user_name,
-            "ts_epoch": self.ts_epoch,
-            "tags": self.tags,
-            "system_tags": self.system_tags,
-        }
+    def serialize(self, expanded: bool = False):
+        if expanded:
+            return {
+                "flow_id": self.flow_id,
+                "run_number": self.run_number,
+                "run_id": self.run_id,
+                "step_name": self.step_name,
+                "task_id": self.task_id,
+                "task_name": self.task_name,
+                "user_name": self.user_name,
+                "ts_epoch": self.ts_epoch,
+                "tags": self.tags,
+                "system_tags": self.system_tags,
+            }
+        else:
+            return {
+                "flow_id": self.flow_id,
+                "run_number": get_exposed_run_id(self.run_number, self.run_id),
+                "step_name": self.step_name,
+                "task_id": get_exposed_task_id(self.task_id, self.task_name),
+                "user_name": self.user_name,
+                "ts_epoch": self.ts_epoch,
+                "tags": self.tags,
+                "system_tags": self.system_tags,
+            }
 
 
 class MetadataRow(object):
     flow_id: str = None
     run_number: int = None
+    run_id: str = None
     step_name: str = None
     task_id: int = None
+    task_name: str = None
     id: int = None  # autoincrement
     field_name: str = None
     value: dict = None
@@ -167,8 +225,10 @@ class MetadataRow(object):
         self,
         flow_id,
         run_number,
+        run_id,
         step_name,
         task_id,
+        task_name,
         id,
         field_name,
         value,
@@ -180,8 +240,10 @@ class MetadataRow(object):
     ):
         self.flow_id = flow_id
         self.run_number = run_number
+        self.run_id = run_id
         self.step_name = step_name
         self.task_id = task_id
+        self.task_name = task_name
         self.field_name = field_name
         self.value = value
         self.type = type
@@ -194,13 +256,13 @@ class MetadataRow(object):
         self.tags = tags
         self.system_tags = system_tags
 
-    def serialize(self):
+    def serialize(self, expanded: bool = False):
         return {
             "id": self.id,
             "flow_id": self.flow_id,
-            "run_number": self.run_number,
+            "run_number": get_exposed_run_id(self.run_number, self.run_id),
             "step_name": self.step_name,
-            "task_id": self.task_id,
+            "task_id": get_exposed_task_id(self.task_id, self.task_name),
             "field_name": self.field_name,
             "value": self.value,
             "type": self.type,
@@ -214,8 +276,10 @@ class MetadataRow(object):
 class ArtifactRow(object):
     flow_id: str = None
     run_number: int = None
+    run_id: str = None
     step_name: str = None
     task_id: int = None
+    task_name: str = None
     name: str = None
     location: str = None
     sha: str = None
@@ -229,8 +293,10 @@ class ArtifactRow(object):
         self,
         flow_id,
         run_number,
+        run_id,
         step_name,
         task_id,
+        task_name,
         name,
         location,
         ds_type,
@@ -245,8 +311,10 @@ class ArtifactRow(object):
     ):
         self.flow_id = flow_id
         self.run_number = run_number
+        self.run_id = run_id
         self.step_name = step_name
         self.task_id = task_id
+        self.task_name = task_name
         self.name = name
         self.location = location
         self.ds_type = ds_type
@@ -262,12 +330,12 @@ class ArtifactRow(object):
         self.tags = tags
         self.system_tags = system_tags
 
-    def serialize(self):
+    def serialize(self, expanded: bool = False):
         return {
             "flow_id": self.flow_id,
-            "run_number": self.run_number,
+            "run_number": get_exposed_run_id(self.run_number, self.run_id),
             "step_name": self.step_name,
-            "task_id": self.task_id,
+            "task_id": get_exposed_task_id(self.task_id, self.task_name),
             "name": self.name,
             "location": self.location,
             "ds_type": self.ds_type,

--- a/migration_service/api/__init__.py
+++ b/migration_service/api/__init__.py
@@ -1,0 +1,32 @@
+import os
+
+version_dict = {
+    '0': 'v_1_0_1',
+    '1': 'v_1_0_1',
+    '20200603104139': 'latest'
+}
+
+latest = "latest"
+
+goose_template = "goose postgres " \
+                 "\"dbname={} " \
+                 "user={} " \
+                 "password={} " \
+                 "host={} " \
+                 "port={} " \
+                 "sslmode=disable\" {}"
+
+path = os.path.dirname(__file__) + "/../migration_files"
+goose_migration_template = "goose -dir " + path + " postgres " \
+                         "\"dbname={} " \
+                         "user={} " \
+                         "password={} " \
+                         "host={} " \
+                         "port={} " \
+                         "sslmode=disable\" {}"
+
+host = os.environ.get("MF_METADATA_DB_HOST", "localhost")
+port = os.environ.get("MF_METADATA_DB_PORT", 5432)
+user = os.environ.get("MF_METADATA_DB_USER", "postgres")
+password = os.environ.get("MF_METADATA_DB_PSWD", "postgres")
+database_name = os.environ.get("MF_METADATA_DB_NAME", "postgres")

--- a/migration_service/api/admin.py
+++ b/migration_service/api/admin.py
@@ -1,4 +1,5 @@
 import os
+import json
 from aiohttp import web
 from subprocess import Popen
 from .utils import ApiUtils
@@ -10,11 +11,14 @@ class AdminApi(object):
     def __init__(self, app):
         app.router.add_route("GET", "/version", self.version)
         app.router.add_route("GET", "/ping", self.ping)
+        app.router.add_route("GET", "/db_schema_status", self.db_schema_status)
 
         endpoints_enabled = int(os.environ.get("MF_MIGRATION_ENDPOINTS_ENABLED",
                                 1))
         if endpoints_enabled:
             app.router.add_route("PATCH", "/upgrade", self.upgrade)
+            app.router.add_route("PUT", "/downgrade_by_one",
+                                 self.downgrade_by_one)
 
     async def ping(self, request):
         """
@@ -47,7 +51,7 @@ class AdminApi(object):
             "405":
                 description: invalid HTTP Method
         """
-        version = await ApiUtils.get_goose_version()
+        version = await ApiUtils.get_latest_compatible_version()
         return web.Response(text=version)
 
     async def upgrade(self, request):
@@ -76,3 +80,63 @@ class AdminApi(object):
             return web.Response(text="upgrade success")
         else:
             return web.Response(text="upgrade failed", status=500)
+
+    async def db_schema_status(self, request):
+        """
+        ---
+        description: This end-point returns varius stats around
+        tags:
+        - Admin
+        produces:
+        - 'application/json'
+        responses:
+            "200":
+                description: successful operation. returns status of db schema and migrations
+            "500":
+                description: could not upgrade
+        """
+        try:
+            version = await ApiUtils.get_goose_version()
+            migration_in_progress = await ApiUtils.is_migration_in_progress()
+            unapplied_migrations = ApiUtils.get_unapplied_migrations(version)
+            body = {
+                "is_up_to_date": len(unapplied_migrations) == 0,
+                "current_version": version,
+                "migration_in_progress": migration_in_progress,
+                "db_schema_versions": ApiUtils.list_migrations(),
+                "unapplied_migrations": unapplied_migrations
+            }
+            return web.Response(body=json.dumps(body))
+
+        except Exception as e:
+            body = {
+                "detail": repr(e)
+            }
+            return web.Response(status=500, body=json.dumps(body))
+
+    async def downgrade_by_one(self, request):
+        """
+        ---
+        description: This end-point downgrades to the previous version of the
+            schema
+        tags:
+        - Admin
+        produces:
+        - 'text/plain'
+        responses:
+            "202":
+                description: successful operation. Return  text
+            "500":
+                description: could not downgrade
+        """
+        goose_version_cmd = goose_migration_template.format(
+             database_name, user, password, host, port,
+            "down"
+        )
+        p = Popen(goose_version_cmd, shell=True,
+                  close_fds=True)
+        p.wait()
+        if p.returncode == 0:
+            return web.Response(text="downgrade success")
+        else:
+            return web.Response(text="downgrade failed", status=500)

--- a/migration_service/api/admin.py
+++ b/migration_service/api/admin.py
@@ -17,8 +17,6 @@ class AdminApi(object):
                                 1))
         if endpoints_enabled:
             app.router.add_route("PATCH", "/upgrade", self.upgrade)
-            app.router.add_route("PUT", "/downgrade_by_one",
-                                 self.downgrade_by_one)
 
     async def ping(self, request):
         """
@@ -46,7 +44,7 @@ class AdminApi(object):
         produces:
         - 'text/plain'
         responses:
-            "202":
+            "200":
                 description: successful operation. Return version text
             "405":
                 description: invalid HTTP Method
@@ -64,7 +62,7 @@ class AdminApi(object):
         produces:
         - 'text/plain'
         responses:
-            "202":
+            "200":
                 description: successful operation. Return  text
             "500":
                 description: could not upgrade
@@ -114,29 +112,3 @@ class AdminApi(object):
             }
             return web.Response(status=500, body=json.dumps(body))
 
-    async def downgrade_by_one(self, request):
-        """
-        ---
-        description: This end-point downgrades to the previous version of the
-            schema
-        tags:
-        - Admin
-        produces:
-        - 'text/plain'
-        responses:
-            "202":
-                description: successful operation. Return  text
-            "500":
-                description: could not downgrade
-        """
-        goose_version_cmd = goose_migration_template.format(
-             database_name, user, password, host, port,
-            "down"
-        )
-        p = Popen(goose_version_cmd, shell=True,
-                  close_fds=True)
-        p.wait()
-        if p.returncode == 0:
-            return web.Response(text="downgrade success")
-        else:
-            return web.Response(text="downgrade failed", status=500)

--- a/migration_service/api/admin.py
+++ b/migration_service/api/admin.py
@@ -1,0 +1,78 @@
+import os
+from aiohttp import web
+from subprocess import Popen
+from .utils import ApiUtils
+from . import goose_migration_template, host, port, user, password, \
+    database_name
+
+
+class AdminApi(object):
+    def __init__(self, app):
+        app.router.add_route("GET", "/version", self.version)
+        app.router.add_route("GET", "/ping", self.ping)
+
+        endpoints_enabled = int(os.environ.get("MF_MIGRATION_ENDPOINTS_ENABLED",
+                                1))
+        if endpoints_enabled:
+            app.router.add_route("PATCH", "/upgrade", self.upgrade)
+
+    async def ping(self, request):
+        """
+        ---
+        description: This end-point allow to test that service is up.
+        tags:
+        - Admin
+        produces:
+        - 'text/plain'
+        responses:
+            "202":
+                description: successful operation. Return "pong" text
+            "405":
+                description: invalid HTTP Method
+        """
+        return web.Response(text="pong")
+
+    async def version(self, request):
+        """
+        ---
+        description: This end-point returns the latest compatible version of the
+            metadata service
+        tags:
+        - Admin
+        produces:
+        - 'text/plain'
+        responses:
+            "202":
+                description: successful operation. Return version text
+            "405":
+                description: invalid HTTP Method
+        """
+        version = await ApiUtils.get_goose_version()
+        return web.Response(text=version)
+
+    async def upgrade(self, request):
+        """
+        ---
+        description: This end-point upgrades to the latest available version of
+            of the schema
+        tags:
+        - Admin
+        produces:
+        - 'text/plain'
+        responses:
+            "202":
+                description: successful operation. Return  text
+            "500":
+                description: could not upgrade
+        """
+        goose_version_cmd = goose_migration_template.format(
+             database_name, user, password, host, port,
+            "up"
+        )
+        p = Popen(goose_version_cmd, shell=True,
+                  close_fds=True)
+        p.wait()
+        if p.returncode == 0:
+            return web.Response(text="upgrade success")
+        else:
+            return web.Response(text="upgrade failed", status=500)

--- a/migration_service/api/utils.py
+++ b/migration_service/api/utils.py
@@ -1,0 +1,40 @@
+from subprocess import Popen, PIPE
+from ..data.postgres_async_db import PostgresUtils
+from . import version_dict, latest, goose_template, \
+    host, port, user, password, database_name, goose_migration_template
+
+
+class ApiUtils(object):
+    @staticmethod
+    async def get_goose_version():
+        is_present = await PostgresUtils.is_present("flows_v3")
+        version = "unknown"
+        if is_present:
+            # if tables exist but goose doesn't find version table then
+            goose_version_cmd = goose_template.format(
+                database_name, user, password, host,
+                port, "version"
+            )
+
+            p = Popen(goose_version_cmd, stdout=PIPE, stderr=PIPE, shell=True,
+                      close_fds=True)
+            p.wait()
+
+            std_err = p.stderr.read()
+            lines_err = std_err.decode("utf-8").split("\n")
+            for line in lines_err:
+                if "goose: version" in line:
+                    s = line.split("goose: version ")
+                    version = s[1]
+                    print(line)
+                    break
+            return version_dict[version]
+        else:
+            goose_version_cmd = goose_migration_template.format(
+                database_name, user, password, host, port,
+                "up"
+            )
+            p = Popen(goose_version_cmd, shell=True,
+                      close_fds=True)
+            p.wait()
+            return latest

--- a/migration_service/api/utils.py
+++ b/migration_service/api/utils.py
@@ -5,29 +5,46 @@ from . import version_dict, latest, goose_template, \
 
 
 class ApiUtils(object):
+
+    @staticmethod
+    def list_migrations():
+        migrations_list = list((version_dict.keys()))
+        migrations_list.sort(key=int)
+        return migrations_list[1:]
+
+    @staticmethod
+    def get_unapplied_migrations(current_version):
+        migrations_list = ApiUtils.list_migrations()
+        index_version = migrations_list.index(current_version)
+        return migrations_list[index_version+1:]
+
     @staticmethod
     async def get_goose_version():
+        # if tables exist but goose doesn't find version table then
+        goose_version_cmd = goose_template.format(
+            database_name, user, password, host,
+            port, "version"
+        )
+
+        p = Popen(goose_version_cmd, stdout=PIPE, stderr=PIPE, shell=True,
+                  close_fds=True)
+        p.wait()
+
+        std_err = p.stderr.read()
+        lines_err = std_err.decode("utf-8").split("\n")
+        for line in lines_err:
+            if "goose: version" in line:
+                s = line.split("goose: version ")
+                version = s[1]
+                print(line)
+                break
+        return version
+
+    @staticmethod
+    async def get_latest_compatible_version():
         is_present = await PostgresUtils.is_present("flows_v3")
-        version = "unknown"
         if is_present:
-            # if tables exist but goose doesn't find version table then
-            goose_version_cmd = goose_template.format(
-                database_name, user, password, host,
-                port, "version"
-            )
-
-            p = Popen(goose_version_cmd, stdout=PIPE, stderr=PIPE, shell=True,
-                      close_fds=True)
-            p.wait()
-
-            std_err = p.stderr.read()
-            lines_err = std_err.decode("utf-8").split("\n")
-            for line in lines_err:
-                if "goose: version" in line:
-                    s = line.split("goose: version ")
-                    version = s[1]
-                    print(line)
-                    break
+            version = await ApiUtils.get_goose_version()
             return version_dict[version]
         else:
             goose_version_cmd = goose_migration_template.format(
@@ -38,3 +55,21 @@ class ApiUtils(object):
                       close_fds=True)
             p.wait()
             return latest
+
+    @staticmethod
+    async def is_migration_in_progress():
+        goose_version_cmd = goose_template.format(
+            database_name, user, password, host,
+            port, "status"
+        )
+
+        p = Popen(goose_version_cmd, stdout=PIPE, stderr=PIPE, shell=True,
+                  close_fds=True)
+        p.wait()
+
+        std_err = p.stderr.read()
+        lines_err = std_err.decode("utf-8")
+        if "Pending" in lines_err:
+            return True
+
+        return False

--- a/migration_service/data/postgres_async_db.py
+++ b/migration_service/data/postgres_async_db.py
@@ -1,0 +1,48 @@
+import psycopg2
+import psycopg2.extras
+import os
+import aiopg
+import json
+
+class PostgresUtils(object):
+    @staticmethod
+    async def is_present(table_name):
+        with (await AsyncPostgresDB.get_instance().pool.cursor()) as cur:
+            await cur.execute(
+                "select * from information_schema.tables where table_name=%s",
+                (table_name,),
+            )
+            return bool(cur.rowcount)
+
+class AsyncPostgresDB(object):
+    connection = None
+    __instance = None
+
+    pool = None
+
+    @staticmethod
+    def get_instance():
+        if AsyncPostgresDB.__instance is None:
+            AsyncPostgresDB()
+        return AsyncPostgresDB.__instance
+
+    def __init__(self):
+        if self.__instance is not None:
+            return
+
+        AsyncPostgresDB.__instance = self
+
+    async def _init(self):
+
+        host = os.environ.get("MF_METADATA_DB_HOST", "localhost")
+        port = os.environ.get("MF_METADATA_DB_PORT", 5432)
+        user = os.environ.get("MF_METADATA_DB_USER", "postgres")
+        password = os.environ.get("MF_METADATA_DB_PSWD", "postgres")
+        database_name = os.environ.get("MF_METADATA_DB_NAME", "postgres")
+
+        dsn = "dbname={0} user={1} password={2} host={3} port={4}".format(
+            database_name, user, password, host, port
+        )
+        # todo make poolsize min and max configurable as well as timeout
+        # todo add retry and better error message
+        self.pool = await aiopg.create_pool(dsn)

--- a/migration_service/data/postgres_async_db.py
+++ b/migration_service/data/postgres_async_db.py
@@ -1,8 +1,7 @@
-import psycopg2
-import psycopg2.extras
+import time
 import os
 import aiopg
-import json
+
 
 class PostgresUtils(object):
     @staticmethod
@@ -45,4 +44,14 @@ class AsyncPostgresDB(object):
         )
         # todo make poolsize min and max configurable as well as timeout
         # todo add retry and better error message
-        self.pool = await aiopg.create_pool(dsn)
+        retries = 3
+        for i in range(retries):
+            while True:
+                try:
+                    self.pool = await aiopg.create_pool(dsn)
+                except Exception as e:
+                    if retries - i < 1:
+                        raise e
+                    time.sleep(1)
+                    continue
+                break

--- a/migration_service/get_virtual_env.py
+++ b/migration_service/get_virtual_env.py
@@ -1,0 +1,30 @@
+import requests
+import socket
+import time
+
+try:
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    retry_count = 5
+    while retry_count > 0:
+        try:
+            print("connecting")
+            s.connect(('localhost', 8082))
+            print("Port 8082 reachable")
+            break
+        except socket.error as e:
+            print("booting...")
+            print(e)
+            time.sleep(1)
+        except Exception:
+            print("something broke")
+        finally:
+            retry_count = retry_count -1
+    # continue
+    s.close()
+except Exception:
+    pass
+
+r = requests.get('http://localhost:8082/version')
+conf_file = open('/migration_service/config', 'w')
+print(r.text, file=conf_file)
+conf_file.close()

--- a/migration_service/migration_files/1_create_tables.sql
+++ b/migration_service/migration_files/1_create_tables.sql
@@ -1,0 +1,89 @@
+-- +goose Up
+-- +goose StatementBegin
+SELECT 'up SQL query';
+CREATE TABLE flows_v3 (
+  flow_id VARCHAR(255) PRIMARY KEY,
+  user_name VARCHAR(255),
+  ts_epoch BIGINT NOT NULL,
+  tags JSONB,
+  system_tags JSONB
+);
+
+CREATE TABLE runs_v3 (
+  flow_id VARCHAR(255) NOT NULL,
+  run_number SERIAL NOT NULL,
+  user_name VARCHAR(255),
+  ts_epoch BIGINT NOT NULL,
+  tags JSONB,
+  system_tags JSONB,
+  PRIMARY KEY(flow_id, run_number),
+  FOREIGN KEY(flow_id) REFERENCES flows_v3 (flow_id)
+);
+
+CREATE TABLE steps_v3 (
+    flow_id VARCHAR(255) NOT NULL,
+    run_number BIGINT NOT NULL,
+    step_name VARCHAR(255) NOT NULL,
+    user_name VARCHAR(255),
+    ts_epoch BIGINT NOT NULL,
+    tags JSONB,
+    system_tags JSONB,
+    PRIMARY KEY(flow_id, run_number, step_name),
+    FOREIGN KEY(flow_id, run_number) REFERENCES runs_v3 (flow_id, run_number)
+);
+
+
+CREATE TABLE tasks_v3 (
+    flow_id VARCHAR(255) NOT NULL,
+    run_number BIGINT NOT NULL,
+    step_name VARCHAR(255) NOT NULL,
+    task_id BIGSERIAL PRIMARY KEY,
+    user_name VARCHAR(255),
+    ts_epoch BIGINT NOT NULL,
+    tags JSONB,
+    system_tags JSONB,
+    FOREIGN KEY(flow_id, run_number, step_name) REFERENCES steps_v3 (flow_id, run_number, step_name)
+);
+
+CREATE TABLE metadata_v3 (
+    flow_id VARCHAR(255),
+    run_number BIGINT NOT NULL,
+    step_name VARCHAR(255) NOT NULL,
+    task_id BIGINT NOT NULL,
+    id BIGSERIAL NOT NULL,
+    field_name VARCHAR(255) NOT NULL,
+    value TEXT NOT NULL,
+    type VARCHAR(255) NOT NULL,
+    user_name VARCHAR(255),
+    ts_epoch BIGINT NOT NULL,
+    tags JSONB,
+    system_tags JSONB,
+    PRIMARY KEY(flow_id, run_number, step_name, task_id, field_name)
+);
+
+CREATE TABLE artifact_v3 (
+    flow_id VARCHAR(255) NOT NULL,
+    run_number BIGINT NOT NULL,
+    step_name VARCHAR(255) NOT NULL,
+    task_id BIGINT NOT NULL,
+    name VARCHAR(255) NOT NULL,
+    location VARCHAR(255) NOT NULL,
+    ds_type VARCHAR(255) NOT NULL,
+    sha VARCHAR(255),
+    type VARCHAR(255),
+    content_type VARCHAR(255),
+    user_name VARCHAR(255),
+    attempt_id SMALLINT NOT NULL,
+    ts_epoch BIGINT NOT NULL,
+    tags JSONB,
+    system_tags JSONB,
+    PRIMARY KEY(flow_id, run_number, step_name, task_id, attempt_id, name)
+);
+
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+SELECT 'down SQL query';
+
+-- +goose StatementEnd

--- a/migration_service/migration_files/20200603104139_add_str_id_cols.sql
+++ b/migration_service/migration_files/20200603104139_add_str_id_cols.sql
@@ -1,0 +1,87 @@
+-- +goose Up
+-- +goose StatementBegin
+SELECT 'up SQL query';
+ALTER TABLE runs_v3
+ADD COLUMN run_id VARCHAR(255);
+
+ALTER TABLE runs_v3
+ADD COLUMN last_heartbeat_ts BIGINT;
+
+ALTER TABLE runs_v3
+ADD CONSTRAINT runs_v3_flow_id_run_id_key UNIQUE (flow_id, run_id);
+
+ALTER TABLE steps_v3
+ADD COLUMN run_id VARCHAR(255);
+
+ALTER TABLE steps_v3
+ADD CONSTRAINT steps_v3_flow_id_run_id_step_name_key UNIQUE (flow_id, run_id, step_name);
+
+ALTER TABLE tasks_v3
+ADD COLUMN run_id VARCHAR(255);
+
+ALTER TABLE tasks_v3
+ADD COLUMN task_name VARCHAR(255);
+
+ALTER TABLE tasks_v3
+ADD COLUMN last_heartbeat_ts BIGINT;
+
+ALTER TABLE tasks_v3
+ADD CONSTRAINT tasks_v3_flow_id_run_number_step_name_task_name_key UNIQUE (flow_id, run_number, step_name, task_name);
+
+ALTER TABLE metadata_v3
+ADD COLUMN run_id VARCHAR(255);
+
+ALTER TABLE metadata_v3
+ADD COLUMN task_name VARCHAR(255);
+
+ALTER TABLE artifact_v3
+ADD COLUMN run_id VARCHAR(255);
+
+ALTER TABLE artifact_v3
+ADD COLUMN task_name VARCHAR(255);
+
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+SELECT 'down SQL query';
+ALTER TABLE artifact_v3
+DROP COLUMN task_name;
+
+ALTER TABLE artifact_v3
+DROP COLUMN run_id;
+
+ALTER TABLE metadata_v3
+DROP COLUMN run_id;
+
+ALTER TABLE metadata_v3
+DROP COLUMN task_name;
+
+ALTER TABLE tasks_v3
+DROP CONSTRAINT tasks_v3_flow_id_run_number_step_name_task_name_key;
+
+ALTER TABLE tasks_v3
+DROP COLUMN run_id;
+
+ALTER TABLE tasks_v3
+DROP COLUMN task_name;
+
+ALTER TABLE tasks_v3
+DROP COLUMN last_heartbeat_ts;
+
+ALTER TABLE steps_v3
+DROP CONSTRAINT steps_v3_flow_id_run_id_step_name_key;
+
+ALTER TABLE steps_v3
+DROP COLUMN run_id;
+
+ALTER TABLE runs_v3
+DROP CONSTRAINT runs_v3_flow_id_run_id_key;
+
+ALTER TABLE runs_v3
+DROP COLUMN last_heartbeat_ts;
+
+ALTER TABLE runs_v3
+DROP COLUMN run_id;
+
+-- +goose StatementEnd

--- a/migration_service/migration_server.py
+++ b/migration_service/migration_server.py
@@ -1,0 +1,42 @@
+import asyncio
+import os
+
+from aiohttp import web
+from aiohttp_swagger import *
+
+from subprocess import Popen, PIPE
+
+from .api.admin import AdminApi
+
+from .data.postgres_async_db import AsyncPostgresDB
+
+
+def app(loop=None):
+
+    loop = loop or asyncio.get_event_loop()
+    app = web.Application(loop=loop)
+    async_db = AsyncPostgresDB()
+    loop.run_until_complete(async_db._init())
+    AdminApi(app)
+    setup_swagger(app)
+    return app
+
+
+if __name__ == "__main__":
+    try:
+        loop = asyncio.get_event_loop()
+        the_app = app(loop)
+        handler = the_app.make_handler()
+        port = os.environ.get("MF_MIGRATION_PORT", 8082)
+        host = str(os.environ.get("MF_METADATA_HOST", "0.0.0.0"))
+        f = loop.create_server(handler, host, port)
+
+        srv = loop.run_until_complete(f)
+
+        print("serving on", srv.sockets[0].getsockname())
+    except Exception:
+        pass
+    try:
+        loop.run_forever()
+    except KeyboardInterrupt:
+        pass

--- a/migration_service/migration_server.py
+++ b/migration_service/migration_server.py
@@ -23,19 +23,16 @@ def app(loop=None):
 
 
 if __name__ == "__main__":
-    try:
-        loop = asyncio.get_event_loop()
-        the_app = app(loop)
-        handler = the_app.make_handler()
-        port = os.environ.get("MF_MIGRATION_PORT", 8082)
-        host = str(os.environ.get("MF_METADATA_HOST", "0.0.0.0"))
-        f = loop.create_server(handler, host, port)
+    loop = asyncio.get_event_loop()
+    the_app = app(loop)
+    handler = the_app.make_handler()
+    port = os.environ.get("MF_MIGRATION_PORT", 8082)
+    host = str(os.environ.get("MF_METADATA_HOST", "0.0.0.0"))
+    f = loop.create_server(handler, host, port)
 
-        srv = loop.run_until_complete(f)
+    srv = loop.run_until_complete(f)
 
-        print("serving on", srv.sockets[0].getsockname())
-    except Exception:
-        pass
+    print("serving on", srv.sockets[0].getsockname())
     try:
         loop.run_forever()
     except KeyboardInterrupt:

--- a/migration_service/requirements.txt
+++ b/migration_service/requirements.txt
@@ -1,0 +1,4 @@
+aiohttp
+aiohttp_swagger
+psycopg2
+aiopg

--- a/migration_service/run_script.py
+++ b/migration_service/run_script.py
@@ -23,7 +23,7 @@ if __name__ == "__main__":
         path = my_env['PATH']
         my_env['PATH'] = virtual_env_path+"/bin:"+path
         metadata_server_process = Popen(
-            "metadata_service", shell=True,
+            "metadata_service >> /root/metadata_service/output.txt", shell=True,
             close_fds=True, env=my_env)
 
         metadata_server_process.wait()

--- a/migration_service/run_script.py
+++ b/migration_service/run_script.py
@@ -1,0 +1,33 @@
+from subprocess import Popen
+import os
+if __name__ == "__main__":
+    try:
+        my_env = os.environ
+        migration_server_process = Popen("PYTHONPATH=/ python3 -m migration_service.migration_server", shell=True,
+                          close_fds=True, env=my_env)
+
+        get_env_version = Popen(
+            "python3 /migration_service/get_virtual_env.py >> /migration_service/env_output.txt",
+            shell=True,
+            close_fds=True)
+
+        get_env_version.wait()
+
+        # read in version of metadata service to load
+        version_value_file = open('/migration_service/config', 'r')
+        version_value = str(version_value_file.read()).strip()
+
+        # start proper version of metadata service
+        virtual_env_path = '/opt/'+version_value
+        my_env['VIRTUAL_ENV'] = '/opt/'+version_value
+        path = my_env['PATH']
+        my_env['PATH'] = virtual_env_path+"/bin:"+path
+        metadata_server_process = Popen(
+            "metadata_service", shell=True,
+            close_fds=True, env=my_env)
+
+        metadata_server_process.wait()
+        migration_server_process.wait()
+    finally:
+        # should never be reached
+        exit(1)

--- a/migration_tools.py
+++ b/migration_tools.py
@@ -1,0 +1,90 @@
+import os
+import click
+import requests
+import json
+
+
+def _init_config():
+    # Read configuration from $METAFLOW_HOME/config_<profile>.json.
+    config = {}
+    try:
+        home = os.environ.get('METAFLOW_HOME', '~/.metaflowconfig')
+        profile = os.environ.get('METAFLOW_PROFILE')
+        path_to_config = os.path.join(home, 'config.json')
+        if profile:
+            path_to_config = os.path.join(home, 'config_%s.json' % profile)
+        path_to_config = os.path.expanduser(path_to_config)
+
+        if os.path.exists(path_to_config):
+            with open(path_to_config) as f:
+                return json.load(f)
+    except Exception:
+        pass
+    return config
+
+
+def _get_url(url, service='migration'):
+    if url:
+        return url
+
+    metaflow_config = _init_config()
+
+    default = 'http://localhost:8082'
+    if service is not 'migration':
+        default = 'http://localhost:8080'
+
+    return metaflow_config.get('METAFLOW_SERVICE_URL', default)
+
+
+@click.group()
+def tools():
+    pass
+
+
+@tools.command()
+@click.option('--base-url',
+              default=None,
+              required=False,
+              help='defaults to reading ~/.metaflowconfig and fallback to '
+                   'http://localhost:8082')
+def upgrade(base_url):
+    """Upgrade to latest db schema"""
+    _url = _get_url(base_url)
+    url = _url + "/upgrade"
+    response = requests.patch(url)
+    print(response.text)
+
+
+@tools.command()
+@click.option('--base-url',
+              default=None,
+              required=False,
+              help='defaults to reading ~/.metaflowconfig and fallback to '
+                   'http://localhost:8082')
+def db_status(base_url):
+    """get status of current db schema"""
+    _url = _get_url(base_url)
+    url = _url + "/db_schema_status"
+    response = requests.get(url)
+    print(response.json())
+
+
+@tools.command()
+@click.option('--base-url',
+              default=None,
+              required=False,
+              help='defaults to reading ~/.metaflowconfig and fallback to '
+                   'http://localhost:8080')
+def metadata_service_version(base_url):
+    """get status of current db schema"""
+    _url = _get_url(base_url, 'metadata')
+    url = _url + "/version"
+    response = requests.get(url)
+    print(response.text)
+
+
+cli = click.CommandCollection(sources=[tools])
+
+
+if __name__ == "__main__":
+    cli()

--- a/migration_tools.py
+++ b/migration_tools.py
@@ -1,39 +1,5 @@
-import os
 import click
 import requests
-import json
-
-
-def _init_config():
-    # Read configuration from $METAFLOW_HOME/config_<profile>.json.
-    config = {}
-    try:
-        home = os.environ.get('METAFLOW_HOME', '~/.metaflowconfig')
-        profile = os.environ.get('METAFLOW_PROFILE')
-        path_to_config = os.path.join(home, 'config.json')
-        if profile:
-            path_to_config = os.path.join(home, 'config_%s.json' % profile)
-        path_to_config = os.path.expanduser(path_to_config)
-
-        if os.path.exists(path_to_config):
-            with open(path_to_config) as f:
-                return json.load(f)
-    except Exception:
-        pass
-    return config
-
-
-def _get_url(url, service='migration'):
-    if url:
-        return url
-
-    metaflow_config = _init_config()
-
-    default = 'http://localhost:8082'
-    if service is not 'migration':
-        default = 'http://localhost:8080'
-
-    return metaflow_config.get('METAFLOW_SERVICE_URL', default)
 
 
 @click.group()
@@ -44,13 +10,11 @@ def tools():
 @tools.command()
 @click.option('--base-url',
               default=None,
-              required=False,
-              help='defaults to reading ~/.metaflowconfig and fallback to '
-                   'http://localhost:8082')
+              required=True,
+              help='url to migration service ex: http://localhost:8082')
 def upgrade(base_url):
     """Upgrade to latest db schema"""
-    _url = _get_url(base_url)
-    url = _url + "/upgrade"
+    url = base_url + "/upgrade"
     response = requests.patch(url)
     print(response.text)
 
@@ -58,13 +22,11 @@ def upgrade(base_url):
 @tools.command()
 @click.option('--base-url',
               default=None,
-              required=False,
-              help='defaults to reading ~/.metaflowconfig and fallback to '
-                   'http://localhost:8082')
+              required=True,
+              help='url to migration service ex: http://localhost:8082')
 def db_status(base_url):
     """get status of current db schema"""
-    _url = _get_url(base_url)
-    url = _url + "/db_schema_status"
+    url = base_url + "/db_schema_status"
     response = requests.get(url)
     print(response.json())
 
@@ -72,13 +34,11 @@ def db_status(base_url):
 @tools.command()
 @click.option('--base-url',
               default=None,
-              required=False,
-              help='defaults to reading ~/.metaflowconfig and fallback to '
-                   'http://localhost:8080')
+              required=True,
+              help='url to metadata service ex: http://localhost:8080')
 def metadata_service_version(base_url):
     """get status of current db schema"""
-    _url = _get_url(base_url, 'metadata')
-    url = _url + "/version"
+    url = base_url + "/version"
     response = requests.get(url)
     print(response.text)
 

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 setup(
   name = 'metadata_service',
-  version = '1.0.1',
+  version = '2.0.0',
   license='Apache License 2.0',
   description = 'Metadata Service: backend service for Metaflow',
   author = 'Machine Learning Infrastructure Team at Netflix',


### PR DESCRIPTION
Migration Service
a tool to help users manage underlying DB migrations and launch
the most recent compatible version of the metadata service

Metadata Service changes
bump version to 2.0.0
add support for user provided run_ids and task_ids
add heartbeat column to be used in the future
