### PR TITLE
only set ts if missing for task and metadata

### DIFF
--- a/metadata_service/data/models.py
+++ b/metadata_service/data/models.py
@@ -129,7 +129,7 @@ class TaskRow(object):
         self.step_name = step_name
         self.task_id = task_id
         self.user_name = user_name
-        if ts_epoch is not None:
+        if ts_epoch is None:
             ts_epoch = int(round(time.time() * 1000))
 
         self.ts_epoch = ts_epoch
@@ -186,7 +186,7 @@ class MetadataRow(object):
         self.value = value
         self.type = type
         self.user_name = user_name
-        if ts_epoch is not None:
+        if ts_epoch is None:
             ts_epoch = int(round(time.time() * 1000))
 
         self.ts_epoch = ts_epoch


### PR DESCRIPTION
Fix bug in setting of create timestamp for task and metadata objects