### PR TITLE
escape apostrophe in postgres params and fix status endpoint

### DIFF
--- a/migration_service/api/utils.py
+++ b/migration_service/api/utils.py
@@ -14,9 +14,12 @@ class ApiUtils(object):
 
     @staticmethod
     def get_unapplied_migrations(current_version):
-        migrations_list = ApiUtils.list_migrations()
-        index_version = migrations_list.index(current_version)
-        return migrations_list[index_version+1:]
+        try:
+            migrations_list = ApiUtils.list_migrations()
+            index_version = migrations_list.index(current_version)
+            return migrations_list[index_version+1:]
+        except:
+            return migrations_list
 
     @staticmethod
     async def get_goose_version():

--- a/migration_service/data/postgres_async_db.py
+++ b/migration_service/data/postgres_async_db.py
@@ -33,11 +33,11 @@ class AsyncPostgresDB(object):
 
     async def _init(self):
 
-        host = os.environ.get("MF_METADATA_DB_HOST", "localhost")
-        port = os.environ.get("MF_METADATA_DB_PORT", 5432)
-        user = os.environ.get("MF_METADATA_DB_USER", "postgres")
-        password = os.environ.get("MF_METADATA_DB_PSWD", "postgres")
-        database_name = os.environ.get("MF_METADATA_DB_NAME", "postgres")
+        host = os.environ.get("MF_METADATA_DB_HOST", "localhost").replace("'", "\'")
+        port = os.environ.get("MF_METADATA_DB_PORT", 5432).replace("'", "\'")
+        user = os.environ.get("MF_METADATA_DB_USER", "postgres").replace("'", "\'")
+        password = os.environ.get("MF_METADATA_DB_PSWD", "postgres").replace("'", "\'")
+        database_name = os.environ.get("MF_METADATA_DB_NAME", "postgres").replace("'", "\'")
 
         dsn = "dbname={0} user={1} password={2} host={3} port={4}".format(
             database_name, user, password, host, port

--- a/migration_service/data/postgres_async_db.py
+++ b/migration_service/data/postgres_async_db.py
@@ -34,7 +34,7 @@ class AsyncPostgresDB(object):
     async def _init(self):
 
         host = os.environ.get("MF_METADATA_DB_HOST", "localhost").replace("'", "\'")
-        port = os.environ.get("MF_METADATA_DB_PORT", 5432).replace("'", "\'")
+        port = os.environ.get("MF_METADATA_DB_PORT", 5432)
         user = os.environ.get("MF_METADATA_DB_USER", "postgres").replace("'", "\'")
         password = os.environ.get("MF_METADATA_DB_PSWD", "postgres").replace("'", "\'")
         database_name = os.environ.get("MF_METADATA_DB_NAME", "postgres").replace("'", "\'")


### PR DESCRIPTION
Bug Fixes for Migration service:
- Correct issue where db_schema_status
- Escape apostrophes in params for postgres connection