### PR TITLE
Add task heartbeat monitor

### DIFF
--- a/services/data/postgres_async_db.py
+++ b/services/data/postgres_async_db.py
@@ -753,7 +753,7 @@ class AsyncTaskTablePostgres(AsyncPostgresTable):
         """
         (CASE
             WHEN attempt.finished_at IS NULL AND {table_name}.last_heartbeat_ts IS NOT NULL
-            THEN {table_name}.last_heartbeat_ts*1000-attempt.started_at
+            THEN {table_name}.last_heartbeat_ts*1000-COALESCE(attempt.started_at, {table_name}.ts_epoch)
             WHEN attempt.finished_at IS NOT NULL
             THEN attempt.finished_at - COALESCE(attempt.started_at, {table_name}.ts_epoch)
             ELSE NULL

--- a/services/ui_backend_service/api/heartbeat_monitor.py
+++ b/services/ui_backend_service/api/heartbeat_monitor.py
@@ -78,6 +78,8 @@ class RunHeartbeatMonitor(HeartbeatMonitor):
       self.remove_from_watch(run_id)
     
   async def add_to_watch(self, run_id):
+    # TODO: Optimize db trigger so we do not have to fetch a record in order to add it to the
+    # heartbeat monitor
     run = await self.get_run(run_id)
 
     if "last_heartbeat_ts" in run and "run_number" in run:
@@ -132,6 +134,8 @@ class TaskHeartbeatMonitor(HeartbeatMonitor):
       self.remove_from_watch(key)
     
   async def add_to_watch(self, data):
+    # TODO: Optimize db trigger so we do not have to fetch a record in order to add it to the
+    # heartbeat monitor
     task = await self.get_task(
       data["flow_id"],
       data["run_number"],

--- a/services/ui_backend_service/api/heartbeat_monitor.py
+++ b/services/ui_backend_service/api/heartbeat_monitor.py
@@ -173,7 +173,6 @@ class TaskHeartbeatMonitor(HeartbeatMonitor):
     task = await self.get_task(flow_id, run_number, step_name, task_id, attempt_id)
     resources = resource_list(self._task_table.table_name, task)
     self.event_emitter.emit('notify', 'UPDATE', resources, task)
-    print("HB expired for task:", task, flush=True)
   
   def generate_dict_key(self, data):
     "Creates an unique key for the 'watched' dictionary for storing the heartbeat of a specific task"

--- a/services/ui_backend_service/api/heartbeat_monitor.py
+++ b/services/ui_backend_service/api/heartbeat_monitor.py
@@ -130,7 +130,7 @@ class TaskHeartbeatMonitor(HeartbeatMonitor):
     if action == "update":
       await self.add_to_watch(data)
     elif action == "complete":
-      key = self.generate_hashmap_key(data)
+      key = self.generate_dict_key(data)
       self.remove_from_watch(key)
     
   async def add_to_watch(self, data):
@@ -143,7 +143,7 @@ class TaskHeartbeatMonitor(HeartbeatMonitor):
       data["task_id"]
     )
 
-    key = self.generate_hashmap_key(data)
+    key = self.generate_dict_key(data)
     if key and "last_heartbeat_ts" in task:
       heartbeat_ts = task["last_heartbeat_ts"]
       if heartbeat_ts is not None: # only start monitoring on runs that have a heartbeat
@@ -171,7 +171,7 @@ class TaskHeartbeatMonitor(HeartbeatMonitor):
     resources = resource_list(self._task_table.table_name, task)
     self.event_emitter.emit('notify', 'UPDATE', resources, task)
   
-  def generate_hashmap_key(self, data):
+  def generate_dict_key(self, data):
     "Creates an unique key for the 'watched' dictionary for storing the heartbeat of a specific task"
     try:
       return "{flow_id}/{run_number}/{step_name}/{task_id}".format(**data)

--- a/services/ui_backend_service/api/heartbeat_monitor.py
+++ b/services/ui_backend_service/api/heartbeat_monitor.py
@@ -10,7 +10,7 @@ HEARTBEAT_INTERVAL = 10 # interval of heartbeats, in seconds
 class HeartbeatMonitor(object):
   def __init__(self, event_name, event_emitter=None):
     self.watched = {}
-    # Handle DB Events
+    # Handle HB Events
     self.event_emitter = event_emitter or AsyncIOEventEmitter()
     event_emitter.on(event_name, self.heartbeat_handler)
 
@@ -26,9 +26,9 @@ class HeartbeatMonitor(object):
     "Adds object to heartbeat monitoring"
     raise NotImplementedError
 
-  async def remove_from_watch(self, key):
+  def remove_from_watch(self, key):
     "Removes object from heartbeat monitoring"
-    raise NotImplementedError
+    self.watched.pop(key, None)
 
   async def load_and_broadcast(self, key):
     '''Triggered when a heartbeat for a key has expired.
@@ -42,7 +42,6 @@ class HeartbeatMonitor(object):
     '''
     while True:
       time_now = int(datetime.datetime.utcnow().timestamp()) # same format as the metadata heartbeat uses
-      # print(f"checking heartbeats of {len(self.watched)} runs, timestamp: {time_now}", flush=True)
       for key, hb in list(self.watched.items()):
         if time_now - hb > HEARTBEAT_INTERVAL * 2:
           await self.load_and_broadcast(key)
@@ -87,9 +86,6 @@ class RunHeartbeatMonitor(HeartbeatMonitor):
       if heartbeat_ts is not None: # only start monitoring on runs that have a heartbeat
         self.watched[run_number] = heartbeat_ts
 
-  def remove_from_watch(self, run_id):
-    self.watched.pop(run_id, None)
-
   async def get_run(self, run_id):
     # Remember to enable_joins for the query, otherwise the 'status' will be missing from the run
     # and we can not broadcast an up-to-date status.
@@ -101,8 +97,83 @@ class RunHeartbeatMonitor(HeartbeatMonitor):
                           )
     return result.body if result.response_code==200 else None
   
-  async def load_and_broadcast(self, run_id):
-    run = await self.get_run(run_id)
+  async def load_and_broadcast(self, key):
+    run = await self.get_run(key)
     resources = resource_list(self._run_table.table_name, run)
     self.event_emitter.emit('notify', 'UPDATE', resources, run)
 
+class TaskHeartbeatMonitor(HeartbeatMonitor):
+  '''
+  Service class for adding objects with heartbeat timestamps to be monitored and acted upon
+  when heartbeat becomes too old.
+
+  Starts an async watcher loop that periodically checks the heartbeat of the subscribed tasks for expired timestamps
+
+  Usage
+  -----
+  Responds to event_emitter emissions with messages:
+    "task-heartbeat", "update", data -> updates heartbeat timestamp that is found in database
+    "task-heartbeat", "complete" data -> removes task from heartbeat checks
+  '''
+  def __init__(self, event_emitter=None):
+    # Init the abstract class
+    super().__init__(
+      event_name="task-heartbeat",
+      event_emitter=event_emitter
+    )
+    # Table for data fetching for load_and_broadcast and add_to_watch
+    self._task_table = AsyncPostgresDB.get_instance().task_table_postgres
+
+  async def heartbeat_handler(self, action, data):
+    if action == "update":
+      await self.add_to_watch(data)
+    elif action == "complete":
+      key = self.generate_hashmap_key(data)
+      self.remove_from_watch(key)
+    
+  async def add_to_watch(self, data):
+    task = await self.get_task(
+      data["flow_id"],
+      data["run_number"],
+      data["step_name"],
+      data["task_id"]
+    )
+
+    key = self.generate_hashmap_key(data)
+    if key and "last_heartbeat_ts" in task:
+      heartbeat_ts = task["last_heartbeat_ts"]
+      if heartbeat_ts is not None: # only start monitoring on runs that have a heartbeat
+        self.watched[key] = heartbeat_ts
+
+  async def get_task(self, flow_id, run_number, step_name, task_id):
+    # Remember to enable_joins for the query, otherwise the 'status' will be missing from the run
+    # and we can not broadcast an up-to-date status.
+    result, _ = await self._task_table.find_records(
+                            conditions=[
+                              "flow_id = %s",
+                              "run_number = %s",
+                              "step_name = %s",
+                              "task_id = %s"
+                            ],
+                            values=[flow_id, run_number, step_name, task_id],
+                            fetch_single=True,
+                            enable_joins=True
+                          )
+    return result.body if result.response_code==200 else None
+  
+  async def load_and_broadcast(self, key):
+    flow_id, run_number, step_name, task_id = self.decode_key_ids(key)
+    task = await self.get_task(flow_id, run_number, step_name, task_id)
+    resources = resource_list(self._task_table.table_name, task)
+    self.event_emitter.emit('notify', 'UPDATE', resources, task)
+  
+  def generate_hashmap_key(self, data):
+    "Creates an unique key for the 'watched' dictionary for storing the heartbeat of a specific task"
+    try:
+      return "{flow_id}/{run_number}/{step_name}/{task_id}".format(**data)
+    except:
+      return None
+  
+  def decode_key_ids(self, key):
+    flow, run, step, task = key.split("/")
+    return flow, run, step, task

--- a/services/ui_backend_service/api/heartbeat_monitor.py
+++ b/services/ui_backend_service/api/heartbeat_monitor.py
@@ -7,7 +7,50 @@ from .notify import resource_list
 
 HEARTBEAT_INTERVAL = 10 # interval of heartbeats, in seconds
 
-class RunHeartbeatMonitor(object):
+class HeartbeatMonitor(object):
+  def __init__(self, event_name, event_emitter=None):
+    self.watched = {}
+    # Handle DB Events
+    self.event_emitter = event_emitter or AsyncIOEventEmitter()
+    event_emitter.on(event_name, self.heartbeat_handler)
+
+    # Start heartbeat watcher
+    loop = asyncio.get_event_loop()
+    loop.create_task(self.check_heartbeats())
+
+  async def heartbeat_handler(self):
+    "handle the event_emitter events"
+    raise NotImplementedError
+
+  async def add_to_watch(self):
+    "Adds object to heartbeat monitoring"
+    raise NotImplementedError
+
+  async def remove_from_watch(self, key):
+    "Removes object from heartbeat monitoring"
+    raise NotImplementedError
+
+  async def load_and_broadcast(self, key):
+    '''Triggered when a heartbeat for a key has expired.
+    Loads object based on key from watchlist, and broadcasts content to listeners.'''
+    raise NotImplementedError
+
+  async def check_heartbeats(self):
+    '''
+    Async Task that is responsible for checking the heartbeats of all monitored runs,
+    and triggering handlers in case the heartbeat is too old.
+    '''
+    while True:
+      time_now = int(datetime.datetime.utcnow().timestamp()) # same format as the metadata heartbeat uses
+      # print(f"checking heartbeats of {len(self.watched)} runs, timestamp: {time_now}", flush=True)
+      for key, hb in list(self.watched.items()):
+        if time_now - hb > HEARTBEAT_INTERVAL * 2:
+          await self.load_and_broadcast(key)
+          self.remove_from_watch(key)
+          
+      await asyncio.sleep(HEARTBEAT_INTERVAL)
+
+class RunHeartbeatMonitor(HeartbeatMonitor):
   '''
   Service class for adding objects with heartbeat timestamps to be monitored and acted upon
   when heartbeat becomes too old.
@@ -20,36 +63,31 @@ class RunHeartbeatMonitor(object):
     "run-heartbeat", "update", run_id -> updates heartbeat timestamp that is found in database
     "run-heartbeat", "complete" run_id -> removes run from heartbeat checks
   '''
-  def __init__(self, event_emitter=None, key = "run_number", heartbeat_field = "last_heartbeat_ts"):
-    self.heartbeat_field = heartbeat_field
-    self.key = key
-    self.watched = {}
+  def __init__(self, event_emitter=None):
+    # Init the abstract class
+    super().__init__(
+      event_name="run-heartbeat",
+      event_emitter=event_emitter
+    )
+    # Table for data fetching for load_and_broadcast and add_to_watch
     self._run_table = AsyncPostgresDB.get_instance().run_table_postgres
-    # Handle DB Events
-    self.event_emitter = event_emitter or AsyncIOEventEmitter()
-    event_emitter.on('run-heartbeat', self.heartbeat_handler)
-
-    # Start heartbeat watcher
-    loop = asyncio.get_event_loop()
-    loop.create_task(self.check_heartbeats())
 
   async def heartbeat_handler(self, action, run_id):
     if action == "update":
-      await self.add_run_to_watch(run_id)
-
-    if action == "complete":
-      self.remove_run_from_watch(run_id)
+      await self.add_to_watch(run_id)
+    elif action == "complete":
+      self.remove_from_watch(run_id)
     
-  async def add_run_to_watch(self, run_id):
+  async def add_to_watch(self, run_id):
     run = await self.get_run(run_id)
 
-    if self.heartbeat_field in run and self.key in run:
-      run_number = run[self.key]
-      heartbeat_ts = run[self.heartbeat_field]
+    if "last_heartbeat_ts" in run and "run_number" in run:
+      run_number = run["run_number"]
+      heartbeat_ts = run["last_heartbeat_ts"]
       if heartbeat_ts is not None: # only start monitoring on runs that have a heartbeat
         self.watched[run_number] = heartbeat_ts
 
-  def remove_run_from_watch(self, run_id):
+  def remove_from_watch(self, run_id):
     self.watched.pop(run_id, None)
 
   async def get_run(self, run_id):
@@ -64,24 +102,7 @@ class RunHeartbeatMonitor(object):
     return result.body if result.response_code==200 else None
   
   async def load_and_broadcast(self, run_id):
-    '''
-    Load updated run and broadcast the changes to the websocket event handler.
-    '''
     run = await self.get_run(run_id)
     resources = resource_list(self._run_table.table_name, run)
     self.event_emitter.emit('notify', 'UPDATE', resources, run)
 
-  async def check_heartbeats(self):
-    '''
-    Async Task that is responsible for checking the heartbeats of all monitored runs,
-    and triggering handlers in case the heartbeat is too old.
-    '''
-    while True:
-      time_now = int(datetime.datetime.utcnow().timestamp()) # same format as the metadata heartbeat uses
-      # print(f"checking heartbeats of {len(self.watched)} runs, timestamp: {time_now}", flush=True)
-      for run_number, last_heartbeat_ts in list(self.watched.items()):
-        if time_now - last_heartbeat_ts > HEARTBEAT_INTERVAL * 2:
-          await self.load_and_broadcast(run_number)
-          self.remove_run_from_watch(run_number)
-          
-      await asyncio.sleep(HEARTBEAT_INTERVAL)

--- a/services/ui_backend_service/api/notify.py
+++ b/services/ui_backend_service/api/notify.py
@@ -48,6 +48,10 @@ class ListenNotify(object):
                         if table.table_name == self.db.run_table_postgres.table_name:
                             self.event_emitter.emit('run-heartbeat', 'update', data['run_number'])
 
+                        # Heartbeat watcher for Tasks.
+                        if table.table_name == self.db.task_table_postgres.table_name:
+                            self.event_emitter.emit('task-heartbeat', 'update', data)
+
                         # Notify when Run parameters are ready.
                         if operation == "INSERT" and \
                                 table.table_name == self.db.step_table_postgres.table_name and \
@@ -58,6 +62,9 @@ class ListenNotify(object):
                         if operation == "INSERT" and \
                                 table.table_name == self.db.artifact_table_postgres.table_name and \
                                 data["name"] == "_task_ok":
+
+                            # remove heartbeat watcher for completed task
+                            self.event_emitter.emit("task-heartbeat", "complete", data)
 
                             # Always mark task finished if '_task_ok' artifact is created
                             # Include 'attempt_id' so we can identify which attempt this artifact related to

--- a/services/ui_backend_service/tests/integration_tests/utils.py
+++ b/services/ui_backend_service/tests/integration_tests/utils.py
@@ -133,19 +133,19 @@ async def add_step(db: AsyncPostgresDB, flow_id="HelloFlow",
 
 async def add_task(db: AsyncPostgresDB, flow_id="HelloFlow",
                    run_number: int = None, run_id: str = None, step_name="step", task_id=None, task_name=None,
-                   user_name="dipper", tags=["foo:bar"], system_tags=["runtime:dev"]):
-    task = TaskRow(
-        flow_id=flow_id,
-        run_number=run_number,
-        run_id=run_id,
-        step_name=step_name,
-        task_name=task_name,
-        task_id=task_id,
-        user_name=user_name,
-        tags=tags,
-        system_tags=system_tags,
-    )
-    return await db.task_table_postgres.add_task(task)
+                   user_name="dipper", tags=["foo:bar"], system_tags=["runtime:dev"],
+                   last_heartbeat_ts=None):
+    task = {
+        "flow_id": flow_id,
+        "run_number": run_number,
+        "step_name": step_name,
+        "task_name": task_name,
+        "user_name": user_name,
+        "tags": json.dumps(tags),
+        "system_tags": json.dumps(system_tags),
+        "last_heartbeat_ts": last_heartbeat_ts
+    }
+    return await db.task_table_postgres.create_record(task)
 
 
 async def add_metadata(db: AsyncPostgresDB, flow_id="HelloFlow",

--- a/services/ui_backend_service/ui_server.py
+++ b/services/ui_backend_service/ui_server.py
@@ -19,7 +19,7 @@ from .api.dag import DagApi
 
 from .api.ws import Websocket
 from .api.notify import ListenNotify
-from .api.heartbeat_monitor import RunHeartbeatMonitor
+from .api.heartbeat_monitor import RunHeartbeatMonitor, TaskHeartbeatMonitor
 from .cache.store import CacheStore
 from .frontend import Frontend
 
@@ -44,6 +44,7 @@ def app(loop=None, db_conf: DBConfiguration = None):
     app.on_cleanup.append(cache_store.stop_caches)
     ListenNotify(app, event_emitter)
     RunHeartbeatMonitor(event_emitter)
+    TaskHeartbeatMonitor(event_emitter)
     Websocket(app, event_emitter)
 
     FlowApi(app)


### PR DESCRIPTION
- refactors heartbeat monitor into an abstract for shared functionality, also documenting the common interface
- adds Task heartbeat monitor. Accounts for attempt_id when expiring task heartbeats.
- add test coverage for tasks with heartbeat