### PR TITLE
Add Codestyle check to repository workflow 

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,6 +3,27 @@ name: Test
 on: [push]
 
 jobs:
+  codestyle:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        python-version: [3.7]
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install Python ${{ matrix.python-version }} dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install pycodestyle
+      - name: Run Python PEP8 code style checks
+        continue-on-error: true
+        run: pycodestyle
+  
   unit:
     runs-on: ubuntu-latest
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,9 @@
 [metadata]
 license_files = LICENSE
+
+[pycodestyle]
+count = False
+exclude = *_test.py,.svn,CVS,.bzr,.hg,.git,__pycache__,.tox
+ignore = E722
+max-line-length = 160
+statistics = True


### PR DESCRIPTION
* adds PEP8 codestyle checks. Serves as a reporting tool for now instead of failing the pipeline due to style errors, as there are errors raised by the current codebase.

consider changing to a hard-fail on style errors once codebase has been unified.