### PR TITLE
Add artifact refinement for database responses

### DIFF
--- a/services/data/models.py
+++ b/services/data/models.py
@@ -170,6 +170,7 @@ class TaskRow(object):
     task_name: str = None
     user_name: str = None
     status: str = None
+    task_ok: str = None
     ts_epoch: int = 0
     finished_at: int = None
     duration: int = None
@@ -187,6 +188,7 @@ class TaskRow(object):
         task_id=None,
         task_name=None,
         status=None,
+        task_ok=None,
         ts_epoch=None,
         finished_at=None,
         duration=None,
@@ -208,6 +210,7 @@ class TaskRow(object):
             ts_epoch = int(round(time.time() * 1000))
 
         self.status = status
+        self.task_ok = task_ok
         self.ts_epoch = ts_epoch
         self.finished_at = finished_at
         self.duration = duration
@@ -227,6 +230,7 @@ class TaskRow(object):
                 "task_name": self.task_name,
                 "user_name": self.user_name,
                 "status": self.status,
+                "task_ok": self.task_ok,
                 "ts_epoch": self.ts_epoch,
                 "finished_at": self.finished_at,
                 "duration": self.duration,
@@ -243,6 +247,7 @@ class TaskRow(object):
                 "task_id": str(get_exposed_task_id(self.task_id, self.task_name)),
                 "user_name": self.user_name,
                 "status": self.status,
+                "task_ok": self.task_ok,
                 "ts_epoch": self.ts_epoch,
                 "finished_at": self.finished_at,
                 "duration": self.duration,

--- a/services/data/postgres_async_db.py
+++ b/services/data/postgres_async_db.py
@@ -671,7 +671,8 @@ class AsyncTaskTablePostgres(AsyncPostgresTable):
     joins = ["LEFT JOIN {artifacts_table} AS artifacts ON ({table_name}.flow_id = artifacts.flow_id AND {table_name}.task_id = artifacts.task_id AND artifacts.name = '_task_ok')"
              .format(table_name=table_name, artifacts_table="artifact_v3")]
     select_columns = ["tasks_v3.{0} AS {0}".format(k) for k in keys]
-    join_columns = ["artifacts.ts_epoch AS finished_at",
+    join_columns = ["artifacts.location AS task_ok",
+                    "artifacts.ts_epoch AS finished_at",
                     """
                     (CASE
                         WHEN artifacts.ts_epoch IS NOT NULL

--- a/services/data/postgres_async_db.py
+++ b/services/data/postgres_async_db.py
@@ -6,7 +6,8 @@ import json
 import math
 import time
 import datetime
-from typing import List
+from typing import List, Callable
+from asyncio import iscoroutinefunction
 
 from .db_utils import DBResponse, DBPagination, aiopg_exception_handling, \
     get_db_ts_epoch_str, translate_run_key, translate_task_key
@@ -171,7 +172,8 @@ class AsyncPostgresTable(object):
 
     async def find_records(self, conditions: List[str] = None, values=[], fetch_single=False,
                            limit: int = 0, offset: int = 0, order: List[str] = None, groups: List[str] = None,
-                           group_limit: int = 10, expanded=False, enable_joins=False) -> (DBResponse, DBPagination):
+                           group_limit: int = 10, expanded=False, enable_joins=False,
+                           postprocess: Callable[[DBResponse], DBResponse] = None) -> (DBResponse, DBPagination):
         # Grouping not enabled
         if groups is None or len(groups) == 0:
             sql_template = """
@@ -236,8 +238,16 @@ class AsyncPostgresTable(object):
                 offset="OFFSET {}".format(offset) if offset else ""
             ).strip()
 
-        return await self.execute_sql(select_sql=select_sql, values=values, fetch_single=fetch_single,
+        result, pagination = await self.execute_sql(select_sql=select_sql, values=values, fetch_single=fetch_single,
                                       expanded=expanded, limit=limit, offset=offset)
+        # Modify the response after the fetch has been executed
+        if postprocess is not None:
+            if iscoroutinefunction(postprocess):
+                result = await postprocess(result)
+            else:
+                result = postprocess(result)
+
+        return result, pagination
 
     async def execute_sql(self, select_sql: str, values=[], fetch_single=False,
                           expanded=False, limit: int = 0, offset: int = 0) -> (DBResponse, DBPagination):

--- a/services/ui_backend_service/api/data_refiner.py
+++ b/services/ui_backend_service/api/data_refiner.py
@@ -2,47 +2,60 @@ from ..cache.store import CacheStore
 from services.data.db_utils import DBResponse
 import json
 
+
 class Refinery(object):
-  "Used to refine objects with data only available from S3"
+    """Used to refine objects with data only available from S3.
 
-  def __init__(self, field_names = []):
-    self.artifact_store = CacheStore().artifact_cache
-    self.field_names = field_names
+    Parameters:
+    -----------
+    field_names: list of field names that contain S3 locations to be replaced with content.
+    """
 
-  async def refine_record(self, record):
-    locations = [ record[field] for field in self.field_names if field in record ]
-    data = await self.fetch_data(locations)
-    _rec = record
-    for k, v in _rec.items():
-      if k in self.field_names and v in data:
-        _rec[k] = data[v]
-    return _rec
+    def __init__(self, field_names=[]):
+        self.artifact_store = CacheStore().artifact_cache
+        self.field_names = field_names
 
-  async def refine_records(self, records):
-    locations = [ record[field] for field in self.field_names for record in records if field in record ]
-    data = await self.fetch_data(locations)
+    async def refine_record(self, record):
+        locations = [record[field] for field in self.field_names if field in record]
+        data = await self.fetch_data(locations)
+        _rec = record
+        for k, v in _rec.items():
+            if k in self.field_names and v in data:
+                _rec[k] = data[v]
+        return _rec
 
-    _recs = []
-    for rec in records:
-      for k, v in rec.items():
-        if k in self.field_names and v in data:
-          rec[k] = data[v]
-      _recs.append(rec)
-    return _recs
-  
-  async def fetch_data(self, locations):
-    _res = await self.artifact_store.cache.GetArtifacts(locations)
-    if not _res.is_ready():
-      await _res.wait()
-    return _res.get()
+    async def refine_records(self, records):
+        locations = [record[field] for field in self.field_names for record in records if field in record]
+        data = await self.fetch_data(locations)
 
-  async def postprocess(self, response: DBResponse):
-    if response.response_code != 200 or not response.body:
-        return response
-    if isinstance(response.body, list):
-      body = await self.refine_records(response.body)
-    else:
-      body = await self.refine_record(response.body)
-    
-    return DBResponse(response_code=response.response_code,
-                      body=body)
+        _recs = []
+        for rec in records:
+            for k, v in rec.items():
+                if k in self.field_names and v in data:
+                    rec[k] = data[v]
+            _recs.append(rec)
+        return _recs
+
+    async def fetch_data(self, locations):
+        _res = await self.artifact_store.cache.GetArtifacts(locations)
+        if not _res.is_ready():
+            await _res.wait()
+        return _res.get()
+
+    async def postprocess(self, response: DBResponse):
+        """
+        Async post processing callback that can be used as the find_records helpers
+        postprocessing parameter.
+
+        Passed in DBResponse will be refined on the configured field_names, replacing the S3 locations
+        with their contents.
+        """
+        if response.response_code != 200 or not response.body:
+            return response
+        if isinstance(response.body, list):
+            body = await self.refine_records(response.body)
+        else:
+            body = await self.refine_record(response.body)
+
+        return DBResponse(response_code=response.response_code,
+                          body=body)

--- a/services/ui_backend_service/api/data_refiner.py
+++ b/services/ui_backend_service/api/data_refiner.py
@@ -1,0 +1,48 @@
+from ..cache.store import CacheStore
+from services.data.db_utils import DBResponse
+import json
+
+class Refinery(object):
+  "Used to refine objects with data only available from S3"
+
+  def __init__(self, field_names = []):
+    self.artifact_store = CacheStore().artifact_cache
+    self.field_names = field_names
+
+  async def refine_record(self, record):
+    locations = [ record[field] for field in self.field_names if field in record ]
+    data = await self.fetch_data(locations)
+    _rec = record
+    for k, v in _rec.items():
+      if k in self.field_names and v in data:
+        _rec[k] = data[v]
+    return _rec
+
+  async def refine_records(self, records):
+    locations = [ record[field] for field in self.field_names for record in records if field in record ]
+    data = await self.fetch_data(locations)
+
+    _recs = []
+    for rec in records:
+      for k, v in rec.items():
+        if k in self.field_names and v in data:
+          rec[k] = data[v]
+      _recs.append(rec)
+    return _recs
+  
+  async def fetch_data(self, locations):
+    _res = await self.artifact_store.cache.GetArtifacts(locations)
+    if not _res.is_ready():
+      await _res.wait()
+    return _res.get()
+
+  async def postprocess(self, response: DBResponse):
+    if response.response_code != 200 or not response.body:
+        return response
+    if isinstance(response.body, list):
+      body = await self.refine_records(response.body)
+    else:
+      body = await self.refine_record(response.body)
+    
+    return DBResponse(response_code=response.response_code,
+                      body=body)

--- a/services/ui_backend_service/api/data_refiner.py
+++ b/services/ui_backend_service/api/data_refiner.py
@@ -20,8 +20,8 @@ class Refinery(object):
         data = await self.fetch_data(locations)
         _rec = record
         for k, v in _rec.items():
-            if k in self.field_names and v in data:
-                _rec[k] = data[v]
+            if k in self.field_names:
+                _rec[k] = data[v] if v in data else None
         return _rec
 
     async def refine_records(self, records):
@@ -31,8 +31,8 @@ class Refinery(object):
         _recs = []
         for rec in records:
             for k, v in rec.items():
-                if k in self.field_names and v in data:
-                    rec[k] = data[v]
+                 if k in self.field_names:
+                    rec[k] = data[v] if v in data else None
             _recs.append(rec)
         return _recs
 

--- a/services/ui_backend_service/api/data_refiner.py
+++ b/services/ui_backend_service/api/data_refiner.py
@@ -37,10 +37,13 @@ class Refinery(object):
         return _recs
 
     async def fetch_data(self, locations):
-        _res = await self.artifact_store.cache.GetArtifacts(locations)
-        if not _res.is_ready():
-            await _res.wait()
-        return _res.get()
+        try:
+            _res = await self.artifact_store.cache.GetArtifacts(locations)
+            if not _res.is_ready():
+                await _res.wait()
+            return _res.get()
+        except:
+            return {}
 
     async def postprocess(self, response: DBResponse):
         """

--- a/services/ui_backend_service/api/data_refiner.py
+++ b/services/ui_backend_service/api/data_refiner.py
@@ -31,7 +31,7 @@ class Refinery(object):
         _recs = []
         for rec in records:
             for k, v in rec.items():
-                 if k in self.field_names:
+                if k in self.field_names:
                     rec[k] = data[v] if v in data else None
             _recs.append(rec)
         return _recs
@@ -63,15 +63,17 @@ class Refinery(object):
         return DBResponse(response_code=response.response_code,
                           body=body)
 
+
 class TaskRefiner(Refinery):
     """
     Refiner class for postprocessing Task rows.
 
     Fetches specified content from S3 and cleans up unnecessary fields from response.
     """
-    def __init__(self, field_names):
-        super().__init__(field_names)
-    
+
+    def __init__(self):
+        super().__init__(field_names = ["task_ok"])
+
     async def postprocess(self, response: DBResponse):
         """Calls the refiner postprocessing to fetch S3 values for content.
         Cleans up returned fields, for example by combining 'task_ok' boolean into the 'status'
@@ -87,8 +89,8 @@ class TaskRefiner(Refinery):
             return item
 
         if isinstance(refined_response.body, list):
-            body = [_cleanup(task) for task in refined_response.body ]
+            body = [_cleanup(task) for task in refined_response.body]
         else:
             body = _cleanup(refined_response.body)
-        
+
         return DBResponse(response_code=refined_response.response_code, body=body)

--- a/services/ui_backend_service/api/notify.py
+++ b/services/ui_backend_service/api/notify.py
@@ -1,8 +1,9 @@
 import json
 import asyncio
-from typing import Dict, List, Any
+from typing import Dict, List, Any, Callable
 from services.data.postgres_async_db import AsyncPostgresDB
 from pyee import AsyncIOEventEmitter
+from .data_refiner import TaskRefiner
 
 
 class ListenNotify(object):
@@ -10,6 +11,7 @@ class ListenNotify(object):
         self.app = app
         self.event_emitter = event_emitter or AsyncIOEventEmitter()
         self.db = AsyncPostgresDB.get_instance()
+        self.task_refiner = TaskRefiner()
 
         loop = asyncio.get_event_loop()
         loop.create_task(self._init())
@@ -37,13 +39,13 @@ class ListenNotify(object):
                     table = await self.db.get_table_by_name(table_name)
                     if table != None:
                         resources = resource_list(table.table_name, data)
-
+                        postprocess = self.get_table_postprocessor(table.table_name)
                         # Broadcast this event to `api/ws.py` (Websocket.event_handler)
                         # and notify each Websocket connection about this event
                         if resources != None and len(resources) > 0:
                             await load_and_broadcast(self.event_emitter, operation, table,
-                                                     data, table.primary_keys)
-                        
+                                                     data, table.primary_keys, postprocess=postprocess)
+
                         # Heartbeat watcher for Runs.
                         if table.table_name == self.db.run_table_postgres.table_name:
                             self.event_emitter.emit('run-heartbeat', 'update', data['run_number'])
@@ -53,7 +55,7 @@ class ListenNotify(object):
                                 table.table_name == self.db.step_table_postgres.table_name and \
                                 data["step_name"] == "start":
                             self.event_emitter.emit("run-parameters", data['flow_id'], data['run_number'])
-                        
+
                         # Notify related resources once new `_task_ok` artifact has been created
                         if operation == "INSERT" and \
                                 table.table_name == self.db.artifact_table_postgres.table_name and \
@@ -61,9 +63,19 @@ class ListenNotify(object):
 
                             # Always mark task finished if '_task_ok' artifact is created
                             # Include 'attempt_id' so we can identify which attempt this artifact related to
+                            _attempt_id = data.get("attempt_id", 0)
+                            # First attempt has already been inserted by task table trigger.
+                            # Later attempts must count as inserts to register properly for the UI
+                            _op = "UPDATE" if _attempt_id == 0 else "INSERT"
                             await load_and_broadcast(
-                                self.event_emitter, "UPDATE", self.db.task_table_postgres,
-                                data, self.db.task_table_postgres.primary_keys, {"attempt_id": data.get("attempt_id", 0)})
+                                event_emitter=self.event_emitter,
+                                operation=_op,
+                                table=self.db.task_table_postgres,
+                                data=data,
+                                keys=self.db.task_table_postgres.primary_keys,
+                                custom_filter_dict={"attempt_id": _attempt_id},
+                                postprocess=self.task_refiner.postprocess
+                            )
 
                             # Last step is always called 'end' and only one '_task_ok' should be present
                             # Run is considered finished once 'end' step has '_task_ok' artifact
@@ -78,6 +90,12 @@ class ListenNotify(object):
 
                 except Exception as err:
                     print(err, flush=True)
+
+    def get_table_postprocessor(self, table_name):
+        if table_name == self.db.task_table_postgres.table_name:
+            return self.task_refiner.postprocess
+        else:
+            return None
 
 
 def resource_list(table_name: str, data: Dict):
@@ -98,7 +116,8 @@ def resource_list(table_name: str, data: Dict):
         "tasks_v3": [
             "/flows/{flow_id}/runs/{run_number}/tasks",
             "/flows/{flow_id}/runs/{run_number}/steps/{step_name}/tasks",
-            "/flows/{flow_id}/runs/{run_number}/steps/{step_name}/tasks/{task_id}"
+            "/flows/{flow_id}/runs/{run_number}/steps/{step_name}/tasks/{task_id}",
+            "/flows/{flow_id}/runs/{run_number}/steps/{step_name}/tasks/{task_id}/attempts"
         ],
         "metadata_v3": [
             "/flows/{flow_id}/runs/{run_number}/metadata",
@@ -115,24 +134,27 @@ def resource_list(table_name: str, data: Dict):
     return []
 
 
-async def load_data_from_db(table, filter_dict: Dict[str, Any]):
+async def load_data_from_db(table, filter_dict: Dict[str, Any],
+                            postprocess: Callable = None):
     conditions, values = [], []
     for k, v in filter_dict.items():
         conditions.append("{} = %s".format(k))
         values.append(v)
 
     results, _ = await table.find_records(
-        conditions=conditions, values=values, fetch_single=True, enable_joins=True
+        conditions=conditions, values=values, fetch_single=True,
+        enable_joins=True, postprocess=postprocess
     )
     resources = resource_list(table.table_name, results.body)
     return results.body, resources
 
 
 async def load_and_broadcast(event_emitter, operation: str, table,
-                             data: Dict, keys: List[str], custom_filter_dict={}):
+                             data: Dict, keys: List[str], custom_filter_dict={},
+                             postprocess: Callable = None):
     filter_dict = {}
     for k in keys:
         filter_dict[k] = data[k]
 
-    _data, _resources = await load_data_from_db(table, {**filter_dict, **custom_filter_dict})
+    _data, _resources = await load_data_from_db(table, {**filter_dict, **custom_filter_dict}, postprocess)
     event_emitter.emit('notify', operation, _resources, _data)

--- a/services/ui_backend_service/api/task.py
+++ b/services/ui_backend_service/api/task.py
@@ -146,7 +146,8 @@ class TaskApi(object):
                                   allowed_group=self._async_table.keys,
                                   allowed_filters=self._async_table.keys +
                                   ["finished_at", "duration", "attempt_id"],
-                                  enable_joins=True
+                                  enable_joins=True,
+                                  postprocess=self._postprocess
                                   )
 
     @handle_exceptions
@@ -273,7 +274,7 @@ class TaskApi(object):
 
         def _cleanup(item):
             # TODO: test if 'running' statuses go through correctly.
-            item['status'] = item['status'] if item['task_ok'] else 'failed'
+            item['status'] = 'failed' if item['status'] == 'completed' and item['task_ok'] is False else item['status']
             item.pop('task_ok')
             return item
 

--- a/services/ui_backend_service/api/task.py
+++ b/services/ui_backend_service/api/task.py
@@ -30,7 +30,7 @@ class TaskApi(object):
         self._async_table = AsyncPostgresDB.get_instance().task_table_postgres
         self.refiner = Refinery(field_names=["task_ok"])
 
-    # @handle_exceptions
+    @handle_exceptions
     async def get_run_tasks(self, request):
         """
         ---

--- a/services/ui_backend_service/api/task.py
+++ b/services/ui_backend_service/api/task.py
@@ -1,5 +1,5 @@
 from services.data.postgres_async_db import AsyncPostgresDB
-from services.data.db_utils import translate_run_key, translate_task_key
+from services.data.db_utils import DBResponse, translate_run_key, translate_task_key
 from services.utils import handle_exceptions
 from .utils import find_records
 from .data_refiner import Refinery
@@ -86,7 +86,7 @@ class TaskApi(object):
                                   allowed_filters=self._async_table.keys +
                                   ["finished_at", "duration", "attempt_id"],
                                   enable_joins=True,
-                                  postprocess=self.refiner.postprocess
+                                  postprocess=self._postprocess
                                   )
 
     @handle_exceptions
@@ -195,7 +195,7 @@ class TaskApi(object):
                                       flow_name, run_id_value, step_name, task_id_value],
                                   initial_order=["attempt_id DESC"],
                                   enable_joins=True,
-                                  postprocess=self.refiner.postprocess)
+                                  postprocess=self._postprocess)
 
     @handle_exceptions
     async def get_task_attempts(self, request):
@@ -260,5 +260,26 @@ class TaskApi(object):
                                   allowed_filters=self._async_table.keys +
                                   ["finished_at", "duration", "attempt_id"],
                                   enable_joins=True,
-                                  postprocess=self.refiner.postprocess
+                                  postprocess=self._postprocess
                                   )
+
+    async def _postprocess(self, response: DBResponse):
+        """Calls the refiner postprocessing to fetch S3 values for content.
+        Cleans up returned fields, for example by combining 'task_ok' boolean into the 'status'
+        """
+        refined_response = await self.refiner.postprocess(response)
+        if response.response_code != 200 or not response.body:
+            return response
+
+        def _cleanup(item):
+            # TODO: test if 'running' statuses go through correctly.
+            item['status'] = item['status'] if item['task_ok'] else 'failed'
+            item.pop('task_ok')
+            return item
+
+        if isinstance(refined_response.body, list):
+            body = [_cleanup(task) for task in refined_response.body ]
+        else:
+            body = _cleanup(refined_response.body)
+        
+        return DBResponse(response_code=refined_response.response_code, body=body)

--- a/services/ui_backend_service/api/task.py
+++ b/services/ui_backend_service/api/task.py
@@ -194,7 +194,8 @@ class TaskApi(object):
                                   initial_values=[
                                       flow_name, run_id_value, step_name, task_id_value],
                                   initial_order=["attempt_id DESC"],
-                                  enable_joins=True)
+                                  enable_joins=True,
+                                  postprocess=self.refiner.postprocess)
 
     @handle_exceptions
     async def get_task_attempts(self, request):
@@ -258,5 +259,6 @@ class TaskApi(object):
                                   allowed_group=self._async_table.keys,
                                   allowed_filters=self._async_table.keys +
                                   ["finished_at", "duration", "attempt_id"],
-                                  enable_joins=True
+                                  enable_joins=True,
+                                  postprocess=self.refiner.postprocess
                                   )

--- a/services/ui_backend_service/api/task.py
+++ b/services/ui_backend_service/api/task.py
@@ -2,6 +2,7 @@ from services.data.postgres_async_db import AsyncPostgresDB
 from services.data.db_utils import translate_run_key, translate_task_key
 from services.utils import handle_exceptions
 from .utils import find_records
+from .data_refiner import Refinery
 
 
 class TaskApi(object):
@@ -27,8 +28,9 @@ class TaskApi(object):
             self.get_task_attempts,
         )
         self._async_table = AsyncPostgresDB.get_instance().task_table_postgres
+        self.refiner = Refinery(field_names=["task_ok"])
 
-    @handle_exceptions
+    # @handle_exceptions
     async def get_run_tasks(self, request):
         """
         ---
@@ -83,7 +85,8 @@ class TaskApi(object):
                                   allowed_group=self._async_table.keys,
                                   allowed_filters=self._async_table.keys +
                                   ["finished_at", "duration", "attempt_id"],
-                                  enable_joins=True
+                                  enable_joins=True,
+                                  postprocess=self.refiner.postprocess
                                   )
 
     @handle_exceptions

--- a/services/ui_backend_service/api/task.py
+++ b/services/ui_backend_service/api/task.py
@@ -28,7 +28,7 @@ class TaskApi(object):
             self.get_task_attempts,
         )
         self._async_table = AsyncPostgresDB.get_instance().task_table_postgres
-        self.refiner = TaskRefiner(field_names=["task_ok"])
+        self.refiner = TaskRefiner()
 
     @handle_exceptions
     async def get_run_tasks(self, request):

--- a/services/ui_backend_service/api/utils.py
+++ b/services/ui_backend_service/api/utils.py
@@ -285,7 +285,7 @@ async def find_records(request: web.BaseRequest, async_table=None, initial_condi
 
     # Modify the response after the fetch has been executed
     if postprocess is not None:
-        results = postprocess(results)
+        results = await postprocess(results)
 
     if fetch_single:
         status, res = format_response(request, results)

--- a/services/ui_backend_service/api/utils.py
+++ b/services/ui_backend_service/api/utils.py
@@ -4,7 +4,7 @@ from aiohttp import web
 from typing import Callable, List, Dict
 from services.data.db_utils import DBResponse
 from services.utils import format_qs, format_baseurl, web_response
-
+from inspect import isawaitable
 
 def format_response(request: web.BaseRequest, db_response: DBResponse) -> (int, Dict):
     query = {}
@@ -285,7 +285,7 @@ async def find_records(request: web.BaseRequest, async_table=None, initial_condi
 
     # Modify the response after the fetch has been executed
     if postprocess is not None:
-        results = await postprocess(results)
+            results = (await postprocess(results)) if isawaitable(postprocess) else postprocess(results)
 
     if fetch_single:
         status, res = format_response(request, results)

--- a/services/ui_backend_service/api/utils.py
+++ b/services/ui_backend_service/api/utils.py
@@ -4,7 +4,7 @@ from aiohttp import web
 from typing import Callable, List, Dict
 from services.data.db_utils import DBResponse
 from services.utils import format_qs, format_baseurl, web_response
-from inspect import isawaitable
+from asyncio import iscoroutinefunction
 
 def format_response(request: web.BaseRequest, db_response: DBResponse) -> (int, Dict):
     query = {}
@@ -285,7 +285,10 @@ async def find_records(request: web.BaseRequest, async_table=None, initial_condi
 
     # Modify the response after the fetch has been executed
     if postprocess is not None:
-            results = (await postprocess(results)) if isawaitable(postprocess) else postprocess(results)
+        if iscoroutinefunction(postprocess):
+            results = await postprocess(results)
+        else:
+            results = postprocess(results)
 
     if fetch_single:
         status, res = format_response(request, results)

--- a/services/ui_backend_service/api/utils.py
+++ b/services/ui_backend_service/api/utils.py
@@ -4,7 +4,6 @@ from aiohttp import web
 from typing import Callable, List, Dict
 from services.data.db_utils import DBResponse
 from services.utils import format_qs, format_baseurl, web_response
-from asyncio import iscoroutinefunction
 
 def format_response(request: web.BaseRequest, db_response: DBResponse) -> (int, Dict):
     query = {}
@@ -280,15 +279,8 @@ async def find_records(request: web.BaseRequest, async_table=None, initial_condi
     results, pagination = await async_table.find_records(
         conditions=conditions, values=values, limit=limit, offset=offset,
         order=ordering if len(ordering) > 0 else None, groups=groups, group_limit=group_limit,
-        fetch_single=fetch_single, enable_joins=enable_joins, expanded=False
+        fetch_single=fetch_single, enable_joins=enable_joins, expanded=False, postprocess=postprocess
     )
-
-    # Modify the response after the fetch has been executed
-    if postprocess is not None:
-        if iscoroutinefunction(postprocess):
-            results = await postprocess(results)
-        else:
-            results = postprocess(results)
 
     if fetch_single:
         status, res = format_response(request, results)

--- a/services/ui_backend_service/cache/search_artifacts_action.py
+++ b/services/ui_backend_service/cache/search_artifacts_action.py
@@ -138,6 +138,8 @@ class SearchArtifacts(CacheAction):
                 load_success, value = json.loads(existing_keys[key])
             else:
                 load_success, value = False, None
+            if value:
+                value = str(value)
 
             search_results[format_loc(key)] = {
                 "included": load_success,

--- a/services/ui_backend_service/cache/utils.py
+++ b/services/ui_backend_service/cache/utils.py
@@ -15,7 +15,7 @@ def decode(path):
     "decodes a gzip+pickle compressed object from a file path"
     with GzipFile(path) as f:
         obj = pickle.load(f)
-        return str(obj)
+        return obj
 
 # No-Retry S3 client
 import os

--- a/services/ui_backend_service/tests/integration_tests/tasks_test.py
+++ b/services/ui_backend_service/tests/integration_tests/tasks_test.py
@@ -37,6 +37,7 @@ async def test_list_tasks(cli, db):
                             run_number=_step.get("run_number"),
                             run_id=_step.get("run_id"))).body
     _task['status'] = 'running'
+    _task.pop('task_ok', None)
 
     await _test_list_resources(cli, db, "/flows/{flow_id}/runs/{run_number}/tasks".format(**_task), 200, [_task])
     await _test_list_resources(cli, db, "/flows/{flow_id}/runs/{run_number}/steps/{step_name}/tasks".format(**_task), 200, [_task])
@@ -57,6 +58,7 @@ async def test_list_tasks_non_numerical(cli, db):
                             run_id=_step.get("run_id"),
                             task_name="bar")).body
     _task['status'] = 'running'
+    _task.pop('task_ok', None)
 
     await _test_list_resources(cli, db, "/flows/{flow_id}/runs/{run_number}/tasks".format(**_task), 200, [_task])
     await _test_list_resources(cli, db, "/flows/{flow_id}/runs/{run_number}/steps/{step_name}/tasks".format(**_task), 200, [_task])
@@ -74,6 +76,7 @@ async def test_single_task(cli, db):
                             run_number=_step.get("run_number"),
                             run_id=_step.get("run_id"))).body
     _task['status'] = 'running'
+    _task.pop('task_ok', None)
 
     await _test_single_resource(cli, db, "/flows/{flow_id}/runs/{run_number}/steps/{step_name}/tasks/{task_id}".format(**_task), 200, _task)
 
@@ -88,6 +91,7 @@ async def test_single_task_non_numerical(cli, db):
                             step_name=_step.get("step_name"),
                             task_name="bar")).body
     _task['status'] = 'running'
+    _task.pop('task_ok', None)
 
     await _test_single_resource(cli, db, "/flows/{flow_id}/runs/{run_number}/steps/{step_name}/tasks/{task_id}".format(**_task), 200, _task)
     await _test_single_resource(cli, db, "/flows/{flow_id}/runs/{run_number}/steps/{step_name}/tasks/bar".format(**_task), 200, _task)
@@ -104,6 +108,7 @@ async def test_list_task_attempts(cli, db):
                             run_number=_step.get("run_number"),
                             run_id=_step.get("run_id"))).body
     _task['status'] = 'running'
+    _task.pop('task_ok', None)
 
     await _test_list_resources(cli, db, "/flows/{flow_id}/runs/{run_number}/steps/{step_name}/tasks/{task_id}/attempts".format(**_task), 200, [_task])
 
@@ -170,6 +175,7 @@ async def test_task_with_multiple_attempts(cli, db):
                             run_number=_step.get("run_number"),
                             run_id=_step.get("run_id"))).body
     _task['status'] = 'running'
+    _task.pop('task_ok', None)
 
     await _test_list_resources(cli, db, "/flows/{flow_id}/runs/{run_number}/steps/{step_name}/tasks/{task_id}/attempts".format(**_task), 200, [_task])
 


### PR DESCRIPTION
* Add generic postprocessing to enrich database responses with content from S3.
* change find_records postprocessing helper to accept async callbacks
* adds `task_ok` s3 location to Task database responses, that gets postprocessed to the actual content.