### PR TITLE
Websocket past data: `since` to return missing data

### DIFF
--- a/services/ui_backend_service/README-websocket.md
+++ b/services/ui_backend_service/README-websocket.md
@@ -14,6 +14,16 @@ Subscribing to a RESTful resources realtime events is done by sending the follow
   }
 ```
 
+Subscribe to future events and return past data since unix time (seconds):
+```json
+  {
+    "type": "SUBSCRIBE", 
+    "resource": "path-to-subscribable-restful-resource",
+    "uuid": "client-generated-uuid",
+    "since": 1602752197
+  }
+```
+
 Unsubscribing is done through the same endpoint with the message:
 ```json
   {

--- a/services/ui_backend_service/README.md
+++ b/services/ui_backend_service/README.md
@@ -43,6 +43,14 @@ This also works as a Docker build argument to download and install latest or spe
 > $ docker build --arg UI_ENABLED=1 UI_VERSION=v0.1.2 ...
 > ```
 
+Configure amount of seconds realtime events are kept in queue (delivered to UI in case of reconnects):
+
+- `WS_QUEUE_TTL_SECONDS` [defaults to 300 (5 minutes)]
+
+Configure amount of runs to prefetch during server startup (artifact cache):
+
+- `PREFETCH_RUNS_LIMIT` [defaults to 50]
+
 Running the service without Docker (from project root):
 
 > ```sh
@@ -111,6 +119,7 @@ ew = ends with              *string$
 ```
 
 ## Custom Navigation links for UI
+
 You can customize the admin navigation links presented by the UI by renaming the provided `links.example.json` file to `links.json`. The backend service serves the contents of the file as-is, so be sure to adhere to the predefined structure.
 
 **Local Dev**

--- a/services/ui_backend_service/api/utils.py
+++ b/services/ui_backend_service/api/utils.py
@@ -303,11 +303,11 @@ class TTLQueue:
         self._ttl: int = ttl_in_seconds
         self._queue = deque()
 
-    def append(self, value: any):
+    async def append(self, value: any):
         self._queue.append((time.time(), value))
-        self.discard_expired_values()
+        await self.discard_expired_values()
 
-    def discard_expired_values(self):
+    async def discard_expired_values(self):
         cutoff_time = time.time() - self._ttl
         try:
             while self._queue[0][0] < cutoff_time:
@@ -315,9 +315,9 @@ class TTLQueue:
         except IndexError:
             pass
 
-    def values(self):
-        self.discard_expired_values()
+    async def values(self):
+        await self.discard_expired_values()
         return self._queue
 
-    def values_since(self, since_epoch: int):
-        return [value for value in self.values() if value[0] >= since_epoch]
+    async def values_since(self, since_epoch: int):
+        return [value for value in await self.values() if value[0] >= since_epoch]

--- a/services/ui_backend_service/api/utils.py
+++ b/services/ui_backend_service/api/utils.py
@@ -1,9 +1,11 @@
+import time
 from urllib.parse import urlsplit, parse_qsl
 from multidict import MultiDict
 from aiohttp import web
 from typing import Callable, List, Dict
 from services.data.db_utils import DBResponse
 from services.utils import format_qs, format_baseurl, web_response
+from collections import deque
 
 
 def format_response(request: web.BaseRequest, db_response: DBResponse) -> (int, Dict):
@@ -156,7 +158,7 @@ def builtin_conditions_query_dict(query: MultiDict):
 
                 conditions.append(
                     "tags||system_tags::text LIKE {}(array[{}])"
-                    .format(compare, ",".join(["%s"]*len(tags))))
+                    .format(compare, ",".join(["%s"] * len(tags))))
                 values += map(lambda t: "%{}%".format(t), tags)
 
             else:
@@ -165,7 +167,7 @@ def builtin_conditions_query_dict(query: MultiDict):
                 compare = "?|" if operator == "any" else "?&"
 
                 conditions.append("tags||system_tags {} array[{}]".format(
-                    compare, ",".join(["%s"]*len(tags))))
+                    compare, ",".join(["%s"] * len(tags))))
                 values += tags
 
     return conditions, values
@@ -294,3 +296,28 @@ async def find_records(request: web.BaseRequest, async_table=None, initial_condi
         status, res = format_response_list(
             request, results, page, pagination.pages_total)
         return web_response(status, res)
+
+
+class TTLQueue:
+    def __init__(self, ttl_in_seconds: int):
+        self._ttl: int = ttl_in_seconds
+        self._queue = deque()
+
+    def append(self, value: any):
+        self._queue.append((time.time(), value))
+        self.discard_expired_values()
+
+    def discard_expired_values(self):
+        cutoff_time = time.time() - self._ttl
+        try:
+            while self._queue[0][0] < cutoff_time:
+                self._queue.popleft()
+        except IndexError:
+            pass
+
+    def values(self):
+        self.discard_expired_values()
+        return self._queue
+
+    def values_since(self, since_epoch: int):
+        return [value for value in self.values() if value[0] >= since_epoch]

--- a/services/ui_backend_service/api/ws.py
+++ b/services/ui_backend_service/api/ws.py
@@ -5,7 +5,7 @@ import json
 import asyncio
 import collections
 
-from .utils import resource_conditions
+from .utils import resource_conditions, TTLQueue
 from services.data.postgres_async_db import AsyncPostgresDB
 from pyee import AsyncIOEventEmitter
 
@@ -15,17 +15,21 @@ UNSUBSCRIBE = 'UNSUBSCRIBE'
 WSSubscription = collections.namedtuple(
     "WSSubscription", "ws fullpath resource query uuid conditions values")
 
+
 class Websocket(object):
     '''
     Adds a '/ws' endpoint and support for broadcasting realtime resource events to subscribed frontend clients.
-    
+
     Subscribe to runs created by user dipper:
     /runs?_tags=user:dipper
     'uuid' can be used to identify specific subscription.
-    
-    Subscribe:
-    {"type":"SUBSCRIBE", "uuid": "myst3rySh4ck", "resource": "/runs"}
-    
+
+    Subscribe to future events:
+    {"type": "SUBSCRIBE", "uuid": "myst3rySh4ck", "resource": "/runs"}
+
+    Subscribing to future events and return past data since unix time (seconds):
+    {"type": "SUBSCRIBE", "uuid": "myst3rySh4ck", "resource": "/runs", "since": 1602752197}
+
     Unsubscribe:
     {"type": "UNSUBSCRIBE", "uuid": "myst3rySh4ck"}
 
@@ -33,6 +37,7 @@ class Websocket(object):
     {"type": "UPDATE", "uuid": "myst3rySh4ck", "resource": "/runs", "data": {"foo": "bar"}}
     '''
     subscriptions: List[WSSubscription] = []
+    queue = TTLQueue(60 * 5)  # 5 minute queue
 
     def __init__(self, app, event_emitter=None):
         self.app = app
@@ -43,29 +48,47 @@ class Websocket(object):
         app.router.add_route('GET', '/ws', self.websocket_handler)
 
     async def event_handler(self, operation: str, resources: List[str], data: Dict):
-        for sub in self.subscriptions:
-            for resource in resources:
-                if sub.resource == resource:
-                    # Check if possible filters match this event
-                    # only if the subscription actually provided conditions.
-                    if sub.conditions:
-                        filters_match_request = await self.db.apply_filters_to_data(
-                            data=data, conditions=sub.conditions, values=sub.values)
-                    else:
-                        filters_match_request = True
-                    if filters_match_request:
-                        payload = {'type': operation, 'uuid': sub.uuid,
-                                   'resource': resource, 'data': data}
-                        await sub.ws.send_str(json.dumps(payload))
+        # Append to QUEUE so that we can send events to users in case of
+        self.queue.append({
+            'operation': operation,
+            'resources': resources,
+            'data': data
+        })
 
-    async def subscribe_to(self, ws, uuid: str, resource: str):
+        for subscription in self.subscriptions:
+            await self._event_subscription(subscription, operation, resources, data)
+
+    async def _event_subscription(self, subscription: WSSubscription, operation: str, resources: List[str], data: Dict):
+        for resource in resources:
+            if subscription.resource == resource:
+                # Check if possible filters match this event
+                # only if the subscription actually provided conditions.
+                if subscription.conditions:
+                    filters_match_request = await self.db.apply_filters_to_data(
+                        data=data, conditions=subscription.conditions, values=subscription.values)
+                else:
+                    filters_match_request = True
+                if filters_match_request:
+                    payload = {'type': operation, 'uuid': subscription.uuid,
+                               'resource': resource, 'data': data}
+                    await subscription.ws.send_str(json.dumps(payload))
+
+    async def subscribe_to(self, ws, uuid: str, resource: str, since: int):
         # Always unsubscribe existing duplicate identifiers
         await self.unsubscribe_from(ws, uuid)
 
+        # Create new subscription
         _resource, query, conditions, values = resource_conditions(resource)
-        self.subscriptions.append(WSSubscription(
+        subscription = WSSubscription(
             ws=ws, fullpath=resource, resource=_resource, query=query, uuid=uuid,
-            conditions=conditions, values=values))
+            conditions=conditions, values=values)
+        self.subscriptions.append(subscription)
+
+        # Send previous events that client might have missed due to disconnection
+        if since:
+            event_queue = self.queue.values_since(since)
+            for _, event in event_queue:
+                await self._event_subscription(subscription, event['operation'], event['resources'], event['data'])
 
     async def unsubscribe_from(self, ws, uuid: str = None):
         if uuid:
@@ -87,9 +110,14 @@ class Websocket(object):
                     op_type = payload.get("type")
                     resource = payload.get("resource")
                     uuid = payload.get("uuid")
+                    since = payload.get("since")
+                    if since is not None and str(since).isnumeric():
+                        since = int(since)
+                    else:
+                        since = None
 
                     if op_type == SUBSCRIBE and uuid and resource:
-                        await self.subscribe_to(ws, uuid, resource)
+                        await self.subscribe_to(ws, uuid, resource, since)
                     elif op_type == UNSUBSCRIBE and uuid:
                         await self.unsubscribe_from(ws, uuid)
 

--- a/services/ui_backend_service/tests/integration_tests/notify_test.py
+++ b/services/ui_backend_service/tests/integration_tests/notify_test.py
@@ -227,21 +227,21 @@ async def test_pg_notify_trigger_updates_on_attempt_id(cli, db, loop):
     _flow = (await add_flow(db, flow_id="HelloFlow")).body
 
     # Wait for results
-    await wait_for(_should_call, 0.1)
+    await wait_for(_should_call, TIMEOUT_FUTURE)
 
     # Add new Run
     _should_call = _set_notify_handler(cli, loop)
     _run = (await add_run(db, flow_id=_flow.get("flow_id"))).body
 
     # Wait for results
-    await wait_for(_should_call, 0.1)
+    await wait_for(_should_call, TIMEOUT_FUTURE)
 
     # Add normal Step
     _should_call = _set_notify_handler(cli, loop)
     _step = (await add_step(db, flow_id=_run.get("flow_id"), step_name="step", run_number=_run.get("run_number"), run_id=_run.get("run_id"))).body
 
     # Wait for results
-    await wait_for(_should_call, 0.1)
+    await wait_for(_should_call, TIMEOUT_FUTURE)
 
     # Add new Task
     _should_call = _set_notify_handler(cli, loop)
@@ -252,7 +252,7 @@ async def test_pg_notify_trigger_updates_on_attempt_id(cli, db, loop):
                                  run_id=_step.get("run_id"))).body
 
     # Wait for results
-    await wait_for(_should_call, 0.1)
+    await wait_for(_should_call, TIMEOUT_FUTURE)
 
     # Add artifact with attempt_id = 0 (Task will be done)
     _artifact_step = (await add_artifact(db,
@@ -276,9 +276,9 @@ async def test_pg_notify_trigger_updates_on_attempt_id(cli, db, loop):
     cli.server.app.event_emitter.on('notify', _event_handler_task_done)
 
     # Wait for results
-    await wait_for(_should_call_artifact, 0.1)
+    await wait_for(_should_call_artifact, TIMEOUT_FUTURE)
 
-    operation, _, result = await wait_for(_should_call_task_done, 0.1)
+    operation, _, result = await wait_for(_should_call_task_done, TIMEOUT_FUTURE)
     assert operation == "UPDATE"
     assert result["finished_at"] == _artifact_step["ts_epoch"]
     assert result["attempt_id"] == 0
@@ -307,9 +307,9 @@ async def test_pg_notify_trigger_updates_on_attempt_id(cli, db, loop):
     cli.server.app.event_emitter.on('notify', _event_handler_task_done)
 
     # Wait for results
-    await wait_for(_should_call_artifact, 0.1)
+    await wait_for(_should_call_artifact, TIMEOUT_FUTURE)
 
-    operation, _, result = await wait_for(_should_call_task_done, 0.1)
+    operation, _, result = await wait_for(_should_call_task_done, TIMEOUT_FUTURE)
     assert operation == "UPDATE"
     assert result["finished_at"] == _artifact_step["ts_epoch"]
     assert result["attempt_id"] == 1

--- a/services/ui_backend_service/tests/integration_tests/utils.py
+++ b/services/ui_backend_service/tests/integration_tests/utils.py
@@ -29,7 +29,7 @@ TIMEOUT_FUTURE = 0.1
 # Test fixture helpers begin
 
 
-def init_app(loop, aiohttp_client):
+def init_app(loop, aiohttp_client, queue_ttl=30):
     app = web.Application()
     app.event_emitter = AsyncIOEventEmitter()
 
@@ -46,7 +46,7 @@ def init_app(loop, aiohttp_client):
     ArtificatsApi(app)
     TagApi(app)
 
-    Websocket(app, app.event_emitter)
+    Websocket(app, app.event_emitter, queue_ttl)
 
     AdminApi(app)
 


### PR DESCRIPTION
Introduces ability to deliver past Websocket events while subscribing to resources (defined by `since` parameter):

```json
  {
    "type": "SUBSCRIBE", 
    "resource": "path-to-subscribable-restful-resource",
    "uuid": "client-generated-uuid",
    "since": 1602752197
  }
```

This event queue TTL is 5 minutes by default and can be controlled with `WS_QUEUE_TTL_SECONDS` environment variable. This TTL is used by the UI as well to determine if client data is stale in case reconnecting took too long (and prompts user to refresh browser if that's the case).

Added 3 integration tests:
- `ws_test.test_subscription_queue` - Make sure past data is returned correctly when `since` parameter is provided
- `ws_test.test_subscription_queue_without_since` - Make sure past data is not returned in case `since` parameter not provided
- `ws_test.test_subscription_queue_ttl_expired` - Make sure past data is not returned when queue is items are past TTL

This PR also includes `README.md` entry for `PREFETCH_RUNS_LIMIT` environment variable.