### PR TITLE
Include existing keys in generated result key set of cache actions

### DIFF
--- a/services/ui_backend_service/cache/get_artifacts_action.py
+++ b/services/ui_backend_service/cache/get_artifacts_action.py
@@ -63,7 +63,9 @@ class GetArtifacts(CacheAction):
                 stream_output=None,
                 **kwargs):
 
-        results = {}
+        # make a copy of already existing results, as the cache action has to produce all keys it promised
+        # in the format_request response.
+        results = {**existing_keys}
         locations = message['artifact_locations']
 
         artifact_keys = [key for key in keys if key.startswith('search:artifactdata')]
@@ -117,8 +119,6 @@ class GetArtifacts(CacheAction):
         for key in artifact_keys:
             if key in results:
                 success, value = json.loads(results[key])
-            elif key in existing_keys:
-                success, value = json.loads(existing_keys[key])
             else:
                 success, value = False, None
             

--- a/services/ui_backend_service/cache/search_artifacts_action.py
+++ b/services/ui_backend_service/cache/search_artifacts_action.py
@@ -76,7 +76,9 @@ class SearchArtifacts(CacheAction):
                 stream_output=None,
                 **kwargs):
 
-        results = {}
+        # make a copy of already existing results, as the cache action has to produce all keys it promised
+        # in the format_request response.
+        results = {**existing_keys}
         locations = message['artifact_locations']
 
         artifact_keys = [key for key in keys if key.startswith('search:artifactdata')]
@@ -134,8 +136,6 @@ class SearchArtifacts(CacheAction):
         for key in artifact_keys:
             if key in results:
                 load_success, value = json.loads(results[key])
-            elif key in existing_keys:
-                load_success, value = json.loads(existing_keys[key])
             else:
                 load_success, value = False, None
             if value:

--- a/services/ui_backend_service/cache/store.py
+++ b/services/ui_backend_service/cache/store.py
@@ -158,14 +158,16 @@ class ArtifactCacheStore(object):
         return combined_results
     
     async def run_parameters_event_handler(self, flow_id, run_number):
-        parameters = await self.get_run_parameters(flow_id, run_number)
-        if parameters:
+        try:
+            parameters = await self.get_run_parameters(flow_id, run_number)
             self.event_emitter.emit(
                 "notify",
                 "UPDATE",
                 [f"/flows/{flow_id}/runs/{run_number}/parameters"],
                 parameters
             )
+        except GetParametersFailed:
+            pass
     
     async def preload_event_handler(self, run_id):
         "Handler for event-emitter for preloading artifacts for a run id"


### PR DESCRIPTION
* Fix to the way result keys are generated from cache actions. Makes a copy of existing_keys, as the cache server expects all keys to be produced that were promised by the response from `format_request` (can not omit existing keys)

* added error handling to run parameters event handler in case the params fetch raises an error (no-op on the websocket broadcast in this case)