### PR TITLE
Prefetch default rules: past 2 days and maximum of 50 runs.

### DIFF
--- a/docker-compose.development.yml
+++ b/docker-compose.development.yml
@@ -23,6 +23,8 @@ services:
       - MF_UI_METADATA_PORT=${MF_UI_METADATA_PORT:-8083}
       - MF_UI_METADATA_HOST=${MF_UI_METADATA_HOST:-0.0.0.0}
       - UI_ENABLED=1
+      - PREFETCH_RUNS_SINCE=3600 # 1 hour in seconds
+      - PREFETCH_RUNS_LIMIT=1 # Prefetch only one run
     depends_on:
       - db
   metadata:

--- a/services/ui_backend_service/README.md
+++ b/services/ui_backend_service/README.md
@@ -49,6 +49,7 @@ Configure amount of seconds realtime events are kept in queue (delivered to UI i
 
 Configure amount of runs to prefetch during server startup (artifact cache):
 
+- `PREFETCH_RUNS_SINCE` [in seconds, defaults to 2 days ago (86400 * 2 seconds)]
 - `PREFETCH_RUNS_LIMIT` [defaults to 50]
 
 Running the service without Docker (from project root):

--- a/services/ui_backend_service/cache/store.py
+++ b/services/ui_backend_service/cache/store.py
@@ -36,6 +36,8 @@ class CacheStore(object):
             await self.dag_cache.stop_cache()
 
 
+# Prefetch runs since 2 days ago (in seconds), limit maximum of 50 runs
+METAFLOW_ARTIFACT_PREFETCH_RUNS_SINCE = os.environ.get('PREFETCH_RUNS_SINCE', 86400 * 2)
 METAFLOW_ARTIFACT_PREFETCH_RUNS_LIMIT = os.environ.get('PREFETCH_RUNS_LIMIT', 50)
 
 
@@ -77,10 +79,9 @@ class ArtifactCacheStore(object):
             print(event, flush=True)
 
     async def get_recent_run_numbers(self):
-        since = int(round(time.time() * 1000)) - 86400_000 * 2  # 2 days ago
         _records, _ = await self._run_table.find_records(
             conditions=["ts_epoch >= %s"],
-            values=[since],
+            values=[int(round(time.time() * 1000)) - (int(METAFLOW_ARTIFACT_PREFETCH_RUNS_SINCE) * 1000)],
             order=['ts_epoch DESC'],
             limit=METAFLOW_ARTIFACT_PREFETCH_RUNS_LIMIT,
             expanded=True


### PR DESCRIPTION
This PR introduces new environment variable `PREFETCH_RUNS_SINCE` how many past seconds is considered when fetching most recent runs.

Current default values:

- `PREFETCH_RUNS_SINCE` in seconds, defaults to 2 days ago (86400 * 2 seconds)
- `PREFETCH_RUNS_LIMIT` defaults to 50

Default values for local development (`docker-compose.development.yml`):
- `PREFETCH_RUNS_SINCE` 3600
- `PREFETCH_RUNS_LIMIT` 1