### PR TITLE
UI: Adjust cache and postprocessing concurrent limits

### DIFF
--- a/docker-compose.development.yml
+++ b/docker-compose.development.yml
@@ -25,6 +25,10 @@ services:
       - UI_ENABLED=1
       - PREFETCH_RUNS_SINCE=3600 # 1 hour in seconds
       - PREFETCH_RUNS_LIMIT=1 # Prefetch only one run
+      - S3_NUM_WORKERS=2
+      - CACHE_ARTIFACT_MAX_ACTIONS=16
+      - CACHE_DAG_MAX_ACTIONS=16
+      - WS_POSTPROCESS_CONCURRENCY_LIMIT=8
     depends_on:
       - db
   metadata:

--- a/services/ui_backend_service/api/ws.py
+++ b/services/ui_backend_service/api/ws.py
@@ -15,6 +15,7 @@ from .data_refiner import TaskRefiner
 from throttler import throttle_simultaneous
 
 WS_QUEUE_TTL_SECONDS = os.environ.get("WS_QUEUE_TTL_SECONDS", 60 * 5)  # 5 minute TTL by default
+WS_POSTPROCESS_CONCURRENCY_LIMIT = int(os.environ.get("WS_POSTPROCESS_CONCURRENCY_LIMIT", 8))
 
 SUBSCRIBE = 'SUBSCRIBE'
 UNSUBSCRIBE = 'UNSUBSCRIBE'

--- a/services/ui_backend_service/cache/s3op.py
+++ b/services/ui_backend_service/cache/s3op.py
@@ -37,7 +37,7 @@ sys.path.insert(0,
 # we use Metaflow's parallel_imap_unordered instead of
 # multiprocessing.Pool because https://bugs.python.org/issue31886
 
-NUM_WORKERS_DEFAULT = 2
+NUM_WORKERS_DEFAULT = int(os.environ.get("S3_NUM_WORKERS", 2))
 
 S3Url = namedtuple('S3Url', ['bucket', 'path', 'url', 'local', 'prefix'])
 

--- a/services/ui_backend_service/cache/s3op.py
+++ b/services/ui_backend_service/cache/s3op.py
@@ -3,6 +3,14 @@
 # adds specific error code for missing S3 credentials.
 # and removes aws_retry decorator usage to fit backend usecase.
 
+from metaflow.datatools.s3op import _populate_prefixes
+from metaflow.datatools.s3op import verify_results, generate_local_path
+from metaflow.datatools.s3op import S3Ops as _S3Ops
+from metaflow.datatools.s3op import with_unit
+from metaflow.datatools.s3op import worker, start_workers, process_urls
+from metaflow.datatools.s3op import format_triplet, normalize_client_error
+from metaflow.multicore_utils import parallel_map
+from metaflow.util import url_quote, url_unquote
 import math
 import string
 import sys
@@ -24,14 +32,12 @@ import click
 
 # s3op can be launched as a stand-alone script. We must set
 # PYTHONPATH for the parent Metaflow explicitly.
-sys.path.insert(0,\
-    os.path.abspath(os.path.join(os.path.dirname(__file__), '../../')))
+sys.path.insert(0,
+                os.path.abspath(os.path.join(os.path.dirname(__file__), '../../')))
 # we use Metaflow's parallel_imap_unordered instead of
 # multiprocessing.Pool because https://bugs.python.org/issue31886
-from metaflow.util import url_quote, url_unquote
-from metaflow.multicore_utils import parallel_map
 
-NUM_WORKERS_DEFAULT = 64
+NUM_WORKERS_DEFAULT = 2
 
 S3Url = namedtuple('S3Url', ['bucket', 'path', 'url', 'local', 'prefix'])
 
@@ -46,15 +52,12 @@ ERROR_VERIFY_FAILED = 9
 ERROR_LOCAL_FILE_NOT_FOUND = 10
 ERROR_MISSING_CREDENTIALS = 11
 
-from metaflow.datatools.s3op import format_triplet, normalize_client_error
 
 # S3 worker pool
-from metaflow.datatools.s3op import worker, start_workers, process_urls
 
 # Utility functions
-from metaflow.datatools.s3op import with_unit
 
-from metaflow.datatools.s3op import S3Ops as _S3Ops
+
 class S3Ops(_S3Ops):
     def get_size(self, url):
         self.reset_client()
@@ -62,7 +65,7 @@ class S3Ops(_S3Ops):
             head = self.s3.head_object(Bucket=url.bucket, Key=url.path)
             return True, url, [(url, head['ContentLength'])]
         except NoCredentialsError as err:
-          return False, url, ERROR_MISSING_CREDENTIALS
+            return False, url, ERROR_MISSING_CREDENTIALS
         except ClientError as err:
             error_code = normalize_client_error(err)
             if error_code == 404:
@@ -106,28 +109,32 @@ class S3Ops(_S3Ops):
         except self.s3.exceptions.NoSuchBucket:
             return False, prefix_url, ERROR_URL_NOT_FOUND
         except NoCredentialsError as err:
-          return False, prefix_url, ERROR_MISSING_CREDENTIALS
+            return False, prefix_url, ERROR_MISSING_CREDENTIALS
         except ClientError as err:
             if err.response['Error']['Code'] == 'AccessDenied':
                 return False, prefix_url, ERROR_URL_ACCESS_DENIED
             else:
                 raise
 
+
 # We want to reuse an s3 client instance over multiple operations.
 # This is accomplished by op_ functions below.
-from metaflow.datatools.s3op import verify_results, generate_local_path
+
 
 def op_get_size(urls):
     s3 = S3Ops()
     return [s3.get_size(url) for url in urls]
 
+
 def op_list_prefix(prefix_urls):
     s3 = S3Ops()
     return [s3.list_prefix(prefix) for prefix in prefix_urls]
 
+
 def op_list_prefix_nonrecursive(prefix_urls):
     s3 = S3Ops()
     return [s3.list_prefix(prefix, delimiter='/') for prefix in prefix_urls]
+
 
 def exit(exit_code, url):
     if exit_code == ERROR_INVALID_URL:
@@ -151,6 +158,7 @@ def exit(exit_code, url):
         msg = 'Unknown error'
     print(msg, file=sys.stderr)
     sys.exit(exit_code)
+
 
 def parallel_op(op, lst, num_workers):
     # parallel op divides work equally amongst num_workers
@@ -181,11 +189,12 @@ def parallel_op(op, lst, num_workers):
             yield x
 
 # CLI
+
+
 @click.group()
 def cli():
     pass
 
-from metaflow.datatools.s3op import _populate_prefixes
 
 @cli.command('list', help='List S3 objects')
 @click.option('--inputs',
@@ -231,6 +240,7 @@ def lst(prefixes,
         else:
             print(format_triplet(url.prefix, url.url, str(size)))
 
+
 @cli.command(help='Download files from S3')
 @click.option('--recursive/--no-recursive',
               default=False,
@@ -250,7 +260,7 @@ def lst(prefixes,
 @click.option('--allow-missing/--no-allow-missing',
               default=False,
               show_default=True,
-              help='Do not exit if missing files are detected. '\
+              help='Do not exit if missing files are detected. '
                    'Implies --verify.')
 @click.option('--verbose/--no-verbose',
               default=True,

--- a/services/ui_backend_service/cache/store.py
+++ b/services/ui_backend_service/cache/store.py
@@ -59,7 +59,7 @@ class ArtifactCacheStore(object):
         self.cache = CacheAsyncClient('cache_data/artifact_search',
                                       actions,
                                       max_size=600000,
-                                      max_actions=32)
+                                      max_actions=16)
         await self.cache.start()
         asyncio.run_coroutine_threadsafe(self.preload_initial_data(), self.loop)
 
@@ -196,7 +196,8 @@ class DAGCacheStore(object):
         actions = [GenerateDag]
         self.cache = CacheAsyncClient('cache_data/dag',
                                       actions,
-                                      max_size=100000)
+                                      max_size=100000,
+                                      max_actions=16)
         await self.cache.start()
 
     async def stop_cache(self):

--- a/services/ui_backend_service/cache/store.py
+++ b/services/ui_backend_service/cache/store.py
@@ -9,6 +9,9 @@ import asyncio
 import time
 import os
 
+CACHE_ARTIFACT_MAX_ACTIONS = int(os.environ.get("CACHE_ARTIFACT_MAX_ACTIONS", 16))
+CACHE_DAG_MAX_ACTIONS = int(os.environ.get("CACHE_DAG_MAX_ACTIONS", 16))
+
 
 class CacheStore(object):
     "Singleton class for all the different cache clients that are used to access caches"
@@ -59,7 +62,7 @@ class ArtifactCacheStore(object):
         self.cache = CacheAsyncClient('cache_data/artifact_search',
                                       actions,
                                       max_size=600000,
-                                      max_actions=16)
+                                      max_actions=CACHE_ARTIFACT_MAX_ACTIONS)
         await self.cache.start()
         asyncio.run_coroutine_threadsafe(self.preload_initial_data(), self.loop)
 
@@ -197,7 +200,7 @@ class DAGCacheStore(object):
         self.cache = CacheAsyncClient('cache_data/dag',
                                       actions,
                                       max_size=100000,
-                                      max_actions=16)
+                                      max_actions=CACHE_DAG_MAX_ACTIONS)
         await self.cache.start()
 
     async def stop_cache(self):

--- a/services/ui_backend_service/requirements.txt
+++ b/services/ui_backend_service/requirements.txt
@@ -3,3 +3,4 @@ aiohttp-swagger==1.0.15
 boto3==1.15.10
 pyee==8.0.1
 yarl==1.5.1
+throttler==1.2.0


### PR DESCRIPTION
Following changes were introduced:

- `cache/s3op.py` - `NUM_WORKERS_DEFAULT = 2`
- `cache/store.py` - `CacheAsyncClient(max_actions=16)` (artifact+dag)
- `api/ws.py` - postprocess concurrency limit to `8`

Following environment variables were introduced:

- `S3_NUM_WORKERS` - defaults to `2`
- `CACHE_ARTIFACT_MAX_ACTIONS` - defaults to `16`
- `CACHE_DAG_MAX_ACTIONS` - defaults to `16`
- `WS_POSTPROCESS_CONCURRENCY_LIMIT` - defaults to `8`

Adds one dependency `throttler==1.2.0` for adjusting postprocess concurrency limit.