### PR TITLE
Enhance logging support and api responses for subprocess traces

### DIFF
--- a/services/ui_backend_service/api/dag.py
+++ b/services/ui_backend_service/api/dag.py
@@ -70,7 +70,7 @@ class DagApi(object):
             async for event in dag.stream():
                 if event["type"] == "error":
                     # raise error, there was an exception during processing.
-                    raise GenerateDAGFailed(event["message"], event["id"])
+                    raise GenerateDAGFailed(event["message"], event["id"], event["traceback"])
             await dag.wait()  # wait until results are ready
         dag = dag.get()
         response = DBResponse(200, dag)
@@ -80,9 +80,10 @@ class DagApi(object):
 
 
 class GenerateDAGFailed(Exception):
-    def __init__(self, msg="Failed to process DAG", id="failed-to-process-dag"):
+    def __init__(self, msg="Failed to process DAG", id="failed-to-process-dag", traceback_str=None):
         self.message = msg
         self.id = id
+        self.traceback_str = traceback_str
 
     def __str__(self):
         return self.message

--- a/services/ui_backend_service/cache/generate_dag_action.py
+++ b/services/ui_backend_service/cache/generate_dag_action.py
@@ -8,6 +8,7 @@ from .custom_flowgraph import FlowGraph  # TODO: change to metaflow.graph when t
 
 from .utils import NoRetryS3
 from .utils import MetaflowS3CredentialsMissing, MetaflowS3AccessDenied, MetaflowS3Exception, MetaflowS3NotFound, MetaflowS3URLException
+from utils import get_traceback_str
 
 
 class GenerateDag(CacheAction):
@@ -72,8 +73,8 @@ class GenerateDag(CacheAction):
 
         result_key = [key for key in keys if key.startswith('dag:result')][0]
 
-        def stream_error(err, id):
-            return stream_output({"type": "error", "message": err, "id": id})
+        def stream_error(err, id, traceback=None):
+            return stream_output({"type": "error", "message": err, "id": id, "traceback": traceback})
 
         # get codepackage from S3
         with NoRetryS3() as s3:
@@ -93,7 +94,7 @@ class GenerateDag(CacheAction):
             except UnsupportedFlowLanguage as ex:
                 stream_error(str(ex), "dag-unsupported-flow-language")
             except Exception as ex:
-                stream_error(str(ex), "dag-processing-error")
+                stream_error(str(ex), "dag-processing-error", get_traceback_str())
 
         return results
 

--- a/services/ui_backend_service/cache/get_artifacts_action.py
+++ b/services/ui_backend_service/cache/get_artifacts_action.py
@@ -4,6 +4,7 @@ from metaflow.client.cache import CacheAction
 from .utils import NoRetryS3
 from .utils import MetaflowS3CredentialsMissing, MetaflowS3AccessDenied, MetaflowS3Exception, MetaflowS3NotFound, MetaflowS3URLException
 from .utils import decode, batchiter
+from utils import get_traceback_str
 import json
 
 MAX_SIZE = 4096
@@ -72,8 +73,8 @@ class GetArtifacts(CacheAction):
         result_key = [key for key in keys if key.startswith('parameters:result')][0]
 
         # Lambdas for streaming status updates.
-        def stream_error(err, id):
-            return stream_output({"type": "error", "message": err, "id": id})
+        def stream_error(err, id, traceback=None):
+            return stream_output({"type": "error", "message": err, "id": id, "traceback": traceback})
 
         # Make a list of artifact locations that require fetching (not cached previously)
         locations_to_fetch = [loc for loc in locations if not artifact_cache_id(loc) in existing_keys]
@@ -94,7 +95,7 @@ class GetArtifacts(CacheAction):
                             except Exception as ex:
                                 # Exceptions might be fixable with configuration changes or other measures,
                                 # therefore we do not want to write anything to the cache for these artifacts.
-                                stream_error(str(ex), "artifact-handle-failed")
+                                stream_error(str(ex), "artifact-handle-failed", get_traceback_str())
                         else:
                             results[artifact_key] = json.dumps([False, 'object is too large'])
                 except MetaflowS3AccessDenied as ex:
@@ -106,7 +107,7 @@ class GetArtifacts(CacheAction):
                 except MetaflowS3CredentialsMissing as ex:
                     stream_error(str(ex), "s3-missing-credentials")
                 except MetaflowS3Exception as ex:
-                    stream_error(str(ex), "s3-generic-error")
+                    stream_error(str(ex), "s3-generic-error", get_traceback_str())
         # Skip the inaccessible locations
         other_locations = [loc for loc in locations_to_fetch if not loc.startswith("s3://")]
         for loc in other_locations:

--- a/services/ui_backend_service/cache/store.py
+++ b/services/ui_backend_service/cache/store.py
@@ -8,6 +8,7 @@ from .get_artifacts_action import GetArtifacts
 import asyncio
 import time
 import os
+import logging
 
 CACHE_ARTIFACT_MAX_ACTIONS = int(os.environ.get("CACHE_ARTIFACT_MAX_ACTIONS", 16))
 CACHE_DAG_MAX_ACTIONS = int(os.environ.get("CACHE_DAG_MAX_ACTIONS", 16))
@@ -79,7 +80,10 @@ class ArtifactCacheStore(object):
 
         res = await self.cache.GetArtifacts(artifact_locations)
         async for event in res.stream():
-            print(event, flush=True)
+            if event["type"] == "error":
+                logging.error(event)
+            else:
+                logging.info(event)
 
     async def get_recent_run_numbers(self):
         _records, _ = await self._run_table.find_records(

--- a/services/ui_backend_service/cache/store.py
+++ b/services/ui_backend_service/cache/store.py
@@ -156,7 +156,7 @@ class ArtifactCacheStore(object):
             async for event in _params.stream():
                 if event["type"] == "error":
                     # raise error, there was an exception during processing.
-                    raise GetParametersFailed(event["message"], event["id"])
+                    raise GetParametersFailed(event["message"], event["id"], event["traceback"])
             await _params.wait()  # wait until results are ready
         _params = _params.get()
 
@@ -208,9 +208,10 @@ class DAGCacheStore(object):
 
 
 class GetParametersFailed(Exception):
-    def __init__(self, msg="Failed to Get Parameters", id="failed-to-get-parameters"):
+    def __init__(self, msg="Failed to Get Parameters", id="failed-to-get-parameters", traceback_str=None):
         self.message = msg
         self.id = id
+        self.traceback_str = traceback_str
 
     def __str__(self):
         return self.message

--- a/services/ui_backend_service/ui_server.py
+++ b/services/ui_backend_service/ui_server.py
@@ -1,6 +1,5 @@
 import asyncio
 import os
-import logging
 import signal
 
 from aiohttp import web
@@ -26,7 +25,7 @@ from .cache.store import CacheStore
 from .frontend import Frontend
 
 from services.data.postgres_async_db import AsyncPostgresDB
-from services.utils import DBConfiguration
+from services.utils import DBConfiguration, logging
 
 from pyee import AsyncIOEventEmitter, ExecutorEventEmitter
 

--- a/services/ui_backend_service/ui_server.py
+++ b/services/ui_backend_service/ui_server.py
@@ -104,5 +104,6 @@ def async_loop_error_handler(loop, context):
 def async_loop_signal_handler(signal):
     logging.info("Received signal: {}".format(signal))
 
+
 if __name__ == "__main__":
     main()

--- a/services/ui_backend_service/ui_server.py
+++ b/services/ui_backend_service/ui_server.py
@@ -78,7 +78,7 @@ def main():
     loop = asyncio.get_event_loop()
     # Set exception and signal handlers for async loop. Mainly for logging purposes.
     loop.set_exception_handler(async_loop_error_handler)
-    for sig in {signal.SIGTERM, signal.SIGHUP, signal.SIGINT}:
+    for sig in (signal.SIGTERM, signal.SIGHUP, signal.SIGINT):
         loop.add_signal_handler(sig, lambda sig=sig: async_loop_signal_handler(sig))
 
     the_app = app(loop, DBConfiguration())

--- a/services/utils/__init__.py
+++ b/services/utils/__init__.py
@@ -68,7 +68,7 @@ def handle_exceptions(func):
             # pass along an id for the error
             err_id = getattr(err, 'id', 'generic-error')
             # either use provided traceback from subprocess, or generate trace from current process
-            err_trace = getattr(err, 'traceback_str', get_traceback_str())
+            err_trace = getattr(err, 'traceback_str', None) or get_traceback_str()
             logging.error(err_trace)
             return http_500(str(err), err_id, err_trace)
 

--- a/services/utils/__init__.py
+++ b/services/utils/__init__.py
@@ -9,6 +9,7 @@ from multidict import MultiDict
 from aiohttp import web
 from functools import wraps
 from typing import Dict
+import logging
 
 version = pkg_resources.require("metadata_service")[0].version
 
@@ -42,11 +43,11 @@ def get_traceback_str():
     )
 
 
-def http_500(msg, id):
+def http_500(msg, id, traceback_str=get_traceback_str()):
     # NOTE: worth considering if we want to expose tracebacks in the future in the api messages.
     body = {
         'id': id,
-        'traceback': get_traceback_str(),
+        'traceback': traceback_str,
         'detail': msg,
         'status': 500,
         'title': 'Internal Server Error',
@@ -64,8 +65,12 @@ def handle_exceptions(func):
         try:
             return await func(*args, **kwargs)
         except Exception as err:
-            err_id = getattr(err, 'id', 'generic-error')  # pass along an id for the error
-            return http_500(str(err), err_id)
+            # pass along an id for the error
+            err_id = getattr(err, 'id', 'generic-error')
+            # either use provided traceback from subprocess, or generate trace from current process
+            err_trace = getattr(err, 'traceback_str', get_traceback_str())
+            logging.error(err_trace)
+            return http_500(str(err), err_id, err_trace)
 
     return wrapper
 

--- a/services/utils/__init__.py
+++ b/services/utils/__init__.py
@@ -16,6 +16,9 @@ version = pkg_resources.require("metadata_service")[0].version
 METADATA_SERVICE_VERSION = version
 METADATA_SERVICE_HEADER = 'METADATA_SERVICE_VERSION'
 
+# Setup log level based on environment variable
+log_level = os.environ.get('LOGLEVEL', 'INFO').upper()
+logging.basicConfig(level=log_level)
 
 async def read_body(request_content):
     byte_array = bytearray()

--- a/services/utils/__init__.py
+++ b/services/utils/__init__.py
@@ -20,6 +20,7 @@ METADATA_SERVICE_HEADER = 'METADATA_SERVICE_VERSION'
 log_level = os.environ.get('LOGLEVEL', 'INFO').upper()
 logging.basicConfig(level=log_level)
 
+
 async def read_body(request_content):
     byte_array = bytearray()
     while not request_content.at_eof():


### PR DESCRIPTION
* passes traces on exceptions from the cache action subprocesses to api responses correctly.
* adds signal and exception handlers for main event loop for logging purposes.
* adds logging to common exception catches, including error 500 responses from api.

Log level can be controlled by the `LOGLEVEL` environment variable. Defaults to a very verbose `INFO` level.