### PR TITLE
Revert earlier event emitter changes back to AsyncIOEventEmitter

### DIFF
--- a/services/ui_backend_service/api/heartbeat_monitor.py
+++ b/services/ui_backend_service/api/heartbeat_monitor.py
@@ -1,7 +1,7 @@
 import asyncio
 import datetime
 from typing import Dict
-from pyee import ExecutorEventEmitter
+from pyee import AsyncIOEventEmitter
 from services.data.postgres_async_db import AsyncPostgresDB
 from services.data.db_utils import translate_run_key, translate_task_key
 from .notify import resource_list
@@ -14,18 +14,12 @@ class HeartbeatMonitor(object):
     def __init__(self, event_name, event_emitter=None):
         self.watched = {}
         # Handle HB Events
-        self.event_emitter = event_emitter or ExecutorEventEmitter()
-        event_emitter.on(event_name, self._heartbeat_handler)
+        self.event_emitter = event_emitter or AsyncIOEventEmitter()
+        event_emitter.on(event_name, self.heartbeat_handler)
 
         # Start heartbeat watcher
         self.loop = asyncio.get_event_loop()
         self.loop.create_task(self.check_heartbeats())
-
-    def _heartbeat_handler(self, *args, **kwargs):
-        """Wrapper to run coroutine event handler code threadsafe in a loop,
-        as the ExecutorEventEmitter does not accept coroutines as handlers.
-        """
-        asyncio.run_coroutine_threadsafe(self.heartbeat_handler(*args, **kwargs), self.loop)
 
     async def heartbeat_handler(self):
         "handle the event_emitter events"

--- a/services/ui_backend_service/api/notify.py
+++ b/services/ui_backend_service/api/notify.py
@@ -2,13 +2,13 @@ import json
 import asyncio
 from typing import Dict, List
 from services.data.postgres_async_db import AsyncPostgresDB
-from pyee import ExecutorEventEmitter
+from pyee import AsyncIOEventEmitter
 
 
 class ListenNotify(object):
     def __init__(self, app, event_emitter=None):
         self.app = app
-        self.event_emitter = event_emitter or ExecutorEventEmitter()
+        self.event_emitter = event_emitter or AsyncIOEventEmitter()
         self.db = AsyncPostgresDB.get_instance()
 
         self.loop = asyncio.get_event_loop()

--- a/services/ui_backend_service/tests/integration_tests/notify_test.py
+++ b/services/ui_backend_service/tests/integration_tests/notify_test.py
@@ -36,7 +36,7 @@ async def db(cli):
 def _set_notify_handler(cli, loop):
     should_call = Future(loop=loop)
 
-    def event_handler(operation: str, resources: List[str], result: Dict, table, filter_dict):
+    async def event_handler(operation: str, resources: List[str], result: Dict, table, filter_dict):
         should_call.set_result([operation, resources, result])
     cli.server.app.event_emitter.once('notify', event_handler)
 
@@ -142,7 +142,7 @@ async def test_pg_notify_trigger_updates_on_task(cli, db, loop):
     # Add artifact (Task will be done)
     _should_call_task_done = Future(loop=loop)
 
-    def _event_handler_task_done(operation: str, resources: List[str], result: Dict, table, filter_dict):
+    async def _event_handler_task_done(operation: str, resources: List[str], result: Dict, table, filter_dict):
         if not _should_call_task_done.done():
             _should_call_task_done.set_result([operation, resources, result])
     cli.server.app.event_emitter.on('notify', _event_handler_task_done)
@@ -168,7 +168,7 @@ async def test_pg_notify_trigger_updates_on_task(cli, db, loop):
     _should_call_task_done = Future(loop=loop)
     _should_call_run_done = Future(loop=loop)
 
-    def _event_handler_task_done(operation: str, resources: List[str], result: Dict, table, filter_dict):
+    async def _event_handler_task_done(operation: str, resources: List[str], result: Dict, table, filter_dict):
         if operation == "UPDATE":
             if "/runs" in resources:
                 _should_call_run_done.set_result(
@@ -240,7 +240,7 @@ async def test_pg_notify_trigger_updates_on_attempt_id(cli, db, loop):
 
     _should_call_task_done = Future(loop=loop)
 
-    def _event_handler_task_done(operation: str, resources: List[str], result: Dict, table, filter_dict):
+    async def _event_handler_task_done(operation: str, resources: List[str], result: Dict, table, filter_dict):
         if not _should_call_task_done.done():
             _should_call_task_done.set_result([operation, resources, result])
     cli.server.app.event_emitter.on('notify', _event_handler_task_done)
@@ -265,7 +265,7 @@ async def test_pg_notify_trigger_updates_on_attempt_id(cli, db, loop):
     # Add artifact with attempt_id = 1 (Task will be done)
     _should_call_task_done = Future(loop=loop)
 
-    def _event_handler_task_done(operation: str, resources: List[str], result: Dict, table, filter_dict):
+    async def _event_handler_task_done(operation: str, resources: List[str], result: Dict, table, filter_dict):
         if not _should_call_task_done.done():
             _should_call_task_done.set_result([operation, resources, result])
     cli.server.app.event_emitter.on('notify', _event_handler_task_done)

--- a/services/ui_backend_service/tests/integration_tests/utils.py
+++ b/services/ui_backend_service/tests/integration_tests/utils.py
@@ -1,5 +1,5 @@
 from aiohttp import web
-from pyee import ExecutorEventEmitter
+from pyee import AsyncIOEventEmitter
 import json
 import datetime
 
@@ -33,7 +33,7 @@ TIMEOUT_FUTURE = 0.1
 
 def init_app(loop, aiohttp_client, queue_ttl=30):
     app = web.Application()
-    app.event_emitter = ExecutorEventEmitter()
+    app.event_emitter = AsyncIOEventEmitter()
 
     # Migration routes as a subapp
     migration_app = web.Application()

--- a/services/ui_backend_service/ui_server.py
+++ b/services/ui_backend_service/ui_server.py
@@ -27,7 +27,7 @@ from .frontend import Frontend
 from services.data.postgres_async_db import AsyncPostgresDB
 from services.utils import DBConfiguration, logging
 
-from pyee import AsyncIOEventEmitter, ExecutorEventEmitter
+from pyee import AsyncIOEventEmitter
 
 from .doc import swagger_definitions, swagger_description
 
@@ -39,7 +39,7 @@ def app(loop=None, db_conf: DBConfiguration = None):
     async_db = AsyncPostgresDB()
     loop.run_until_complete(async_db._init(db_conf))
 
-    event_emitter = ExecutorEventEmitter()
+    event_emitter = AsyncIOEventEmitter()
     cache_store = CacheStore(event_emitter=event_emitter)
     app.on_startup.append(cache_store.start_caches)
     app.on_cleanup.append(cache_store.stop_caches)


### PR DESCRIPTION
* Revert event emitter back to AsyncIOEventEmitter due to better performance, and this not being the root cause in the end for deadlocks.