### PR TITLE
Add ui backend git commit hash and build date

### DIFF
--- a/Dockerfile.ui_service
+++ b/Dockerfile.ui_service
@@ -6,6 +6,12 @@ ARG UI_VERSION="v0.1.2"
 ENV UI_ENABLED=$UI_ENABLED
 ENV UI_VERSION=$UI_VERSION
 
+ARG BUILD_TIMESTAMP
+ARG BUILD_COMMIT_HASH
+
+ENV BUILD_TIMESTAMP=$BUILD_TIMESTAMP
+ENV BUILD_COMMIT_HASH=$BUILD_COMMIT_HASH
+
 ADD services/__init__.py /root/services/__init__.py
 ADD services/data /root/services/data
 ADD services/utils /root/services/utils

--- a/services/ui_backend_service/api/admin.py
+++ b/services/ui_backend_service/api/admin.py
@@ -10,6 +10,7 @@ UI_SERVICE_VERSION = "{metadata_v}-{timestamp}-{commit}".format(
     commit=SERVICE_COMMIT_HASH or ""
 )
 
+
 class AdminApi(object):
     def __init__(self, app):
         app.router.add_route("GET", "/ping", self.ping)

--- a/services/ui_backend_service/api/admin.py
+++ b/services/ui_backend_service/api/admin.py
@@ -2,8 +2,13 @@ from aiohttp import web
 import json
 import os
 from multidict import MultiDict
-from services.utils import METADATA_SERVICE_VERSION, METADATA_SERVICE_HEADER
+from services.utils import METADATA_SERVICE_VERSION, METADATA_SERVICE_HEADER, SERVICE_COMMIT_HASH, SERVICE_BUILD_TIMESTAMP
 
+UI_SERVICE_VERSION = "{metadata_v}-{timestamp}-{commit}".format(
+    metadata_v=METADATA_SERVICE_VERSION,
+    timestamp=SERVICE_BUILD_TIMESTAMP or "",
+    commit=SERVICE_COMMIT_HASH or ""
+)
 
 class AdminApi(object):
     def __init__(self, app):
@@ -25,7 +30,7 @@ class AdminApi(object):
             "405":
                 description: invalid HTTP Method
         """
-        return web.Response(text=str(METADATA_SERVICE_VERSION))
+        return web.Response(text=str(UI_SERVICE_VERSION))
 
     async def ping(self, request):
         """

--- a/services/utils/__init__.py
+++ b/services/utils/__init__.py
@@ -16,6 +16,11 @@ version = pkg_resources.require("metadata_service")[0].version
 METADATA_SERVICE_VERSION = version
 METADATA_SERVICE_HEADER = 'METADATA_SERVICE_VERSION'
 
+# The latest commit hash of the repository, if set as an environment variable.
+SERVICE_COMMIT_HASH = os.environ.get("BUILD_COMMIT_HASH", None)
+# Build time of service, if set as an environment variable.
+SERVICE_BUILD_TIMESTAMP = os.environ.get("BUILD_TIMESTAMP", None)
+
 # Setup log level based on environment variable
 log_level = os.environ.get('LOGLEVEL', 'INFO').upper()
 logging.basicConfig(level=log_level)


### PR DESCRIPTION
* Adds build args to ui_service dockerfile and exposes them as env variables BUILD_COMMIT_HASH and BUILD_TIMESTAMP
* exposes the aforementioned values as part of the ui_service `/version` api response.