### PR TITLE
Fix to possibly blocking heartbeat monitor check loop

### DIFF
--- a/services/ui_backend_service/api/heartbeat_monitor.py
+++ b/services/ui_backend_service/api/heartbeat_monitor.py
@@ -49,7 +49,7 @@ class HeartbeatMonitor(object):
             time_now = int(datetime.datetime.utcnow().timestamp())  # same format as the metadata heartbeat uses
             for key, hb in list(self.watched.items()):
                 if time_now - hb > HEARTBEAT_INTERVAL * 2:
-                    await self.load_and_broadcast(key)
+                    self.loop.create_task(self.load_and_broadcast(key))
                     self.remove_from_watch(key)
 
             await asyncio.sleep(HEARTBEAT_INTERVAL)


### PR DESCRIPTION
* Opting to spawn tasks instead of awaiting inside the heartbeat check iteration to make sure the loop is not blocked by slow broadcasts.