### PR TITLE
UI performance optimization

### DIFF
--- a/services/ui_backend_service/api/notify.py
+++ b/services/ui_backend_service/api/notify.py
@@ -23,7 +23,7 @@ class ListenNotify(object):
             await cur.execute("LISTEN notify")
             while True:
                 msg = await conn.notifies.get()
-                await self.handle_trigger_msg(msg)
+                self.loop.create_task(self.handle_trigger_msg(msg))
 
     async def handle_trigger_msg(self, msg: str):
         try:
@@ -122,4 +122,4 @@ def resource_list(table_name: str, data: Dict):
 
 async def _broadcast(event_emitter, operation: str, table, data: Dict, filter_dict={}):
     _resources = resource_list(table.table_name, data)
-    event_emitter.emit('notify', operation, _resources, data, table, filter_dict)
+    event_emitter.emit('notify', operation, _resources, data, table.table_name, filter_dict)


### PR DESCRIPTION
- Remove postprocessing when adding task to heartbeat monitor
- notify.py process queue with `create_task` instead of `await`
- notify.py: don't pass table instance (with connection pool) to ws, instead use table_name and use ws connection pool