### PR TITLE
Fix pg_notify listener terminated unexpectedly

### DIFF
--- a/services/ui_backend_service/api/notify.py
+++ b/services/ui_backend_service/api/notify.py
@@ -24,8 +24,13 @@ class ListenNotify(object):
         async with conn.cursor() as cur:
             await cur.execute("LISTEN notify")
             while True:
-                msg = await conn.notifies.get()
-                self.loop.create_task(self.handle_trigger_msg(msg))
+                try:
+                    msg = conn.notifies.get_nowait()
+                    self.loop.create_task(self.handle_trigger_msg(msg))
+                except asyncio.QueueEmpty as e:
+                    await asyncio.sleep(0.1)
+                except Exception as e:
+                    logging.exception(e)
 
     async def handle_trigger_msg(self, msg: str):
         try:


### PR DESCRIPTION
`pg_notify` task is sometimes terminated unexpectedly for unknown reason by the event loop. This sometimes happened instantly after server start, sometimes took several days to occure.

It seems that asyncio Queue `get_nowait()` fixes the issue, however I'm not completely sure why.

`get()` - https://github.com/python/cpython/blob/master/Lib/asyncio/queues.py#L150
`get_nowait()` - https://github.com/python/cpython/blob/master/Lib/asyncio/queues.py#L176