### PR TITLE
Integration test fixes

### DIFF
--- a/services/ui_backend_service/api/admin.py
+++ b/services/ui_backend_service/api/admin.py
@@ -2,7 +2,7 @@ from aiohttp import web
 import json
 import os
 from multidict import MultiDict
-from services.utils import METADATA_SERVICE_VERSION, METADATA_SERVICE_HEADER, SERVICE_COMMIT_HASH, SERVICE_BUILD_TIMESTAMP
+from services.utils import web_response, METADATA_SERVICE_VERSION, METADATA_SERVICE_HEADER, SERVICE_COMMIT_HASH, SERVICE_BUILD_TIMESTAMP
 
 UI_SERVICE_VERSION = "{metadata_v}-{timestamp}-{commit}".format(
     metadata_v=METADATA_SERVICE_VERSION,
@@ -16,6 +16,13 @@ class AdminApi(object):
         app.router.add_route("GET", "/ping", self.ping)
         app.router.add_route("GET", "/version", self.version)
         app.router.add_route("GET", "/links", self.links)
+
+        defaults = [
+            {"href": 'https://docs.metaflow.org/', "label": 'Metaflow documentation'},
+            {"href": 'https://github.com/Netflix/metaflow', "label": 'Github'}
+        ]
+
+        self.navigation_links = _load_links_file() or defaults
 
     async def version(self, request):
         """
@@ -66,14 +73,8 @@ class AdminApi(object):
             "405":
                 description: invalid HTTP Method
         """
-        defaults = [
-            {"href": 'https://docs.metaflow.org/', "label": 'Metaflow documentation'},
-            {"href": 'https://github.com/Netflix/metaflow', "label": 'Github'}
-        ]
-        custom_links = _load_links_file()
 
-        links = custom_links if custom_links else defaults
-        return web.Response(status=200, body=json.dumps(links))
+        return web_response(status=200, body=self.navigation_links)
 
 
 def _load_links_file():

--- a/services/ui_backend_service/tests/integration_tests/__init__.py
+++ b/services/ui_backend_service/tests/integration_tests/__init__.py
@@ -1,0 +1,4 @@
+import pytest
+
+# we need to register the utils helper for assert rewriting in order to get descriptive assertion errors.
+pytest.register_assert_rewrite("services.ui_backend_service.tests.integration_tests.utils")

--- a/services/ui_backend_service/tests/integration_tests/admin_test.py
+++ b/services/ui_backend_service/tests/integration_tests/admin_test.py
@@ -1,8 +1,6 @@
 import pytest
 from .utils import (
-    init_app, init_db, clean_db,
-    add_flow,
-    _test_list_resources, _test_single_resource
+    init_app, init_db, clean_db
 )
 pytestmark = [pytest.mark.integration_tests]
 
@@ -29,3 +27,24 @@ async def test_ping(cli, db):
 
     assert resp.status == 200
     assert body == "pong"
+
+
+async def test_version(cli, db):
+    resp = await cli.get("/version")
+    body = await resp.text()
+
+    assert resp.status == 200
+    assert "2.0.4" in body
+
+
+async def test_links(cli, db):
+    default_links = [
+        {"href": 'https://docs.metaflow.org/', "label": 'Metaflow documentation'},
+        {"href": 'https://github.com/Netflix/metaflow', "label": 'Github'}
+    ]
+
+    resp = await cli.get("/links")
+    body = await resp.json()
+
+    assert resp.status == 200
+    assert body == default_links

--- a/services/ui_backend_service/tests/integration_tests/utils.py
+++ b/services/ui_backend_service/tests/integration_tests/utils.py
@@ -216,7 +216,6 @@ async def _test_single_resource(cli, db: AsyncPostgresDB, path: str, expected_st
     assert data == expected_data
 
 
-
 def get_heartbeat_ts(offset=5):
     "Return a heartbeat timestamp with the given offset in seconds. Default offset is 5 seconds"
     return int(datetime.datetime.utcnow().timestamp()) + offset

--- a/services/ui_backend_service/tests/integration_tests/utils.py
+++ b/services/ui_backend_service/tests/integration_tests/utils.py
@@ -203,18 +203,8 @@ async def _test_list_resources(cli, db: AsyncPostgresDB, path: str, expected_sta
     body = await resp.json()
     data = body.get("data")
 
-    try:
-        assert resp.status == expected_status
-    except AssertionError as ex:
-        print("expected status: {0} but got status: {1}".format(resp.status, expected_status))
-        raise ex from None
-
-    try:
-        assert data == expected_data
-    except AssertionError as ex:
-        print("Expected data to be:\n", expected_data)
-        print("Instead got data:\n", data)
-        raise ex from None
+    assert resp.status == expected_status
+    assert data == expected_data
 
 
 async def _test_single_resource(cli, db: AsyncPostgresDB, path: str, expected_status=200, expected_data={}):
@@ -222,18 +212,9 @@ async def _test_single_resource(cli, db: AsyncPostgresDB, path: str, expected_st
     body = await resp.json()
     data = body.get("data")
 
-    try:
-        assert resp.status == expected_status
-    except AssertionError as ex:
-        print("expected status: {0} but got status: {1}".format(resp.status, expected_status))
-        raise ex from None
+    assert resp.status == expected_status
+    assert data == expected_data
 
-    try:
-        assert data == expected_data
-    except AssertionError as ex:
-        print("Expected data to be:\n", expected_data)
-        print("Instead got data:\n", data)
-        raise ex from None
 
 
 def get_heartbeat_ts(offset=5):


### PR DESCRIPTION
* configure assertion helpers for resources correctly.
* fix version test for admin route
* add test for default admin links. Assert response content type for admin links route
* set admin links once during server init, instead of reading file on every request