### PR TITLE
Run: real_user column for non-users

### DIFF
--- a/services/data/models.py
+++ b/services/data/models.py
@@ -31,6 +31,7 @@ class RunRow(object):
     run_number: int = None
     run_id: str = None
     user_name: str = None
+    real_user: str = None
     status: str = None
     ts_epoch: int = 0
     finished_at: int = None
@@ -40,6 +41,7 @@ class RunRow(object):
         self,
         flow_id,
         user_name,
+        real_user,
         run_number=None,
         run_id=None,
         status=None,
@@ -53,6 +55,7 @@ class RunRow(object):
     ):
         self.flow_id = flow_id
         self.user_name = user_name
+        self.real_user = real_user
         self.run_number = run_number
         self.run_id = run_id
         self.status = status
@@ -74,6 +77,7 @@ class RunRow(object):
                 "run_number": self.run_number,
                 "run_id": self.run_id,
                 "user_name": self.user_name,
+                "real_user": self.real_user,
                 "status": self.status,
                 "ts_epoch": self.ts_epoch,
                 "finished_at": self.finished_at,

--- a/services/data/models.py
+++ b/services/data/models.py
@@ -41,7 +41,7 @@ class RunRow(object):
         self,
         flow_id,
         user_name,
-        real_user,
+        real_user=None,
         run_number=None,
         run_id=None,
         status=None,

--- a/services/ui_backend_service/README.md
+++ b/services/ui_backend_service/README.md
@@ -101,6 +101,7 @@ This affects API responses where meta links are provided as a response.
 /runs?_group=user_name&_limit=2                             Group by `user_name` and limit each group to `2` runs
 /runs?_group=flow_id&_order=flow_id,run_number              Group by `flow_id` and order by `flow_id & run_number`
 /runs?_group=flow_id&user_name=dipper                       List runs by `dipper` and group by `flow_id`
+/runs?real_user=null                                        `real_user` is NULL
 
 /flows/HelloFlow/runs?run_number=40                         `run_number` equals `40`
 /flows/HelloFlow/runs?run_number:eq=40                      `run_number` equals `40`
@@ -131,6 +132,7 @@ ge = greater than ewquals   >=
 co = contains               *string*
 sw = starts with            ^string*
 ew = ends with              *string$
+is = is                     IS
 ```
 
 ## Custom Navigation links for UI

--- a/services/ui_backend_service/api/run.py
+++ b/services/ui_backend_service/api/run.py
@@ -98,9 +98,9 @@ class RunApi(object):
                                   self._async_table,
                                   initial_conditions=[],
                                   initial_values=[],
-                                  allowed_order=self._async_table.keys + ["finished_at", "duration", "status"],
-                                  allowed_group=self._async_table.keys,
-                                  allowed_filters=self._async_table.keys + ["finished_at", "duration", "status"],
+                                  allowed_order=self._async_table.keys + ["real_user", "finished_at", "duration", "status"],
+                                  allowed_group=self._async_table.keys + ["real_user"],
+                                  allowed_filters=self._async_table.keys + ["real_user", "finished_at", "duration", "status"],
                                   enable_joins=True
                                   )
 
@@ -143,9 +143,9 @@ class RunApi(object):
                                   self._async_table,
                                   initial_conditions=["flow_id = %s"],
                                   initial_values=[flow_name],
-                                  allowed_order=self._async_table.keys + ["finished_at", "duration", "status"],
-                                  allowed_group=self._async_table.keys,
-                                  allowed_filters=self._async_table.keys + ["finished_at", "duration", "status"],
+                                  allowed_order=self._async_table.keys + ["real_user", "finished_at", "duration", "status"],
+                                  allowed_group=self._async_table.keys + ["real_user"],
+                                  allowed_filters=self._async_table.keys + ["real_user", "finished_at", "duration", "status"],
                                   enable_joins=True
                                   )
 

--- a/services/ui_backend_service/api/utils.py
+++ b/services/ui_backend_service/api/utils.py
@@ -183,6 +183,7 @@ operators_to_sql = {
     "co": "{} ILIKE %s",      # contains
     "sw": "{} ILIKE %s",      # starts with
     "ew": "{} ILIKE %s",      # ends with
+    "is": "{} IS %s",         # IS
 }
 
 operators_to_sql_values = {
@@ -195,6 +196,7 @@ operators_to_sql_values = {
     "co": "%{}%",
     "sw": "{}%",
     "ew": "%{}",
+    "is": "{}",
 }
 
 
@@ -229,11 +231,11 @@ def custom_conditions_query_dict(query: MultiDict, allowed_keys: List[str] = [])
 
         conditions.append(
             "({})".format(" OR ".join(
-                map(lambda _: operators_to_sql[operator].format(field), vals)
+                map(lambda v: operators_to_sql["is" if v == "null" else operator].format(field), vals)
             ))
         )
         values += map(
-            lambda v: operators_to_sql_values[operator].format(v), vals)
+            lambda v: None if v == "null" else operators_to_sql_values[operator].format(v), vals)
 
     return conditions, values
 

--- a/services/ui_backend_service/tests/integration_tests/runs_test.py
+++ b/services/ui_backend_service/tests/integration_tests/runs_test.py
@@ -32,6 +32,7 @@ async def test_list_runs(cli, db):
 
     _run = (await add_run(db, flow_id=_flow.get("flow_id"))).body
     _run["status"] = "running"
+    _run["real_user"] = None
 
     await _test_list_resources(cli, db, "/runs", 200, [_run])
     await _test_list_resources(cli, db, "/flows/{flow_id}/runs".format(**_flow), 200, [_run])
@@ -65,6 +66,7 @@ async def test_single_run(cli, db):
     _flow = (await add_flow(db, flow_id="HelloFlow")).body
     _run = (await add_run(db, flow_id=_flow.get("flow_id"))).body
     _run["status"] = "running"
+    _run["real_user"] = None
 
     await _test_single_resource(cli, db, "/flows/{flow_id}/runs/{run_number}".format(**_run), 200, _run)
 
@@ -90,6 +92,7 @@ async def test_run_status_with_heartbeat(cli, db):
     # A run with no end task and an expired heartbeat should count as failed.
     _run_failed = (await add_run(db, flow_id=_flow.get("flow_id"), last_heartbeat_ts=1)).body
     _run_failed["status"] = "failed"
+    _run_failed["real_user"] = None
     _run_failed["last_heartbeat_ts"] = 1
     # NOTE: heartbeat_ts and ts_epoch have different units.
     _run_failed["duration"] = _run_failed["last_heartbeat_ts"] * 1000 - _run_failed["ts_epoch"]
@@ -101,6 +104,7 @@ async def test_run_status_with_heartbeat(cli, db):
     _beat = get_heartbeat_ts()
     _run_running = (await add_run(db, flow_id=_flow.get("flow_id"), last_heartbeat_ts=_beat)).body
     _run_running["status"] = "running"
+    _run_running["real_user"] = None
     _run_running["last_heartbeat_ts"] = _beat
     # NOTE: heartbeat_ts and ts_epoch have different units.
     _run_running["duration"] = _run_running["last_heartbeat_ts"] * 1000 - _run_running["ts_epoch"]
@@ -128,6 +132,7 @@ async def test_run_status_with_heartbeat(cli, db):
         })).body
 
     _run_complete["status"] = "completed"
+    _run_complete["real_user"] = None
     _run_complete["finished_at"] = _artifact["ts_epoch"]
     _run_complete["duration"] = _run_complete["finished_at"] - _run_complete["ts_epoch"]
 
@@ -142,6 +147,7 @@ async def test_old_run_status_without_heartbeat(cli, db):
     # A run with epoch and no end step _task_ok should count as running.
     _run_running = (await add_run(db, flow_id=_flow.get("flow_id"))).body
     _run_running["status"] = "running"
+    _run_running["real_user"] = None
 
     await _test_single_resource(cli, db, "/flows/{flow_id}/runs/{run_number}".format(**_run_running), 200, _run_running)
 
@@ -165,6 +171,7 @@ async def test_old_run_status_without_heartbeat(cli, db):
         })).body
 
     _run_complete["status"] = "completed"
+    _run_complete["real_user"] = None
     _run_complete["finished_at"] = _artifact["ts_epoch"]
     _run_complete["duration"] = _run_complete["finished_at"] - _run_complete["ts_epoch"]
 
@@ -187,6 +194,7 @@ async def test_old_run_status_without_heartbeat(cli, db):
     # finished at should be the start time + cutoff period
     _run_failed["finished_at"] = _run_failed["ts_epoch"] + (60 * 60 * 24 * 14 * 1000)
     _run_failed["status"] = "failed"
+    _run_failed["real_user"] = None
 
     await _test_single_resource(cli, db, "/flows/{flow_id}/runs/{run_number}".format(**_run_failed), 200, _run_failed)
 
@@ -232,6 +240,7 @@ async def test_single_run_attempt_ok_completed(cli, db):
 
     # We are expecting run status 'completed'
     _run["status"] = "completed"
+    _run["real_user"] = None
     _run["finished_at"] = _artifact["ts_epoch"]
     _run["duration"] = _run["finished_at"] - _run["ts_epoch"]
 
@@ -279,6 +288,7 @@ async def test_single_run_attempt_ok_failed(cli, db):
 
     # We are expecting run status 'completed'
     _run["status"] = "failed"
+    _run["real_user"] = None
     _run["finished_at"] = _artifact["ts_epoch"]
     _run["duration"] = _run["finished_at"] - _run["ts_epoch"]
 


### PR DESCRIPTION
Introduce `real_user` column for runs that displays user's name or `NULL` in case of non-users (user -tag missing).

Non-users will be ordered last while grouping.