### PR TITLE
Fix: Runs list duplicate in case of end step is retried

### DIFF
--- a/services/data/postgres_async_db.py
+++ b/services/data/postgres_async_db.py
@@ -603,7 +603,16 @@ class AsyncRunTablePostgres(AsyncPostgresTable):
                 attempt_ok.field_name = 'attempt_ok' AND
                 attempt_ok.tags ? CONCAT('attempt_id:', artifacts.attempt_id)
             )
-            WHERE artifacts.name = '_task_ok' AND artifacts.step_name = 'end'
+            WHERE
+                artifacts.name = '_task_ok' AND
+                artifacts.step_name = 'end' AND
+                artifacts.attempt_id = (
+                    SELECT MAX(attempt_id) FROM {artifact_table} WHERE
+                        flow_id = artifacts.flow_id AND
+                        run_number = artifacts.run_number AND
+                        task_id = artifacts.task_id AND
+                        step_name = artifacts.step_name
+                )
         ) AS artifacts ON (
             {table_name}.flow_id = artifacts.flow_id AND
             {table_name}.run_number = artifacts.run_number

--- a/services/ui_backend_service/tests/integration_tests/runs_test.py
+++ b/services/ui_backend_service/tests/integration_tests/runs_test.py
@@ -320,3 +320,71 @@ async def test_single_run_attempt_ok_failed(cli, db):
     _run["duration"] = _run["finished_at"] - _run["ts_epoch"]
 
     await _test_single_resource(cli, db, "/flows/{flow_id}/runs/{run_number}".format(**_run), 200, _run)
+
+
+async def test_single_run_attempt_ok_end_retry(cli, db):
+    _flow = (await add_flow(db, flow_id="HelloFlow")).body
+    _run = (await add_run(db, flow_id=_flow.get("flow_id"))).body
+    _step = (await add_step(db, flow_id=_run.get("flow_id"), step_name="end", run_number=_run.get("run_number"), run_id=_run.get("run_id"))).body
+    _task = (await add_task(db,
+                            flow_id=_step.get("flow_id"),
+                            step_name=_step.get("step_name"),
+                            run_number=_step.get("run_number"),
+                            run_id=_step.get("run_id"))).body
+
+    _artifact_attempt_0 = (await add_artifact(
+        db,
+        flow_id=_task.get("flow_id"),
+        run_number=_task.get("run_number"),
+        step_name="end",
+        task_id=_task.get("task_id"),
+        artifact={
+            "name": "_task_ok",
+            "location": "location",
+            "ds_type": "ds_type",
+            "sha": "sha",
+            "type": "type",
+            "content_type": "content_type",
+            "attempt_id": 0
+        })).body
+
+    _artifact_attempt_1 = (await add_artifact(
+        db,
+        flow_id=_task.get("flow_id"),
+        run_number=_task.get("run_number"),
+        step_name="end",
+        task_id=_task.get("task_id"),
+        artifact={
+            "name": "_task_ok",
+            "location": "location",
+            "ds_type": "ds_type",
+            "sha": "sha",
+            "type": "type",
+            "content_type": "content_type",
+            "attempt_id": 1
+        })).body
+
+    _metadata = (await add_metadata(db,
+                                    flow_id=_task.get("flow_id"),
+                                    run_number=_task.get("run_number"),
+                                    run_id=_task.get("run_id"),
+                                    step_name=_task.get("step_name"),
+                                    task_id=_task.get("task_id"),
+                                    task_name=_task.get("task_name"),
+                                    tags=["attempt_id:0"],
+                                    metadata={
+                                        "field_name": "attempt_ok",
+                                        "value": "True",  # run status = 'completed'
+                                        "type": "internal_attempt_status"})).body
+
+    # We are expecting run status 'completed'
+    _run["status"] = "completed"
+    _run["real_user"] = None
+    _run["finished_at"] = _artifact_attempt_1["ts_epoch"]
+    _run["duration"] = _run["finished_at"] - _run["ts_epoch"]
+
+    _, data = await _test_list_resources(cli, db, "/flows/{flow_id}/runs".format(**_flow), 200, None)
+
+    assert len(data) == 1
+    assert data[0]["finished_at"] == _run["finished_at"]
+    assert data[0]["duration"] == _run["duration"]


### PR DESCRIPTION
Added subquery to get maximum attempt_id for runs thus preventing duplicate records.