### PR TITLE
change heartbeat_ts threshold for queries to include a buffer

### DIFF
--- a/services/data/postgres_async_db.py
+++ b/services/data/postgres_async_db.py
@@ -18,6 +18,7 @@ from services.utils import DBConfiguration
 AIOPG_ECHO = os.environ.get("AIOPG_ECHO", 0) == "1"
 
 WAIT_TIME = 10
+HEARTBEAT_THRESHOLD = WAIT_TIME + 10  # 10sec margin in case of client-server communication delays, before marking a heartbeat stale.
 OLD_RUN_FAILURE_CUTOFF_TIME = 60 * 60 * 24 * 1000 * 14  # 2 weeks (in milliseconds)
 
 # Create database triggers automatically, disabled by default
@@ -638,7 +639,7 @@ class AsyncRunTablePostgres(AsyncPostgresTable):
         END) AS finished_at
         """.format(
             table_name=table_name,
-            heartbeat_threshold=WAIT_TIME,
+            heartbeat_threshold=HEARTBEAT_THRESHOLD,
             cutoff=OLD_RUN_FAILURE_CUTOFF_TIME
         ),
         """
@@ -659,7 +660,7 @@ class AsyncRunTablePostgres(AsyncPostgresTable):
         END) AS status
         """.format(
             table_name=table_name,
-            heartbeat_threshold=WAIT_TIME,
+            heartbeat_threshold=HEARTBEAT_THRESHOLD,
             cutoff=OLD_RUN_FAILURE_CUTOFF_TIME
         ),
         """
@@ -885,7 +886,7 @@ class AsyncTaskTablePostgres(AsyncPostgresTable):
         END) AS status
         """.format(
             table_name=table_name,
-            heartbeat_threshold=WAIT_TIME
+            heartbeat_threshold=HEARTBEAT_THRESHOLD
         ),
         """
         (CASE


### PR DESCRIPTION
- increases heartbeat timestamp threshold for queries, so runs/tasks do not get marked as failed because of lag between client-server communications