### PR TITLE
Add sql query benchmarking support

### DIFF
--- a/services/data/postgres_async_db.py
+++ b/services/data/postgres_async_db.py
@@ -209,7 +209,8 @@ class AsyncPostgresTable(object):
     async def find_records(self, conditions: List[str] = None, values=[], fetch_single=False,
                            limit: int = 0, offset: int = 0, order: List[str] = None, groups: List[str] = None,
                            group_limit: int = 10, expanded=False, enable_joins=False,
-                           postprocess: Callable[[DBResponse], DBResponse] = None) -> (DBResponse, DBPagination):
+                           postprocess: Callable[[DBResponse], DBResponse] = None,
+                           benchmark: bool = False) -> (DBResponse, DBPagination):
 
         # Grouping not enabled
         if groups is None or len(groups) == 0:
@@ -275,6 +276,11 @@ class AsyncPostgresTable(object):
                 offset="OFFSET {}".format(offset) if offset else ""
             ).strip()
 
+        # Run benchmarking on query if requested
+        if benchmark:
+            await self.benchmark_sql(select_sql=select_sql, values=values, fetch_single=fetch_single,
+                                     expanded=expanded, limit=limit, offset=offset)
+
         result, pagination = await self.execute_sql(select_sql=select_sql, values=values, fetch_single=fetch_single,
                                                     expanded=expanded, limit=limit, offset=offset)
         # Modify the response after the fetch has been executed
@@ -285,6 +291,29 @@ class AsyncPostgresTable(object):
                 result = postprocess(result)
 
         return result, pagination
+
+    async def benchmark_sql(self, select_sql: str, values=[], fetch_single=False,
+                            expanded=False, limit: int = 0, offset: int = 0):
+        "Benchmark and log a given SQL query with EXPLAIN ANALYZE"
+        try:
+            with (
+                await self.db.pool.cursor(
+                    cursor_factory=psycopg2.extras.DictCursor
+                )
+            ) as cur:
+                # Run EXPLAIN ANALYZE on query and log the results.
+                benchmark_sql = "EXPLAIN ANALYZE {}".format(select_sql)
+                await cur.execute(benchmark_sql, values)
+
+                records = await cur.fetchall()
+                rows = []
+                for record in records:
+                    rows.append(record[0])
+                self.db.logger.info("\n".join(rows))
+        except (Exception, psycopg2.DatabaseError):
+            self.db.logger.exception("Query Benchmarking failed")
+
+
 
     async def execute_sql(self, select_sql: str, values=[], fetch_single=False,
                           expanded=False, limit: int = 0, offset: int = 0) -> (DBResponse, DBPagination):

--- a/services/data/postgres_async_db.py
+++ b/services/data/postgres_async_db.py
@@ -313,8 +313,6 @@ class AsyncPostgresTable(object):
         except (Exception, psycopg2.DatabaseError):
             self.db.logger.exception("Query Benchmarking failed")
 
-
-
     async def execute_sql(self, select_sql: str, values=[], fetch_single=False,
                           expanded=False, limit: int = 0, offset: int = 0) -> (DBResponse, DBPagination):
         try:

--- a/services/ui_backend_service/api/dag.py
+++ b/services/ui_backend_service/api/dag.py
@@ -50,7 +50,7 @@ class DagApi(object):
         run_id_key, run_id_value = translate_run_key(
             request.match_info.get("run_number"))
         # 'code-package' value contains json with dstype, sha1 hash and location
-        db_response, _ = await self._metadata_table.find_records(
+        db_response, *_ = await self._metadata_table.find_records(
             conditions=["flow_id = %s", "{run_id_key} = %s".format(
                 run_id_key=run_id_key), "field_name = %s"],
             values=[flow_name, run_id_value, "code-package"],

--- a/services/ui_backend_service/api/heartbeat_monitor.py
+++ b/services/ui_backend_service/api/heartbeat_monitor.py
@@ -102,7 +102,7 @@ class RunHeartbeatMonitor(HeartbeatMonitor):
         # NOTE: task being broadcast should contain the same fields as the GET request returns so UI can easily infer changes.
         # Currently this restricts the use of expanded=True
         run_id_key, run_id_value = translate_run_key(run_key)
-        result, _ = await self._run_table.find_records(
+        result, *_ = await self._run_table.find_records(
             conditions=["{column} = %s".format(column=run_id_key)],
             values=[run_id_value],
             fetch_single=True,
@@ -188,7 +188,7 @@ class TaskHeartbeatMonitor(HeartbeatMonitor):
             conditions.append("attempt_id = %s")
             values.append(attempt_id)
 
-        result, _ = await self._task_table.find_records(
+        result, *_ = await self._task_table.find_records(
             conditions=conditions,
             values=values,
             order=["attempt_id DESC"],

--- a/services/ui_backend_service/api/log.py
+++ b/services/ui_backend_service/api/log.py
@@ -156,7 +156,7 @@ async def get_metadata_log(find_records, flow_name, run_number, step_name, task_
     task_id_key, task_id_value = translate_task_key(task_id)
 
     try:
-        results, _ = await find_records(
+        results, *_ = await find_records(
             conditions=["flow_id = %s",
                         "{run_id_key} = %s".format(run_id_key=run_id_key),
                         "step_name = %s",

--- a/services/ui_backend_service/api/utils.py
+++ b/services/ui_backend_service/api/utils.py
@@ -278,13 +278,15 @@ async def find_records(request: web.BaseRequest, async_table=None, initial_condi
     conditions = initial_conditions + builtin_conditions + custom_conditions
     values = initial_values + builtin_vals + custom_vals
     ordering = (initial_order or []) + (order or [])
+    benchmark = request.query.get("benchmark", False) in ['True', 'true', '1', "t"]
 
     results, pagination = await async_table.find_records(
         conditions=conditions, values=values, limit=limit, offset=offset,
         order=ordering if len(ordering) > 0 else None, groups=groups, group_limit=group_limit,
         fetch_single=fetch_single, enable_joins=enable_joins,
         expanded=True,
-        postprocess=postprocess
+        postprocess=postprocess,
+        benchmark=benchmark
     )
 
     if fetch_single:

--- a/services/ui_backend_service/api/utils.py
+++ b/services/ui_backend_service/api/utils.py
@@ -280,7 +280,7 @@ async def find_records(request: web.BaseRequest, async_table=None, initial_condi
     ordering = (initial_order or []) + (order or [])
     benchmark = request.query.get("benchmark", False) in ['True', 'true', '1', "t"]
 
-    results, pagination = await async_table.find_records(
+    results, pagination, benchmark_result = await async_table.find_records(
         conditions=conditions, values=values, limit=limit, offset=offset,
         order=ordering if len(ordering) > 0 else None, groups=groups, group_limit=group_limit,
         fetch_single=fetch_single, enable_joins=enable_joins,
@@ -291,10 +291,13 @@ async def find_records(request: web.BaseRequest, async_table=None, initial_condi
 
     if fetch_single:
         status, res = format_response(request, results)
-        return web_response(status, res)
     else:
         status, res = format_response_list(request, results, pagination, page)
-        return web_response(status, res)
+
+    if benchmark_result:
+        res["benchmark_result"] = benchmark_result
+
+    return web_response(status, res)
 
 
 class TTLQueue:

--- a/services/ui_backend_service/api/ws.py
+++ b/services/ui_backend_service/api/ws.py
@@ -199,7 +199,7 @@ async def load_data_from_db(table, data: Dict[str, Any],
         conditions.append("{} = %s".format(k))
         values.append(v)
 
-    results, _ = await table.find_records(
+    results, *_ = await table.find_records(
         conditions=conditions, values=values, fetch_single=True,
         enable_joins=True,
         expanded=True,

--- a/services/ui_backend_service/data/cache/store.py
+++ b/services/ui_backend_service/data/cache/store.py
@@ -92,7 +92,7 @@ class ArtifactCacheStore(object):
                 logger.info(event)
 
     async def get_recent_run_numbers(self):
-        _records, _ = await self._run_table.find_records(
+        _records, *_ = await self._run_table.find_records(
             conditions=["ts_epoch >= %s"],
             values=[int(round(time.time() * 1000)) - (int(METAFLOW_ARTIFACT_PREFETCH_RUNS_SINCE) * 1000)],
             order=['ts_epoch DESC'],
@@ -111,7 +111,7 @@ class ArtifactCacheStore(object):
 
         artifact_loc_cond = "ds_type = %s"
         artifact_loc = "s3"
-        _records, _ = await self._artifact_table.find_records(
+        _records, *_ = await self._artifact_table.find_records(
             conditions=[run_id_cond, artifact_loc_cond],
             values=[run_ids, artifact_loc],
             expanded=True
@@ -139,7 +139,7 @@ class ArtifactCacheStore(object):
 
         # '_parameters' step has all the parameters as artifacts. only pick the
         # public parameters (no underscore prefix)
-        db_response, _ = await self._artifact_table.find_records(
+        db_response, *_ = await self._artifact_table.find_records(
             conditions=[
                 "flow_id = %s",
                 "{run_id_key} = %s".format(run_id_key=run_id_key),


### PR DESCRIPTION
- add support for benchmarking sql queries through api requests with `benchmark=true` param.
- runs `EXPLAIN ANALYZE` and logs the output when benchmark flag is set