### PR TITLE
Fix db error reporting

### DIFF
--- a/services/metadata_service/api/artifact.py
+++ b/services/metadata_service/api/artifact.py
@@ -137,7 +137,7 @@ class ArtificatsApi(object):
         )
 
         filtered_body = ArtificatsApi._filter_artifacts_by_attempt_id(
-            artifacts.body)
+            artifacts)
         return web.Response(
             status=artifacts.response_code, body=json.dumps(filtered_body)
         )
@@ -181,7 +181,7 @@ class ArtificatsApi(object):
         )
 
         filtered_body = ArtificatsApi._filter_artifacts_by_attempt_id(
-            artifacts.body)
+            artifacts)
         return web.Response(
             status=artifacts.response_code, body=json.dumps(filtered_body)
         )
@@ -216,7 +216,7 @@ class ArtificatsApi(object):
 
         artifacts = await self._async_table.get_artifacts_in_runs(flow_name, run_number)
         filtered_body = ArtificatsApi._filter_artifacts_by_attempt_id(
-            artifacts.body)
+            artifacts)
         return web.Response(
             status=artifacts.response_code, body=json.dumps(filtered_body)
         )
@@ -352,9 +352,11 @@ class ArtificatsApi(object):
 
     @staticmethod
     def _filter_artifacts_by_attempt_id(artifacts):
-        attempt_id = ArtificatsApi._get_latest_attempt_id(artifacts)
+        if artifacts.response_code != 200:
+            return artifacts.body
+        attempt_id = ArtificatsApi._get_latest_attempt_id(artifacts.body)
         result = []
-        for artifact in artifacts:
+        for artifact in artifacts.body:
             if artifact['attempt_id'] == attempt_id:
                 result.append(artifact)
 

--- a/services/metadata_service/api/artifact.py
+++ b/services/metadata_service/api/artifact.py
@@ -136,13 +136,10 @@ class ArtificatsApi(object):
             flow_name, run_number, step_name, task_id
         )
 
-        if artifacts.response_code == 200:
-            body = ArtificatsApi._filter_artifacts_by_attempt_id(
-                artifacts.body)
-        else:
-            body = artifacts.body
+        filtered_body = ArtificatsApi._filter_artifacts_by_attempt_id(
+            artifacts.body)
         return web.Response(
-            status=artifacts.response_code, body=json.dumps(body)
+            status=artifacts.response_code, body=json.dumps(filtered_body)
         )
 
     async def get_artifacts_by_step(self, request):
@@ -183,13 +180,10 @@ class ArtificatsApi(object):
             flow_name, run_number, step_name
         )
 
-        if artifacts.response_code == 200:
-            body = ArtificatsApi._filter_artifacts_by_attempt_id(
-                artifacts.body)
-        else:
-            body = artifacts.body
+        filtered_body = ArtificatsApi._filter_artifacts_by_attempt_id(
+            artifacts.body)
         return web.Response(
-            status=artifacts.response_code, body=json.dumps(body)
+            status=artifacts.response_code, body=json.dumps(filtered_body)
         )
 
     async def get_artifacts_by_run(self, request):
@@ -221,13 +215,10 @@ class ArtificatsApi(object):
         run_number = request.match_info.get("run_number")
 
         artifacts = await self._async_table.get_artifacts_in_runs(flow_name, run_number)
-        if artifacts.response_code == 200:
-            body = ArtificatsApi._filter_artifacts_by_attempt_id(
-                artifacts.body)
-        else:
-            body = artifacts.body
+        filtered_body = ArtificatsApi._filter_artifacts_by_attempt_id(
+            artifacts.body)
         return web.Response(
-            status=artifacts.response_code, body=json.dumps(body)
+            status=artifacts.response_code, body=json.dumps(filtered_body)
         )
 
     async def create_artifacts(self, request):

--- a/services/metadata_service/api/artifact.py
+++ b/services/metadata_service/api/artifact.py
@@ -136,10 +136,13 @@ class ArtificatsApi(object):
             flow_name, run_number, step_name, task_id
         )
 
-        filtered_body = ArtificatsApi._filter_artifacts_by_attempt_id(
-            artifacts.body)
+        if artifacts.response_code == 200:
+            body = ArtificatsApi._filter_artifacts_by_attempt_id(
+                artifacts.body)
+        else:
+            body = artifacts.body
         return web.Response(
-            status=artifacts.response_code, body=json.dumps(filtered_body)
+            status=artifacts.response_code, body=json.dumps(body)
         )
 
     async def get_artifacts_by_step(self, request):
@@ -180,10 +183,13 @@ class ArtificatsApi(object):
             flow_name, run_number, step_name
         )
 
-        filtered_body = ArtificatsApi._filter_artifacts_by_attempt_id(
-            artifacts.body)
+        if artifacts.response_code == 200:
+            body = ArtificatsApi._filter_artifacts_by_attempt_id(
+                artifacts.body)
+        else:
+            body = artifacts.body
         return web.Response(
-            status=artifacts.response_code, body=json.dumps(filtered_body)
+            status=artifacts.response_code, body=json.dumps(body)
         )
 
     async def get_artifacts_by_run(self, request):
@@ -215,10 +221,13 @@ class ArtificatsApi(object):
         run_number = request.match_info.get("run_number")
 
         artifacts = await self._async_table.get_artifacts_in_runs(flow_name, run_number)
-        filtered_body = ArtificatsApi._filter_artifacts_by_attempt_id(
-            artifacts.body)
+        if artifacts.response_code == 200:
+            body = ArtificatsApi._filter_artifacts_by_attempt_id(
+                artifacts.body)
+        else:
+            body = artifacts.body
         return web.Response(
-            status=artifacts.response_code, body=json.dumps(filtered_body)
+            status=artifacts.response_code, body=json.dumps(body)
         )
 
     async def create_artifacts(self, request):


### PR DESCRIPTION
This is an apparent fix of the bug mentioned [here](https://gitter.im/metaflow_org/community?at=5fddaea4c746c6431cc361a4). This bug obfuscates any error response stored by `self._async_table.get_artifact_in_task(...)` in `DBResponse.body`.

Basically, when there is a generic DB error, `self._async_table.get_artifact_in_task(...)` returns a `DBResponse` with `.body` attribute of type string (containing the error message) and a `.response_code` of `500`, indicating an error. The string-type body is set in `db_utils.aiopg_exception_handling`.

`ArtifactsApi._filter_artifacts_by_attempt_id(...)` expects `artifacts.body` to be an iterable, which is what `get_artifact_in_task` returns when no error has occurred (and `fetch_single==False`, which is the case in `get_artifact_in_task`). This fix avoids the call to `ArtifactsApi._filter_artifacts_by_attempt_id(...)` when `DBResponse.response_code` is not `200`.