### PR TITLE
Status integration tests

### DIFF
--- a/services/data/postgres_async_db.py
+++ b/services/data/postgres_async_db.py
@@ -803,7 +803,7 @@ class AsyncTaskTablePostgres(AsyncPostgresTable):
                 task_ok.task_id, task_ok.attempt_id, task_ok.ts_epoch,
                 task_ok.location,
                 attempt.ts_epoch as started_at,
-                COALESCE(done.ts_epoch, task_ok.ts_epoch) as finished_at,
+                COALESCE(attempt_ok.ts_epoch, done.ts_epoch, task_ok.ts_epoch, attempt.ts_epoch) as finished_at,
                 attempt_ok.value::boolean as attempt_ok,
                 foreach_stack.location as foreach_stack
             FROM {artifact_table} as task_ok

--- a/services/ui_backend_service/tests/integration_tests/status_attempts_test.py
+++ b/services/ui_backend_service/tests/integration_tests/status_attempts_test.py
@@ -291,19 +291,6 @@ async def test_attempt_status_failed_attempt_ok_s3(cli, db):
                                                 "value": "0",
                                                 "type": "attempt"})).body
 
-    _metadata_attempt_ok = (await add_metadata(db,
-                                               flow_id=_task.get("flow_id"),
-                                               run_number=_task.get("run_number"),
-                                               run_id=_task.get("run_id"),
-                                               step_name=_task.get("step_name"),
-                                               task_id=_task.get("task_id"),
-                                               task_name=_task.get("task_name"),
-                                               tags=["attempt_id:0"],
-                                               metadata={
-                                                   "field_name": "attempt_ok",
-                                                   "value": "True",
-                                                   "type": "internal_attempt_status"})).body
-
     async def _refine_record(self, record):
         return {**record, "task_ok": False}
 
@@ -311,12 +298,12 @@ async def test_attempt_status_failed_attempt_ok_s3(cli, db):
         "services.ui_backend_service.api.data_refiner.Refinery.refine_record",
         new=_refine_record
     ):
-        _, data = await _test_single_resource(cli, db, "/flows/{flow_id}/runs/{run_number}/steps/{step_name}/tasks/{task_id}".format(**_task), 200)
+        _, data = await _test_single_resource(cli, db, "/flows/{flow_id}/runs/{run_number}/steps/{step_name}/tasks/{task_id}?postprocess=true".format(**_task), 200)
 
         assert data["status"] == "failed"
         assert data["ts_epoch"] == _task["ts_epoch"]
         assert data["started_at"] == _metadata_attempt["ts_epoch"]  # metadata.attempt is present
-        assert data["finished_at"] == _metadata_attempt_ok["ts_epoch"]
+        assert data["finished_at"] == _artifact["ts_epoch"]
 
 
 async def test_attempt_status_failed_heartbeat(cli, db):

--- a/services/ui_backend_service/tests/integration_tests/status_attempts_test.py
+++ b/services/ui_backend_service/tests/integration_tests/status_attempts_test.py
@@ -1,0 +1,338 @@
+import pytest
+from unittest import mock
+from .utils import (
+    init_app, init_db, clean_db,
+    add_flow, add_run, add_artifact,
+    add_step, add_task, add_metadata,
+    _test_list_resources, _test_single_resource
+)
+pytestmark = [pytest.mark.integration_tests]
+
+# Fixtures begin
+
+
+@pytest.fixture
+def cli(loop, aiohttp_client):
+    return init_app(loop, aiohttp_client)
+
+
+@pytest.fixture
+async def db(cli):
+    async_db = await init_db(cli)
+    yield async_db
+    await clean_db(async_db)
+
+
+# Fixtures end
+
+# NOTE: For Attempts which don’t have attempt_ok in metadata, utilize the value of attempt specific task_ok in s3
+
+# Attempt is considered "Successful" when:
+#   1. attempt_ok in task metadata for the attempt is set to True
+#
+# Sart time: created_at(ts_epoch) property for attempt attribute for the attempt in task metadata
+# End time: created_at(ts_epoch) property for attempt_ok attribute for the attempt in task metadata
+
+
+async def __test_attempt_status_completed(cli, db):
+    _flow = (await add_flow(db, flow_id="HelloFlow")).body
+    _run = (await add_run(db, flow_id=_flow.get("flow_id"))).body
+    _step = (await add_step(db, flow_id=_run.get("flow_id"), step_name="end", run_number=_run.get("run_number"), run_id=_run.get("run_id"))).body
+    _task = (await add_task(db,
+                            flow_id=_step.get("flow_id"),
+                            step_name=_step.get("step_name"),
+                            run_number=_step.get("run_number"),
+                            run_id=_step.get("run_id"))).body
+
+    _artifact = (await add_artifact(
+        db,
+        flow_id=_task.get("flow_id"),
+        run_number=_task.get("run_number"),
+        step_name="end",
+        task_id=_task.get("task_id"),
+        artifact={
+            "name": "_task_ok",
+            "location": "location",
+            "ds_type": "ds_type",
+            "sha": "sha",
+            "type": "type",
+            "content_type": "content_type",
+                            "attempt_id": 0
+        })).body
+
+    _metadata_attempt = (await add_metadata(db,
+                                            flow_id=_task.get("flow_id"),
+                                            run_number=_task.get("run_number"),
+                                            run_id=_task.get("run_id"),
+                                            step_name=_task.get("step_name"),
+                                            task_id=_task.get("task_id"),
+                                            task_name=_task.get("task_name"),
+                                            metadata={
+                                                "field_name": "attempt",
+                                                "value": "0",
+                                                "type": "attempt"})).body
+
+    _metadata_attempt_ok = (await add_metadata(db,
+                                               flow_id=_task.get("flow_id"),
+                                               run_number=_task.get("run_number"),
+                                               run_id=_task.get("run_id"),
+                                               step_name=_task.get("step_name"),
+                                               task_id=_task.get("task_id"),
+                                               task_name=_task.get("task_name"),
+                                               tags=["attempt_id:0"],
+                                               metadata={
+                                                   "field_name": "attempt_ok",
+                                                   "value": "True",
+                                                   "type": "internal_attempt_status"})).body
+
+    _, data = await _test_single_resource(cli, db, "/flows/{flow_id}/runs/{run_number}/steps/{step_name}/tasks/{task_id}".format(**_task), 200)
+
+    assert data["status"] == "completed"
+    assert data["ts_epoch"] == _task["ts_epoch"]
+    assert data["started_at"] == _metadata_attempt["ts_epoch"]  # metadata.attempt is present
+    assert data["finished_at"] == _metadata_attempt_ok["ts_epoch"]
+
+
+# Attempt is considered "Running" when all of the following apply:
+#   1. Has a start time
+#   2. attempt_ok does not exist in the task metadata
+#   3. Has logged a heartbeat in the last x minutes
+#   4. No subsequent attempt exists
+#
+# Sart time: created_at(ts_epoch) property for attempt attribute for the attempt in task metadata
+# End time: Does not apply
+
+async def __test_attempt_status_running(cli, db):
+    _flow = (await add_flow(db, flow_id="HelloFlow")).body
+    _run = (await add_run(db, flow_id=_flow.get("flow_id"))).body
+    _step = (await add_step(db, flow_id=_run.get("flow_id"), step_name="end", run_number=_run.get("run_number"), run_id=_run.get("run_id"))).body
+    _task = (await add_task(db,
+                            flow_id=_step.get("flow_id"),
+                            step_name=_step.get("step_name"),
+                            run_number=_step.get("run_number"),
+                            run_id=_step.get("run_id"))).body
+
+    _, data = await _test_single_resource(cli, db, "/flows/{flow_id}/runs/{run_number}/steps/{step_name}/tasks/{task_id}".format(**_task), 200)
+
+    assert data["status"] == "running"
+    assert data["ts_epoch"] == _task["ts_epoch"]
+    assert data["started_at"] == None
+    assert data["finished_at"] == None
+
+
+async def __test_attempt_status_running_second_attempt(cli, db):
+    _flow = (await add_flow(db, flow_id="HelloFlow")).body
+    _run = (await add_run(db, flow_id=_flow.get("flow_id"))).body
+    _step = (await add_step(db, flow_id=_run.get("flow_id"), step_name="end", run_number=_run.get("run_number"), run_id=_run.get("run_id"))).body
+    _task = (await add_task(db,
+                            flow_id=_step.get("flow_id"),
+                            step_name=_step.get("step_name"),
+                            run_number=_step.get("run_number"),
+                            run_id=_step.get("run_id"))).body
+
+    _, data = await _test_single_resource(cli, db, "/flows/{flow_id}/runs/{run_number}/steps/{step_name}/tasks/{task_id}".format(**_task), 200)
+
+    _artifact = (await add_artifact(
+        db,
+        flow_id=_task.get("flow_id"),
+        run_number=_task.get("run_number"),
+        step_name="end",
+        task_id=_task.get("task_id"),
+        artifact={
+            "name": "_task_ok",
+            "location": "location",
+            "ds_type": "ds_type",
+            "sha": "sha",
+            "type": "type",
+            "content_type": "content_type",
+                            "attempt_id": 0
+        })).body
+
+    _metadata_attempt_ok = (await add_metadata(db,
+                                               flow_id=_task.get("flow_id"),
+                                               run_number=_task.get("run_number"),
+                                               run_id=_task.get("run_id"),
+                                               step_name=_task.get("step_name"),
+                                               task_id=_task.get("task_id"),
+                                               task_name=_task.get("task_name"),
+                                               tags=["attempt_id:0"],
+                                               metadata={
+                                                   "field_name": "attempt_ok",
+                                                   "value": "False",
+                                                   "type": "internal_attempt_status"})).body
+
+    _artifact_second = (await add_artifact(
+        db,
+        flow_id=_task.get("flow_id"),
+        run_number=_task.get("run_number"),
+        step_name="end",
+        task_id=_task.get("task_id"),
+        artifact={
+            "name": "_task_ok",
+            "location": "location",
+            "ds_type": "ds_type",
+            "sha": "sha",
+            "type": "type",
+            "content_type": "content_type",
+                            "attempt_id": 1
+        })).body
+
+    assert data["status"] == "running"
+    assert data["ts_epoch"] == _task["ts_epoch"]
+    assert data["started_at"] == None
+    assert data["finished_at"] == None
+
+
+# Attempt is considered "Failed" when any of the following apply:
+#   1. attempt_ok in task metadata for the attempt is set to False
+#   2. No heartbeat has been logged for the task in the last x minutes and no new attempt has started
+#   3. A newer attempt exists
+#
+# Sart time: created_at(ts_epoch) property for attempt attribute for the attempt in task metadata
+# End time: Either of (in priority)
+#   1. created_at property for attempt_ok attribute for the attempt in task metadata
+#   2. The timestamp in the heartbeat column for the task if no subsequent attempt is detected
+#   3. If a subsequent attempt exists, use the start time of the subsequent attempt
+
+async def test_attempt_status_failed_attempt_ok(cli, db):
+    _flow = (await add_flow(db, flow_id="HelloFlow")).body
+    _run = (await add_run(db, flow_id=_flow.get("flow_id"))).body
+    _step = (await add_step(db, flow_id=_run.get("flow_id"), step_name="end", run_number=_run.get("run_number"), run_id=_run.get("run_id"))).body
+    _task = (await add_task(db,
+                            flow_id=_step.get("flow_id"),
+                            step_name=_step.get("step_name"),
+                            run_number=_step.get("run_number"),
+                            run_id=_step.get("run_id"))).body
+
+    _artifact = (await add_artifact(
+        db,
+        flow_id=_task.get("flow_id"),
+        run_number=_task.get("run_number"),
+        step_name="end",
+        task_id=_task.get("task_id"),
+        artifact={
+            "name": "_task_ok",
+            "location": "location",
+            "ds_type": "ds_type",
+            "sha": "sha",
+            "type": "type",
+            "content_type": "content_type",
+                            "attempt_id": 0
+        })).body
+
+    _metadata_attempt = (await add_metadata(db,
+                                            flow_id=_task.get("flow_id"),
+                                            run_number=_task.get("run_number"),
+                                            run_id=_task.get("run_id"),
+                                            step_name=_task.get("step_name"),
+                                            task_id=_task.get("task_id"),
+                                            task_name=_task.get("task_name"),
+                                            metadata={
+                                                "field_name": "attempt",
+                                                "value": "0",
+                                                "type": "attempt"})).body
+
+    _metadata_attempt_ok = (await add_metadata(db,
+                                               flow_id=_task.get("flow_id"),
+                                               run_number=_task.get("run_number"),
+                                               run_id=_task.get("run_id"),
+                                               step_name=_task.get("step_name"),
+                                               task_id=_task.get("task_id"),
+                                               task_name=_task.get("task_name"),
+                                               tags=["attempt_id:0"],
+                                               metadata={
+                                                   "field_name": "attempt_ok",
+                                                   "value": "False",
+                                                   "type": "internal_attempt_status"})).body
+
+    _, data = await _test_single_resource(cli, db, "/flows/{flow_id}/runs/{run_number}/steps/{step_name}/tasks/{task_id}".format(**_task), 200)
+
+    assert data["status"] == "failed"
+    assert data["ts_epoch"] == _task["ts_epoch"]
+    assert data["started_at"] == _metadata_attempt["ts_epoch"]  # metadata.attempt is present
+    assert data["finished_at"] == _metadata_attempt_ok["ts_epoch"]
+
+
+async def test_attempt_status_failed_attempt_ok_s3(cli, db):
+    _flow = (await add_flow(db, flow_id="HelloFlow")).body
+    _run = (await add_run(db, flow_id=_flow.get("flow_id"))).body
+    _step = (await add_step(db, flow_id=_run.get("flow_id"), step_name="end", run_number=_run.get("run_number"), run_id=_run.get("run_id"))).body
+    _task = (await add_task(db,
+                            flow_id=_step.get("flow_id"),
+                            step_name=_step.get("step_name"),
+                            run_number=_step.get("run_number"),
+                            run_id=_step.get("run_id"))).body
+
+    _artifact = (await add_artifact(
+        db,
+        flow_id=_task.get("flow_id"),
+        run_number=_task.get("run_number"),
+        step_name="end",
+        task_id=_task.get("task_id"),
+        artifact={
+            "name": "_task_ok",
+            "location": "location",
+            "ds_type": "ds_type",
+            "sha": "sha",
+            "type": "type",
+            "content_type": "content_type",
+                            "attempt_id": 0
+        })).body
+
+    _metadata_attempt = (await add_metadata(db,
+                                            flow_id=_task.get("flow_id"),
+                                            run_number=_task.get("run_number"),
+                                            run_id=_task.get("run_id"),
+                                            step_name=_task.get("step_name"),
+                                            task_id=_task.get("task_id"),
+                                            task_name=_task.get("task_name"),
+                                            metadata={
+                                                "field_name": "attempt",
+                                                "value": "0",
+                                                "type": "attempt"})).body
+
+    _metadata_attempt_ok = (await add_metadata(db,
+                                               flow_id=_task.get("flow_id"),
+                                               run_number=_task.get("run_number"),
+                                               run_id=_task.get("run_id"),
+                                               step_name=_task.get("step_name"),
+                                               task_id=_task.get("task_id"),
+                                               task_name=_task.get("task_name"),
+                                               tags=["attempt_id:0"],
+                                               metadata={
+                                                   "field_name": "attempt_ok",
+                                                   "value": "True",
+                                                   "type": "internal_attempt_status"})).body
+
+    async def _refine_record(self, record):
+        return {**record, "task_ok": False}
+
+    with mock.patch(
+        "services.ui_backend_service.api.data_refiner.Refinery.refine_record",
+        new=_refine_record
+    ):
+        _, data = await _test_single_resource(cli, db, "/flows/{flow_id}/runs/{run_number}/steps/{step_name}/tasks/{task_id}".format(**_task), 200)
+
+        assert data["status"] == "failed"
+        assert data["ts_epoch"] == _task["ts_epoch"]
+        assert data["started_at"] == _metadata_attempt["ts_epoch"]  # metadata.attempt is present
+        assert data["finished_at"] == _metadata_attempt_ok["ts_epoch"]
+
+
+async def test_attempt_status_failed_heartbeat(cli, db):
+    _flow = (await add_flow(db, flow_id="HelloFlow")).body
+    _run = (await add_run(db, flow_id=_flow.get("flow_id"))).body
+    _step = (await add_step(db, flow_id=_run.get("flow_id"), step_name="end", run_number=_run.get("run_number"), run_id=_run.get("run_id"))).body
+    _task = (await add_task(db,
+                            flow_id=_step.get("flow_id"),
+                            step_name=_step.get("step_name"),
+                            run_number=_step.get("run_number"),
+                            run_id=_step.get("run_id"),
+                            last_heartbeat_ts=1)).body
+
+    _, data = await _test_single_resource(cli, db, "/flows/{flow_id}/runs/{run_number}/steps/{step_name}/tasks/{task_id}".format(**_task), 200)
+
+    assert data["status"] == "failed"
+    assert data["ts_epoch"] == _task["ts_epoch"]
+    assert data["started_at"] == None
+    assert data["finished_at"] == None

--- a/services/ui_backend_service/tests/integration_tests/status_runs_test.py
+++ b/services/ui_backend_service/tests/integration_tests/status_runs_test.py
@@ -1,0 +1,241 @@
+import pytest
+from .utils import (
+    init_app, init_db, clean_db,
+    add_flow, add_run, add_artifact,
+    add_step, add_task, add_metadata,
+    _test_list_resources, _test_single_resource, get_heartbeat_ts
+)
+pytestmark = [pytest.mark.integration_tests]
+
+# Fixtures begin
+
+
+@pytest.fixture
+def cli(loop, aiohttp_client):
+    return init_app(loop, aiohttp_client)
+
+
+@pytest.fixture
+async def db(cli):
+    async_db = await init_db(cli)
+    yield async_db
+    await clean_db(async_db)
+
+# Fixtures end
+
+# NOTE: For Runs which don’t have heartbeat enabled, for heartbeat checks fall back on using the timestamp of the latest metadata entry for the task as a proxy and set x and Y to 2 weeks.
+# NOTE: For Runs which don’t have attempt_ok in metadata, utilize the value of attempt specific task_ok in s3 (IMPORTANT: For the time being this won't affect Run context)
+
+# Run should have "Completed" status when:
+#   1. End task has succeeded
+#
+# Sart time: created_at(ts_epoch) column value in the run table
+# End time: End time for End task
+
+
+async def test_run_status_completed(cli, db):
+    _flow = (await add_flow(db, flow_id="HelloFlow")).body
+    _run = (await add_run(db, flow_id=_flow.get("flow_id"))).body
+    _step = (await add_step(db, flow_id=_run.get("flow_id"), step_name="end", run_number=_run.get("run_number"), run_id=_run.get("run_id"))).body
+    _task = (await add_task(db,
+                            flow_id=_step.get("flow_id"),
+                            step_name=_step.get("step_name"),
+                            run_number=_step.get("run_number"),
+                            run_id=_step.get("run_id"))).body
+
+    _artifact = (await add_artifact(
+        db,
+        flow_id=_task.get("flow_id"),
+        run_number=_task.get("run_number"),
+        step_name="end",
+        task_id=_task.get("task_id"),
+        artifact={
+            "name": "_task_ok",
+            "location": "location",
+            "ds_type": "ds_type",
+            "sha": "sha",
+            "type": "type",
+            "content_type": "content_type",
+                            "attempt_id": 0
+        })).body
+
+    _, data = await _test_single_resource(cli, db, "/flows/{flow_id}/runs/{run_number}".format(**_run), 200, None)
+
+    assert data["status"] == "completed"
+    assert data["ts_epoch"] == _run["ts_epoch"]
+    assert data["finished_at"] == _artifact["ts_epoch"]
+
+    _metadata = (await add_metadata(db,
+                                    flow_id=_task.get("flow_id"),
+                                    run_number=_task.get("run_number"),
+                                    run_id=_task.get("run_id"),
+                                    step_name=_task.get("step_name"),
+                                    task_id=_task.get("task_id"),
+                                    task_name=_task.get("task_name"),
+                                    tags=["attempt_id:0"],
+                                    metadata={
+                                        "field_name": "attempt_ok",
+                                        "value": "True",
+                                        "type": "internal_attempt_status"})).body
+
+    _, data = await _test_single_resource(cli, db, "/flows/{flow_id}/runs/{run_number}".format(**_run), 200, None)
+
+    assert data["status"] == "completed"
+    assert data["ts_epoch"] == _run["ts_epoch"]
+    assert data["finished_at"] == _artifact["ts_epoch"]
+
+
+# Run should have "Running" status when all of the following apply:
+#   1. No failed task
+#   2. Run has not succeeded
+#   3. Has logged a heartbeat in the last Y minutes for some task
+#
+# Sart time: created_at(ts_epoch) column value in the run table
+# End time: Does not apply
+
+async def test_run_status_running_no_failed_task(cli, db):
+    _flow = (await add_flow(db, flow_id="HelloFlow")).body
+    _run = (await add_run(db, flow_id=_flow.get("flow_id"))).body
+    _step = (await add_step(db, flow_id=_run.get("flow_id"), step_name="start", run_number=_run.get("run_number"), run_id=_run.get("run_id"))).body
+    _task = (await add_task(db,
+                            flow_id=_step.get("flow_id"),
+                            step_name=_step.get("step_name"),
+                            run_number=_step.get("run_number"),
+                            run_id=_step.get("run_id"))).body
+
+    _artifact = (await add_artifact(
+        db,
+        flow_id=_task.get("flow_id"),
+        run_number=_task.get("run_number"),
+        step_name="start",
+        task_id=_task.get("task_id"),
+        artifact={
+            "name": "_task_ok",
+            "location": "location",
+            "ds_type": "ds_type",
+            "sha": "sha",
+            "type": "type",
+            "content_type": "content_type",
+                            "attempt_id": 0
+        })).body
+
+    _metadata = (await add_metadata(db,
+                                    flow_id=_task.get("flow_id"),
+                                    run_number=_task.get("run_number"),
+                                    run_id=_task.get("run_id"),
+                                    step_name=_task.get("step_name"),
+                                    task_id=_task.get("task_id"),
+                                    task_name=_task.get("task_name"),
+                                    tags=["attempt_id:0"],
+                                    metadata={
+                                        "field_name": "attempt_ok",
+                                        "value": "True",
+                                        "type": "internal_attempt_status"})).body
+
+    _, data = await _test_single_resource(cli, db, "/flows/{flow_id}/runs/{run_number}".format(**_run), 200, None)
+
+    assert data["status"] == "running"
+    assert data["ts_epoch"] == _run["ts_epoch"]
+    assert data["finished_at"] == None
+
+
+async def test_run_status_running_run_not_succeeded(cli, db):
+    _flow = (await add_flow(db, flow_id="HelloFlow")).body
+    _run = (await add_run(db, flow_id=_flow.get("flow_id"))).body
+    _step = (await add_step(db, flow_id=_run.get("flow_id"), step_name="start", run_number=_run.get("run_number"), run_id=_run.get("run_id"))).body
+    _task = (await add_task(db,
+                            flow_id=_step.get("flow_id"),
+                            step_name=_step.get("step_name"),
+                            run_number=_step.get("run_number"),
+                            run_id=_step.get("run_id"))).body
+
+    _, data = await _test_single_resource(cli, db, "/flows/{flow_id}/runs/{run_number}".format(**_run), 200, None)
+
+    assert data["status"] == "running"
+    assert data["ts_epoch"] == _run["ts_epoch"]
+    assert data["finished_at"] == None
+
+
+async def test_run_status_running_with_heartbeat(cli, db):
+    _flow = (await add_flow(db, flow_id="HelloFlow")).body
+
+    _heartbeat = get_heartbeat_ts()
+
+    _run = (await add_run(db, flow_id=_flow.get("flow_id"), last_heartbeat_ts=_heartbeat)).body
+
+    _, data = await _test_single_resource(cli, db, "/flows/{flow_id}/runs/{run_number}".format(**_run), 200)
+
+    assert data["status"] == "running"
+    assert data["ts_epoch"] == _run["ts_epoch"]
+    assert data["last_heartbeat_ts"] == _heartbeat
+    assert data["duration"] == _run["last_heartbeat_ts"] * 1000 - _run["ts_epoch"]
+    assert data["finished_at"] == None
+
+
+# Run should have "Failed" status when any of the following apply:
+#   1. A task has failed
+#   2. No heartbeat has been logged for the task in the last Y minutes for any task
+#
+# Sart time: created_at(ts_epoch) column value in the run table
+# End time: Latest end time for all tasks
+
+async def test_run_status_failed_failed_task(cli, db):
+    _flow = (await add_flow(db, flow_id="HelloFlow")).body
+    _run = (await add_run(db, flow_id=_flow.get("flow_id"))).body
+    _step = (await add_step(db, flow_id=_run.get("flow_id"), step_name="end", run_number=_run.get("run_number"), run_id=_run.get("run_id"))).body
+    _task = (await add_task(db,
+                            flow_id=_step.get("flow_id"),
+                            step_name=_step.get("step_name"),
+                            run_number=_step.get("run_number"),
+                            run_id=_step.get("run_id"))).body
+
+    _artifact = (await add_artifact(
+        db,
+        flow_id=_task.get("flow_id"),
+        run_number=_task.get("run_number"),
+        step_name="end",
+        task_id=_task.get("task_id"),
+        artifact={
+            "name": "_task_ok",
+            "location": "location",
+            "ds_type": "ds_type",
+            "sha": "sha",
+            "type": "type",
+            "content_type": "content_type",
+                            "attempt_id": 0
+        })).body
+
+    _metadata = (await add_metadata(db,
+                                    flow_id=_task.get("flow_id"),
+                                    run_number=_task.get("run_number"),
+                                    run_id=_task.get("run_id"),
+                                    step_name=_task.get("step_name"),
+                                    task_id=_task.get("task_id"),
+                                    task_name=_task.get("task_name"),
+                                    tags=["attempt_id:0"],
+                                    metadata={
+                                        "field_name": "attempt_ok",
+                                        "value": "False",
+                                        "type": "internal_attempt_status"})).body
+
+    _, data = await _test_single_resource(cli, db, "/flows/{flow_id}/runs/{run_number}".format(**_run), 200, None)
+
+    assert data["status"] == "failed"
+    assert data["ts_epoch"] == _run["ts_epoch"]
+    assert data["finished_at"] == _artifact["ts_epoch"]
+
+
+async def test_run_status_failed_with_heartbeat_expired(cli, db):
+    _flow = (await add_flow(db, flow_id="HelloFlow")).body
+
+    _heartbeat = get_heartbeat_ts()
+
+    _run = (await add_run(db, flow_id=_flow.get("flow_id"), last_heartbeat_ts=1)).body
+
+    _, data = await _test_single_resource(cli, db, "/flows/{flow_id}/runs/{run_number}".format(**_run), 200)
+
+    assert data["status"] == "failed"
+    assert data["ts_epoch"] == _run["ts_epoch"]
+    assert data["last_heartbeat_ts"] == 1
+    assert data["duration"] == _run["last_heartbeat_ts"] * 1000 - _run["ts_epoch"]
+    assert data["finished_at"] == _run["last_heartbeat_ts"] * 1000

--- a/services/ui_backend_service/tests/integration_tests/status_tasks_test.py
+++ b/services/ui_backend_service/tests/integration_tests/status_tasks_test.py
@@ -1,0 +1,294 @@
+import pytest
+from unittest import mock
+from .utils import (
+    init_app, init_db, clean_db,
+    add_flow, add_run, add_artifact,
+    add_step, add_task, add_metadata,
+    _test_list_resources, _test_single_resource
+)
+pytestmark = [pytest.mark.integration_tests]
+
+# Fixtures begin
+
+
+@pytest.fixture
+def cli(loop, aiohttp_client):
+    return init_app(loop, aiohttp_client)
+
+
+@pytest.fixture
+async def db(cli):
+    async_db = await init_db(cli)
+    yield async_db
+    await clean_db(async_db)
+
+
+# Fixtures end
+
+# NOTE: For Tasks which don’t have heartbeat enabled, for heartbeat checks fall back on using the timestamp of the latest metadata entry for the task as a proxy and set x and Y to 2 weeks.
+# NOTE: For Tasks which don’t have attempt_ok in metadata, utilize the value of attempt specific task_ok in s3
+
+# Task is considered "Successful" when:
+#   1. If the latest attempt is successful
+#
+# Sart time: created_at(ts_epoch) column value in the task table
+# End time: ts_epoch for the successful attempt
+
+
+async def __test_task_status_completed(cli, db):
+    _flow = (await add_flow(db, flow_id="HelloFlow")).body
+    _run = (await add_run(db, flow_id=_flow.get("flow_id"))).body
+    _step = (await add_step(db, flow_id=_run.get("flow_id"), step_name="end", run_number=_run.get("run_number"), run_id=_run.get("run_id"))).body
+    _task = (await add_task(db,
+                            flow_id=_step.get("flow_id"),
+                            step_name=_step.get("step_name"),
+                            run_number=_step.get("run_number"),
+                            run_id=_step.get("run_id"))).body
+
+    _artifact = (await add_artifact(
+        db,
+        flow_id=_task.get("flow_id"),
+        run_number=_task.get("run_number"),
+        step_name="end",
+        task_id=_task.get("task_id"),
+        artifact={
+            "name": "_task_ok",
+            "location": "location",
+            "ds_type": "ds_type",
+            "sha": "sha",
+            "type": "type",
+            "content_type": "content_type",
+                            "attempt_id": 0
+        })).body
+
+    _metadata_attempt = (await add_metadata(db,
+                                            flow_id=_task.get("flow_id"),
+                                            run_number=_task.get("run_number"),
+                                            run_id=_task.get("run_id"),
+                                            step_name=_task.get("step_name"),
+                                            task_id=_task.get("task_id"),
+                                            task_name=_task.get("task_name"),
+                                            metadata={
+                                                "field_name": "attempt",
+                                                "value": "0",
+                                                "type": "attempt"})).body
+
+    _metadata_attempt_ok = (await add_metadata(db,
+                                               flow_id=_task.get("flow_id"),
+                                               run_number=_task.get("run_number"),
+                                               run_id=_task.get("run_id"),
+                                               step_name=_task.get("step_name"),
+                                               task_id=_task.get("task_id"),
+                                               task_name=_task.get("task_name"),
+                                               tags=["attempt_id:0"],
+                                               metadata={
+                                                   "field_name": "attempt_ok",
+                                                   "value": "True",
+                                                   "type": "internal_attempt_status"})).body
+
+    _, data = await _test_single_resource(cli, db, "/flows/{flow_id}/runs/{run_number}/steps/{step_name}/tasks/{task_id}".format(**_task), 200)
+
+    assert data["status"] == "completed"
+    assert data["ts_epoch"] == _task["ts_epoch"]
+    assert data["started_at"] == _metadata_attempt["ts_epoch"]  # metadata.attempt is present
+    assert data["finished_at"] == _metadata_attempt_ok["ts_epoch"]
+
+
+# Task is considered "Running" when all of the following apply:
+#   1. Has a running attempt or the task hasn’t failed
+#
+# Sart time: created_at(ts_epoch) column value in the task table
+# End time: Does not apply
+
+
+async def __test_task_status_running(cli, db):
+    _flow = (await add_flow(db, flow_id="HelloFlow")).body
+    _run = (await add_run(db, flow_id=_flow.get("flow_id"))).body
+    _step = (await add_step(db, flow_id=_run.get("flow_id"), step_name="end", run_number=_run.get("run_number"), run_id=_run.get("run_id"))).body
+    _task = (await add_task(db,
+                            flow_id=_step.get("flow_id"),
+                            step_name=_step.get("step_name"),
+                            run_number=_step.get("run_number"),
+                            run_id=_step.get("run_id"))).body
+
+    _, data = await _test_single_resource(cli, db, "/flows/{flow_id}/runs/{run_number}/steps/{step_name}/tasks/{task_id}".format(**_task), 200)
+
+    assert data["status"] == "running"
+    assert data["ts_epoch"] == _task["ts_epoch"]
+    assert data["started_at"] == None
+    assert data["finished_at"] == None
+
+
+# Task is considered "Failed" when all of the following apply:
+#   1. Y minutes have expired after the End time for the task
+#   2. the latest attempt has failed (if one exists)
+#
+# Sart time: created_at(ts_epoch) column value in the task table
+# End time: The latest of
+#   1. The timestamp in the heartbeat column for the task
+#   2. End time of the latest attempt (if one exists)
+
+async def test_task_status_failed_attempt_ok(cli, db):
+    _flow = (await add_flow(db, flow_id="HelloFlow")).body
+    _run = (await add_run(db, flow_id=_flow.get("flow_id"))).body
+    _step = (await add_step(db, flow_id=_run.get("flow_id"), step_name="end", run_number=_run.get("run_number"), run_id=_run.get("run_id"))).body
+    _task = (await add_task(db,
+                            flow_id=_step.get("flow_id"),
+                            step_name=_step.get("step_name"),
+                            run_number=_step.get("run_number"),
+                            run_id=_step.get("run_id"))).body
+
+    _artifact = (await add_artifact(
+        db,
+        flow_id=_task.get("flow_id"),
+        run_number=_task.get("run_number"),
+        step_name="end",
+        task_id=_task.get("task_id"),
+        artifact={
+            "name": "_task_ok",
+            "location": "location",
+            "ds_type": "ds_type",
+            "sha": "sha",
+            "type": "type",
+            "content_type": "content_type",
+                            "attempt_id": 0
+        })).body
+
+    _metadata_attempt = (await add_metadata(db,
+                                            flow_id=_task.get("flow_id"),
+                                            run_number=_task.get("run_number"),
+                                            run_id=_task.get("run_id"),
+                                            step_name=_task.get("step_name"),
+                                            task_id=_task.get("task_id"),
+                                            task_name=_task.get("task_name"),
+                                            metadata={
+                                                "field_name": "attempt",
+                                                "value": "0",
+                                                "type": "attempt"})).body
+
+    _metadata_attempt_ok = (await add_metadata(db,
+                                               flow_id=_task.get("flow_id"),
+                                               run_number=_task.get("run_number"),
+                                               run_id=_task.get("run_id"),
+                                               step_name=_task.get("step_name"),
+                                               task_id=_task.get("task_id"),
+                                               task_name=_task.get("task_name"),
+                                               tags=["attempt_id:0"],
+                                               metadata={
+                                                   "field_name": "attempt_ok",
+                                                   "value": "False",
+                                                   "type": "internal_attempt_status"})).body
+
+    _, data = await _test_single_resource(cli, db, "/flows/{flow_id}/runs/{run_number}/steps/{step_name}/tasks/{task_id}".format(**_task), 200)
+
+    assert data["status"] == "failed"
+    assert data["ts_epoch"] == _task["ts_epoch"]
+    assert data["started_at"] == _metadata_attempt["ts_epoch"]  # metadata.attempt is present
+    assert data["finished_at"] == _metadata_attempt_ok["ts_epoch"]
+
+
+async def test_task_status_failed_attempt_ok_s3(cli, db):
+    _flow = (await add_flow(db, flow_id="HelloFlow")).body
+    _run = (await add_run(db, flow_id=_flow.get("flow_id"))).body
+    _step = (await add_step(db, flow_id=_run.get("flow_id"), step_name="end", run_number=_run.get("run_number"), run_id=_run.get("run_id"))).body
+    _task = (await add_task(db,
+                            flow_id=_step.get("flow_id"),
+                            step_name=_step.get("step_name"),
+                            run_number=_step.get("run_number"),
+                            run_id=_step.get("run_id"))).body
+
+    _artifact = (await add_artifact(
+        db,
+        flow_id=_task.get("flow_id"),
+        run_number=_task.get("run_number"),
+        step_name="end",
+        task_id=_task.get("task_id"),
+        artifact={
+            "name": "_task_ok",
+            "location": "location",
+            "ds_type": "ds_type",
+            "sha": "sha",
+            "type": "type",
+            "content_type": "content_type",
+                            "attempt_id": 0
+        })).body
+
+    _metadata_attempt = (await add_metadata(db,
+                                            flow_id=_task.get("flow_id"),
+                                            run_number=_task.get("run_number"),
+                                            run_id=_task.get("run_id"),
+                                            step_name=_task.get("step_name"),
+                                            task_id=_task.get("task_id"),
+                                            task_name=_task.get("task_name"),
+                                            metadata={
+                                                "field_name": "attempt",
+                                                "value": "0",
+                                                "type": "attempt"})).body
+
+    _metadata_attempt_ok = (await add_metadata(db,
+                                               flow_id=_task.get("flow_id"),
+                                               run_number=_task.get("run_number"),
+                                               run_id=_task.get("run_id"),
+                                               step_name=_task.get("step_name"),
+                                               task_id=_task.get("task_id"),
+                                               task_name=_task.get("task_name"),
+                                               tags=["attempt_id:0"],
+                                               metadata={
+                                                   "field_name": "attempt_ok",
+                                                   "value": "True",
+                                                   "type": "internal_attempt_status"})).body
+
+    async def _refine_record(self, record):
+        return {**record, "task_ok": False}
+
+    with mock.patch(
+        "services.ui_backend_service.api.data_refiner.Refinery.refine_record",
+        new=_refine_record
+    ):
+        _, data = await _test_single_resource(cli, db, "/flows/{flow_id}/runs/{run_number}/steps/{step_name}/tasks/{task_id}".format(**_task), 200)
+
+        assert data["status"] == "failed"
+        assert data["ts_epoch"] == _task["ts_epoch"]
+        assert data["started_at"] == _metadata_attempt["ts_epoch"]  # metadata.attempt is present
+        assert data["finished_at"] == _metadata_attempt_ok["ts_epoch"]
+
+
+async def test_task_status_failed_attempt_ok_s3_artifact_ts_epoch(cli, db):
+    _flow = (await add_flow(db, flow_id="HelloFlow")).body
+    _run = (await add_run(db, flow_id=_flow.get("flow_id"))).body
+    _step = (await add_step(db, flow_id=_run.get("flow_id"), step_name="end", run_number=_run.get("run_number"), run_id=_run.get("run_id"))).body
+    _task = (await add_task(db,
+                            flow_id=_step.get("flow_id"),
+                            step_name=_step.get("step_name"),
+                            run_number=_step.get("run_number"),
+                            run_id=_step.get("run_id"))).body
+
+    _artifact = (await add_artifact(
+        db,
+        flow_id=_task.get("flow_id"),
+        run_number=_task.get("run_number"),
+        step_name="end",
+        task_id=_task.get("task_id"),
+        artifact={
+            "name": "_task_ok",
+            "location": "location",
+            "ds_type": "ds_type",
+            "sha": "sha",
+            "type": "type",
+            "content_type": "content_type",
+                            "attempt_id": 0
+        })).body
+
+    async def _refine_record(self, record):
+        return {**record, "task_ok": False}
+
+    with mock.patch(
+        "services.ui_backend_service.api.data_refiner.Refinery.refine_record",
+        new=_refine_record
+    ):
+        _, data = await _test_single_resource(cli, db, "/flows/{flow_id}/runs/{run_number}/steps/{step_name}/tasks/{task_id}".format(**_task), 200)
+
+        assert data["status"] == "failed"
+        assert data["ts_epoch"] == _task["ts_epoch"]
+        assert data["started_at"] == None  # metadata.attempt not present
+        assert data["finished_at"] == _artifact["ts_epoch"]

--- a/services/ui_backend_service/tests/integration_tests/status_tasks_test.py
+++ b/services/ui_backend_service/tests/integration_tests/status_tasks_test.py
@@ -225,19 +225,6 @@ async def test_task_status_failed_attempt_ok_s3(cli, db):
                                                 "value": "0",
                                                 "type": "attempt"})).body
 
-    _metadata_attempt_ok = (await add_metadata(db,
-                                               flow_id=_task.get("flow_id"),
-                                               run_number=_task.get("run_number"),
-                                               run_id=_task.get("run_id"),
-                                               step_name=_task.get("step_name"),
-                                               task_id=_task.get("task_id"),
-                                               task_name=_task.get("task_name"),
-                                               tags=["attempt_id:0"],
-                                               metadata={
-                                                   "field_name": "attempt_ok",
-                                                   "value": "True",
-                                                   "type": "internal_attempt_status"})).body
-
     async def _refine_record(self, record):
         return {**record, "task_ok": False}
 
@@ -245,12 +232,12 @@ async def test_task_status_failed_attempt_ok_s3(cli, db):
         "services.ui_backend_service.api.data_refiner.Refinery.refine_record",
         new=_refine_record
     ):
-        _, data = await _test_single_resource(cli, db, "/flows/{flow_id}/runs/{run_number}/steps/{step_name}/tasks/{task_id}".format(**_task), 200)
+        _, data = await _test_single_resource(cli, db, "/flows/{flow_id}/runs/{run_number}/steps/{step_name}/tasks/{task_id}?postprocess=true".format(**_task), 200)
 
         assert data["status"] == "failed"
         assert data["ts_epoch"] == _task["ts_epoch"]
         assert data["started_at"] == _metadata_attempt["ts_epoch"]  # metadata.attempt is present
-        assert data["finished_at"] == _metadata_attempt_ok["ts_epoch"]
+        assert data["finished_at"] == _artifact["ts_epoch"]
 
 
 async def test_task_status_failed_attempt_ok_s3_artifact_ts_epoch(cli, db):
@@ -286,7 +273,7 @@ async def test_task_status_failed_attempt_ok_s3_artifact_ts_epoch(cli, db):
         "services.ui_backend_service.api.data_refiner.Refinery.refine_record",
         new=_refine_record
     ):
-        _, data = await _test_single_resource(cli, db, "/flows/{flow_id}/runs/{run_number}/steps/{step_name}/tasks/{task_id}".format(**_task), 200)
+        _, data = await _test_single_resource(cli, db, "/flows/{flow_id}/runs/{run_number}/steps/{step_name}/tasks/{task_id}?postprocess=true".format(**_task), 200)
 
         assert data["status"] == "failed"
         assert data["ts_epoch"] == _task["ts_epoch"]


### PR DESCRIPTION
Added more integration tests for attempt/task/run statuses.

Task `finished_at` field is now populated with:
```sql
COALESCE(attempt_ok.ts_epoch, done.ts_epoch, task_ok.ts_epoch, attempt.ts_epoch) AS finished_at
```

Integration tests now include ability to mock S3 postprocessing behaviour.