### PR TITLE
Fix 'ValueError: too many values to unpack' from postgres_async_db.py

### DIFF
--- a/services/data/postgres_async_db.py
+++ b/services/data/postgres_async_db.py
@@ -202,8 +202,8 @@ class AsyncPostgresTable(object):
             conditions.append("{} = %s".format(col_name))
             values.append(col_val)
 
-        response, _ = await self.find_records(conditions=conditions, values=values, fetch_single=fetch_single,
-                                              order=ordering, limit=limit, expanded=expanded)
+        response, *_ = await self.find_records(conditions=conditions, values=values, fetch_single=fetch_single,
+                                               order=ordering, limit=limit, expanded=expanded)
         return response
 
     async def find_records(self, conditions: List[str] = None, values=[], fetch_single=False,


### PR DESCRIPTION
```
 ValueError: too many values to unpack (expected 2)

 ERROR:aiohttp.server:Error handling request
 Traceback (most recent call last):
   File "/usr/local/lib/python3.7/site-packages/aiohttp/web_protocol.py", line 418, in start
     resp = await task
   File "/usr/local/lib/python3.7/site-packages/aiohttp/web_app.py", line 458, in _handle
     resp = await handler(request)
   File "/root/services/utils/__init__.py", line 93, in wrapper
     return web.Response(status=db_response.response_code,
 AttributeError: 'Response' object has no attribute 'response_code'
```