### PR TITLE
Use quotation marks for column names to prevent error with reserved keywords

### DIFF
--- a/services/data/postgres_async_db.py
+++ b/services/data/postgres_async_db.py
@@ -129,7 +129,7 @@ class _AsyncPostgresDB(object):
 
         select_sql = "SELECT * FROM (VALUES({values})) T({keys}) {where}".format(
             values=", ".join(stm_vals),
-            keys=", ".join(keys),
+            keys=", ".join(map(lambda k: "\"{}\"".format(k), keys)),
             where="WHERE {}".format(" AND ".join(
                 conditions)) if conditions else "",
         )
@@ -211,8 +211,6 @@ class AsyncPostgresTable(object):
                            group_limit: int = 10, expanded=False, enable_joins=False,
                            postprocess: Callable[[DBResponse], DBResponse] = None,
                            benchmark: bool = False) -> (DBResponse, DBPagination):
-        # Alias T is important here which is used to construct ordering and conditions
-
         # Grouping not enabled
         if groups is None or len(groups) == 0:
             sql_template = """
@@ -227,10 +225,6 @@ class AsyncPostgresTable(object):
             {limit}
             {offset}
             """
-
-            if order:
-                # Order using alias T
-                order = map(lambda o: "T.{}".format(o), order)
 
             select_sql = sql_template.format(
                 keys=",".join(

--- a/services/ui_backend_service/api/utils.py
+++ b/services/ui_backend_service/api/utils.py
@@ -95,7 +95,7 @@ def pagination_query(request: web.BaseRequest, allowed_order: List[str] = [], al
                     direction = "DESC"
 
                 if column in allowed_order:
-                    _orders.append("{} {}".format(column, direction))
+                    _orders.append("\"{}\" {}".format(column, direction))
 
             order = _orders
         else:
@@ -112,7 +112,7 @@ def pagination_query(request: web.BaseRequest, allowed_order: List[str] = [], al
         groups = []
         for g in _group.split(","):
             if g in allowed_group:
-                groups.append(g)
+                groups.append("\"{}\"".format(g))
     else:
         groups = None
 
@@ -172,16 +172,16 @@ def builtin_conditions_query_dict(query: MultiDict):
 
 
 operators_to_sql = {
-    "eq": "{} = %s",          # equals
-    "ne": "{} != %s",         # not equals
-    "lt": "{} < %s",          # less than
-    "le": "{} <= %s",         # less than or equals
-    "gt": "{} > %s",          # greater than
-    "ge": "{} >= %s",         # greater than or equals
-    "co": "{} ILIKE %s",      # contains
-    "sw": "{} ILIKE %s",      # starts with
-    "ew": "{} ILIKE %s",      # ends with
-    "is": "{} IS %s",         # IS
+    "eq": "\"{}\" = %s",          # equals
+    "ne": "\"{}\" != %s",         # not equals
+    "lt": "\"{}\" < %s",          # less than
+    "le": "\"{}\" <= %s",         # less than or equals
+    "gt": "\"{}\" > %s",          # greater than
+    "ge": "\"{}\" >= %s",         # greater than or equals
+    "co": "\"{}\" ILIKE %s",      # contains
+    "sw": "\"{}\" ILIKE %s",      # starts with
+    "ew": "\"{}\" ILIKE %s",      # ends with
+    "is": "\"{}\" IS %s",         # IS
 }
 
 operators_to_sql_values = {
@@ -227,10 +227,9 @@ def custom_conditions_query_dict(query: MultiDict, allowed_keys: List[str] = [])
 
         vals = val.split(",")
 
-        # Refer to services.data.postgres_async_db.py:find_records for alias T
         conditions.append(
             "({})".format(" OR ".join(
-                map(lambda v: "T." + operators_to_sql["is" if v == "null" else operator].format(field), vals)
+                map(lambda v: operators_to_sql["is" if v == "null" else operator].format(field), vals)
             ))
         )
         values += map(

--- a/services/ui_backend_service/tests/unit_tests/utils_test.py
+++ b/services/ui_backend_service/tests/unit_tests/utils_test.py
@@ -126,8 +126,8 @@ def test_pagination_query_custom():
     assert page == 3
     assert limit == 5
     assert offset == 10
-    assert order == ["foo DESC"]
-    assert groups == ["bar"]
+    assert order == ["\"foo\" DESC"]
+    assert groups == ["\"bar\""]
     assert group_limit == 10
 
 
@@ -137,7 +137,7 @@ def test_pagination_query_custom_order_asc():
     _, _, _, order, _, _ = pagination_query(
         request=request, allowed_order=["foo"])
 
-    assert order == ["foo ASC"]
+    assert order == ["\"foo\" ASC"]
 
 
 def test_pagination_query_not_allowed():
@@ -222,16 +222,16 @@ def test_builtin_conditions_query_tags_likeany():
 
 def test_custom_conditions_query():
     operators = {
-        "flow_id": ["flow_id = %s", "{}"],
-        "flow_id:eq": ["flow_id = %s", "{}"],
-        "flow_id:ne": ["flow_id != %s", "{}"],
-        "flow_id:lt": ["flow_id < %s", "{}"],
-        "flow_id:le": ["flow_id <= %s", "{}"],
-        "flow_id:gt": ["flow_id > %s", "{}"],
-        "flow_id:ge": ["flow_id >= %s", "{}"],
-        "flow_id:co": ["flow_id ILIKE %s", "%{}%"],
-        "flow_id:sw": ["flow_id ILIKE %s", "{}%"],
-        "flow_id:ew": ["flow_id ILIKE %s", "%{}"]
+        "flow_id": ["\"flow_id\" = %s", "{}"],
+        "flow_id:eq": ["\"flow_id\" = %s", "{}"],
+        "flow_id:ne": ["\"flow_id\" != %s", "{}"],
+        "flow_id:lt": ["\"flow_id\" < %s", "{}"],
+        "flow_id:le": ["\"flow_id\" <= %s", "{}"],
+        "flow_id:gt": ["\"flow_id\" > %s", "{}"],
+        "flow_id:ge": ["\"flow_id\" >= %s", "{}"],
+        "flow_id:co": ["\"flow_id\" ILIKE %s", "%{}%"],
+        "flow_id:sw": ["\"flow_id\" ILIKE %s", "{}%"],
+        "flow_id:ew": ["\"flow_id\" ILIKE %s", "%{}"]
     }
 
     for op, query in operators.items():
@@ -245,8 +245,8 @@ def test_custom_conditions_query():
             request, allowed_keys=["flow_id"])
 
         assert len(conditions) == 2
-        assert conditions[0] == "(T.{0} OR T.{0})".format(where)
-        assert conditions[1] == "(T.{0})".format(where)
+        assert conditions[0] == "({0} OR {0})".format(where)
+        assert conditions[1] == "({0})".format(where)
 
         assert len(values) == 3
         assert values[0] == val.format("HelloFlow")
@@ -262,8 +262,8 @@ def test_custom_conditions_query_allow_any_key():
         request, allowed_keys=None)
 
     assert len(conditions) == 2
-    assert conditions[0] == "(T.flow_id = %s)"
-    assert conditions[1] == "(T.status = %s)"
+    assert conditions[0] == "(\"flow_id\" = %s)"
+    assert conditions[1] == "(\"status\" = %s)"
 
     assert len(values) == 2
     assert values[0] == "HelloFlow"
@@ -280,8 +280,8 @@ def test_resource_conditions():
     assert query.get("status") == "running"
 
     assert len(conditions) == 2
-    assert conditions[0] == "(T.flow_id = %s)"
-    assert conditions[1] == "(T.status = %s)"
+    assert conditions[0] == "(\"flow_id\" = %s)"
+    assert conditions[1] == "(\"status\" = %s)"
 
     assert len(values) == 2
     assert values[0] == "HelloFlow"


### PR DESCRIPTION
Use quotation marks to prevent conflicts with PostgreSQL reserved keywords.

Example:
```sql
SELECT * FROM (VALUES('foo')) T (user); -- Failure

SELECT * FROM (VALUES('foo')) T ("user"); -- Success
```