### PR TITLE
Make heartbeat interval configurable for UI heartbeat checks

### DIFF
--- a/services/data/postgres_async_db.py
+++ b/services/data/postgres_async_db.py
@@ -18,8 +18,9 @@ from services.utils import DBConfiguration
 AIOPG_ECHO = os.environ.get("AIOPG_ECHO", 0) == "1"
 
 WAIT_TIME = 10
-HEARTBEAT_THRESHOLD = WAIT_TIME * 6  # Add margin in case of client-server communication delays, before marking a heartbeat stale.
-OLD_RUN_FAILURE_CUTOFF_TIME = 60 * 60 * 24 * 1000 * 14  # 2 weeks (in milliseconds)
+# Heartbeat check interval. Add margin in case of client-server communication delays, before marking a heartbeat stale.
+HEARTBEAT_THRESHOLD = os.environ.get("HEARTBEAT_THRESHOLD", WAIT_TIME * 6)
+OLD_RUN_FAILURE_CUTOFF_TIME = os.environ.get("OLD_RUN_FAILURE_CUTOFF_TIME", 60 * 60 * 24 * 1000 * 14)  # default 2 weeks (in milliseconds)
 
 # Create database triggers automatically, disabled by default
 # Enable with env variable `DB_TRIGGER_CREATE=1`

--- a/services/data/postgres_async_db.py
+++ b/services/data/postgres_async_db.py
@@ -19,8 +19,8 @@ AIOPG_ECHO = os.environ.get("AIOPG_ECHO", 0) == "1"
 
 WAIT_TIME = 10
 # Heartbeat check interval. Add margin in case of client-server communication delays, before marking a heartbeat stale.
-HEARTBEAT_THRESHOLD = os.environ.get("HEARTBEAT_THRESHOLD", WAIT_TIME * 6)
-OLD_RUN_FAILURE_CUTOFF_TIME = os.environ.get("OLD_RUN_FAILURE_CUTOFF_TIME", 60 * 60 * 24 * 1000 * 14)  # default 2 weeks (in milliseconds)
+HEARTBEAT_THRESHOLD = int(os.environ.get("HEARTBEAT_THRESHOLD", WAIT_TIME * 6))
+OLD_RUN_FAILURE_CUTOFF_TIME = int(os.environ.get("OLD_RUN_FAILURE_CUTOFF_TIME", 60 * 60 * 24 * 1000 * 14))  # default 2 weeks (in milliseconds)
 
 # Create database triggers automatically, disabled by default
 # Enable with env variable `DB_TRIGGER_CREATE=1`

--- a/services/ui_backend_service/README.md
+++ b/services/ui_backend_service/README.md
@@ -73,6 +73,12 @@ Running the service without Docker (from project root):
 > $ python3 -m services.ui_backend_service.ui_server
 > ```
 
+### Optional configuration
+
+The threshold parameters for heartbeat checks can also be configured when necessary with the following environment variables.
+- `HEARTBEAT_THRESHOLD` [controls at what point a heartbeat is considered expired. Default is `WAIT_TIME * 6`]
+- `OLD_RUN_FAILURE_CUTOFF_TIME` [ for runs that do not have a heartbeat, controls at what point a running status run should be considered failed. Default is 2 weeks]
+
 ## Baseurl configuration
 
 Use `MF_BASEURL` environment variable to overwrite the default API baseurl.


### PR DESCRIPTION
Adds two environment variables for heartbeat check configuration
- `HEARTBEAT_THRESHOLD` - controls at what point a heartbeat is considered expired. Default is `WAIT_TIME * 6`
- `OLD_RUN_FAILURE_CUTOFF_TIME` - for runs that do not have a heartbeat, controls at what point a `running` status run should be considered failed. Default is 2 weeks