### PR TITLE
Fix finished at timestamp for failed attempts

### DIFF
--- a/services/data/postgres_async_db.py
+++ b/services/data/postgres_async_db.py
@@ -881,7 +881,13 @@ class AsyncTaskTablePostgres(AsyncPostgresTable):
     select_columns = ["tasks_v3.{0} AS {0}".format(k) for k in keys]
     join_columns = [
         "attempt.started_at as started_at",
-        "attempt.finished_at as finished_at",
+        """
+        (CASE
+        WHEN attempt.finished_at IS NULL AND {table_name}.last_heartbeat_ts IS NOT NULL
+        THEN {table_name}.last_heartbeat_ts*1000
+        ELSE attempt.finished_at
+        END) as finished_at
+        """.format(table_name=table_name),
         "attempt.attempt_ok as attempt_ok",
         # If 'attempt_ok' is present, we can leave task_ok NULL since
         #   that is used to fetch the artifact value from remote location.

--- a/services/ui_backend_service/tests/integration_tests/status_attempts_test.py
+++ b/services/ui_backend_service/tests/integration_tests/status_attempts_test.py
@@ -322,4 +322,4 @@ async def test_attempt_status_failed_heartbeat(cli, db):
     assert data["status"] == "failed"
     assert data["ts_epoch"] == _task["ts_epoch"]
     assert data["started_at"] == None
-    assert data["finished_at"] == None
+    assert data["finished_at"] == 1000  # last heartbeat in this case

--- a/services/ui_backend_service/tests/integration_tests/tasks_test.py
+++ b/services/ui_backend_service/tests/integration_tests/tasks_test.py
@@ -155,6 +155,7 @@ async def test_task_with_attempt_metadata(cli, db):
 
 async def test_task_failed_status_with_heartbeat(cli, db):
     _task = await create_task(db, last_heartbeat_ts=1, status="failed")
+    _task['finished_at'] = 1000  # should be last heartbeat in this case, due to every other timestamp missing.
     _task['duration'] = _task['last_heartbeat_ts'] * 1000 - _task['ts_epoch']
 
     await _test_list_resources(cli, db, "/flows/{flow_id}/runs/{run_number}/steps/{step_name}/tasks/{task_id}/attempts".format(**_task), 200, [_task])


### PR DESCRIPTION
- uses the last_heartbeat_ts as finished_at timestamp in cases where any other finished timestamp is not available