### PR TITLE
Fix integration tests getting stuck.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,7 +67,7 @@ jobs:
         golang-version: ["^1.14.5"]
 
     env:
-      MF_METADATA_DB_HOST: localhost
+      MF_METADATA_DB_HOST: 127.0.0.1 # localhost won't work here
       MF_METADATA_DB_PORT: 5432
       MF_METADATA_DB_USER: test
       MF_METADATA_DB_PSWD: test

--- a/services/data/postgres_async_db.py
+++ b/services/data/postgres_async_db.py
@@ -68,6 +68,7 @@ class _AsyncPostgresDB(object):
                     db_conf.dsn,
                     minsize=db_conf.pool_min,
                     maxsize=db_conf.pool_max,
+                    timeout=db_conf.timeout,
                     echo=AIOPG_ECHO)
 
                 # Clean existing trigger functions before creating new ones

--- a/services/migration_service/data/postgres_async_db.py
+++ b/services/migration_service/data/postgres_async_db.py
@@ -40,7 +40,7 @@ class AsyncPostgresDB(object):
         retries = 3
         for i in range(retries):
             try:
-                self.pool = await aiopg.create_pool(db_conf.dsn)
+                self.pool = await aiopg.create_pool(db_conf.dsn, timeout=db_conf.timeout)
             except Exception as e:
                 print("printing connection exception: " + str(e))
                 if retries - i < 1:

--- a/services/ui_backend_service/tests/integration_tests/utils.py
+++ b/services/ui_backend_service/tests/integration_tests/utils.py
@@ -51,7 +51,7 @@ def init_app(loop, aiohttp_client, queue_ttl=30):
 
 
 async def init_db(cli):
-    db_conf = DBConfiguration()
+    db_conf = DBConfiguration(timeout=1)
 
     # Make sure migration scripts are applied
     migration_db = MigrationAsyncPostgresDB.get_instance()

--- a/services/utils/__init__.py
+++ b/services/utils/__init__.py
@@ -146,8 +146,10 @@ class DBConfiguration(object):
 
     # aiopg default pool sizes
     # https://aiopg.readthedocs.io/en/stable/_modules/aiopg/pool.html#create_pool
-    pool_min: int = 1
-    pool_max: int = 10
+    pool_min: int = None  # aiopg default: 1
+    pool_max: int = None  # aiopg default: 10
+
+    timeout: int = None  # aiopg default: 60 (seconds)
 
     _dsn: str = None
 
@@ -158,7 +160,10 @@ class DBConfiguration(object):
                  user: str = "postgres",
                  password: str = "postgres",
                  database_name: str = "postgres",
-                 prefix="MF_METADATA_DB_"):
+                 prefix="MF_METADATA_DB_",
+                 pool_min: int = 1,
+                 pool_max: int = 10,
+                 timeout: int = 60):
         table = str.maketrans({"'": "\'", "`": r"\`"})
 
         self._dsn = os.environ.get(prefix + "DSN", dsn)
@@ -171,8 +176,10 @@ class DBConfiguration(object):
         self.database_name = os.environ.get(
             prefix + "NAME", database_name).translate(table)
 
-        self.pool_min = int(os.environ.get(prefix + "POOL_MIN", self.pool_min))
-        self.pool_max = int(os.environ.get(prefix + "POOL_MAX", self.pool_max))
+        self.pool_min = int(os.environ.get(prefix + "POOL_MIN", pool_min))
+        self.pool_max = int(os.environ.get(prefix + "POOL_MAX", pool_max))
+
+        self.timeout = int(os.environ.get(prefix + "TIMEOUT", timeout))
 
     @property
     def dsn(self):


### PR DESCRIPTION
PostgreSQL connection kept timing out (after 60s x3) and the integration job appeared "stuck" due to timeout+retry loop.

For some reason `localhost` stopped working and connecting to `127.0.0.1` seems to fix the problem.