### PR TITLE
Add duration and finished at to running meson runs

### DIFF
--- a/services/data/postgres_async_db.py
+++ b/services/data/postgres_async_db.py
@@ -698,9 +698,16 @@ class AsyncRunTablePostgres(AsyncPostgresTable):
             THEN {table_name}.last_heartbeat_ts*1000-{table_name}.ts_epoch
             WHEN artifacts.ts_epoch IS NOT NULL
             THEN artifacts.ts_epoch - {table_name}.ts_epoch
-            ELSE NULL
+            WHEN {table_name}.last_heartbeat_ts IS NULL
+            AND @(extract(epoch from now())::bigint*1000-{table_name}.ts_epoch)>{cutoff}
+            THEN {cutoff}
+            ELSE @(extract(epoch from now())::bigint*1000-{table_name}.ts_epoch)
         END) AS duration
-        """.format(table_name=table_name)
+        """.format(
+            table_name=table_name,
+            heartbeat_threshold=HEARTBEAT_THRESHOLD,
+            cutoff=OLD_RUN_FAILURE_CUTOFF_TIME
+        )
     ]
     flow_table_name = AsyncFlowTablePostgres.table_name
     _command = """

--- a/services/ui_backend_service/tests/integration_tests/utils.py
+++ b/services/ui_backend_service/tests/integration_tests/utils.py
@@ -262,6 +262,9 @@ async def _test_single_resource(cli, db: AsyncPostgresDB, path: str, expected_st
 
 def _test_dict_approx(actual, expected, approx_keys, threshold=1000):
     "Assert that two dicts are almost equal, allowing for some leeway on specified keys"
+    # NOTE: This is mainly required for testing resources that produce data during query execution. For example
+    # when using extract(epoch from now()) we can not accurately expect what the timestamp returned from the api should be.
+    # TODO: If possible, a less error prone solution would be to somehow mock/freeze the now() on a per-test basis.
     for k, v in actual.items():
         if k in approx_keys:
             assert v == approx(expected[k], rel=threshold)


### PR DESCRIPTION
- adds a duration for running runs that have no datapoints (missing heartbeat) for deducing the duration. Uses current time and run ts_epoch as a failover.
- extend integration test helpers to be able to approximately assert results that are generated during query execution (`extract(epoch from now())`)