### PR TITLE
fix for run_tasks response ordering and query performance

### DIFF
--- a/services/ui_backend_service/api/task.py
+++ b/services/ui_backend_service/api/task.py
@@ -81,7 +81,6 @@ class TaskApi(object):
                                           run_id_key=run_id_key)],
                                   initial_values=[
                                       flow_name, run_id_value],
-                                  initial_order=["attempt_id DESC"],
                                   allowed_order=self._async_table.keys + ["finished_at", "duration", "attempt_id"],
                                   allowed_group=self._async_table.keys,
                                   allowed_filters=self._async_table.keys + ["finished_at", "duration", "attempt_id"],


### PR DESCRIPTION
- removes default attempt_id ordering from run_tasks request as unnecessary/confusing.

The UI performs a sort by `ts_epoch ASC` by default, so in order to experience any performance gains, an index for this should be applied. Something along the lines of
```
CREATE INDEX idx_task_v3_ts_epoch_asc ON tasks_v3 (ts_epoch ASC)
```
add this to the migration service in a separate PR if this proves effective in testing.