### PR TITLE
fix running status task finished_at timestamp

### DIFF
--- a/services/data/postgres_async_db.py
+++ b/services/data/postgres_async_db.py
@@ -894,11 +894,16 @@ class AsyncTaskTablePostgres(AsyncPostgresTable):
         "attempt.started_at as started_at",
         """
         (CASE
-        WHEN attempt.finished_at IS NULL AND {table_name}.last_heartbeat_ts IS NOT NULL
+        WHEN attempt.finished_at IS NULL
+            AND {table_name}.last_heartbeat_ts IS NOT NULL
+            AND @(extract(epoch from now())-{table_name}.last_heartbeat_ts)>{heartbeat_threshold}
         THEN {table_name}.last_heartbeat_ts*1000
         ELSE attempt.finished_at
         END) as finished_at
-        """.format(table_name=table_name),
+        """.format(
+            table_name=table_name,
+            heartbeat_threshold=HEARTBEAT_THRESHOLD
+        ),
         "attempt.attempt_ok as attempt_ok",
         # If 'attempt_ok' is present, we can leave task_ok NULL since
         #   that is used to fetch the artifact value from remote location.

--- a/services/ui_backend_service/tests/integration_tests/tasks_test.py
+++ b/services/ui_backend_service/tests/integration_tests/tasks_test.py
@@ -2,7 +2,7 @@ import pytest
 from .utils import (
     init_app, init_db, clean_db,
     add_flow, add_run, add_step, add_task, add_artifact,
-    _test_list_resources, _test_single_resource, add_metadata
+    _test_list_resources, _test_single_resource, add_metadata, get_heartbeat_ts
 )
 pytestmark = [pytest.mark.integration_tests]
 
@@ -157,6 +157,15 @@ async def test_task_failed_status_with_heartbeat(cli, db):
     _task = await create_task(db, last_heartbeat_ts=1, status="failed")
     _task['finished_at'] = 1000  # should be last heartbeat in this case, due to every other timestamp missing.
     _task['duration'] = _task['last_heartbeat_ts'] * 1000 - _task['ts_epoch']
+
+    await _test_list_resources(cli, db, "/flows/{flow_id}/runs/{run_number}/steps/{step_name}/tasks/{task_id}/attempts".format(**_task), 200, [_task])
+
+
+async def test_task_running_status_with_heartbeat(cli, db):
+    hb_freeze = get_heartbeat_ts()
+    _task = await create_task(db, last_heartbeat_ts=hb_freeze)
+    _task['finished_at'] = None  # should not have a finished at for running tasks.
+    _task['duration'] = hb_freeze * 1000 - _task['ts_epoch']
 
     await _test_list_resources(cli, db, "/flows/{flow_id}/runs/{run_number}/steps/{step_name}/tasks/{task_id}/attempts".format(**_task), 200, [_task])
 


### PR DESCRIPTION
- add integration test coverage for task with running status and heartbeat
- fix issue with task finished_at timestamp query