### PR TITLE
Add tsvector support for tag filtering to improve performance

### DIFF
--- a/services/ui_backend_service/api/run.py
+++ b/services/ui_backend_service/api/run.py
@@ -1,7 +1,7 @@
 from services.data.postgres_async_db import AsyncPostgresDB
 from services.data.db_utils import DBResponse, translate_run_key
 from services.utils import handle_exceptions
-from .utils import find_records, web_response, format_response, builtin_conditions_query, pagination_query
+from .utils import find_records, web_response, format_response
 
 import json
 
@@ -96,27 +96,6 @@ class RunApi(object):
         allowed_order = self._async_table.keys + ["user", "run", "finished_at", "duration", "status"]
         allowed_group = self._async_table.keys + ["user"]
         allowed_filters = self._async_table.keys + ["user", "run", "finished_at", "duration", "status"]
-
-        # JSONB tag filters combined with `ORDER BY` causes performance impact
-        # due to lack of pg statistics on JSONB fields. To battle this, first execute
-        # subquery of ordered list from runs_v3 table in and filter by tags on outer query.
-        # This needs more research in the future to further improve performance.
-        builtin_conditions, _ = builtin_conditions_query(request)
-        has_tag_filter = len([s for s in builtin_conditions if 'tags||system_tags' in s]) > 0
-        if has_tag_filter:
-            _, _, _, order, _, _ = pagination_query(request, allowed_order=allowed_order, allowed_group=[])
-            if len(order) > 0:
-                overwrite_select_from = "(SELECT * FROM runs_v3 {order_by}) AS runs_v3".format(
-                    order_by="ORDER BY {}".format(", ".join(order)) if order else ""
-                )
-
-                return await find_records(request, self._async_table,
-                                          allowed_group=allowed_group,
-                                          allowed_filters=allowed_filters,
-                                          enable_joins=True,
-                                          overwrite_select_from=overwrite_select_from
-                                          )
-
         return await find_records(request, self._async_table,
                                   allowed_order=allowed_order,
                                   allowed_group=allowed_group,

--- a/services/ui_backend_service/tests/unit_tests/utils_test.py
+++ b/services/ui_backend_service/tests/unit_tests/utils_test.py
@@ -157,11 +157,23 @@ def test_builtin_conditions_query_tags_all():
     conditions, values = builtin_conditions_query(request)
 
     assert len(conditions) == 1
-    assert conditions[0] == "tags||system_tags ?& array[%s,%s]"
+    assert conditions[0] == "to_tsvector('simple', (tags||system_tags)) @@ plainto_tsquery('simple', %s)"
 
-    assert len(values) == 2
+    assert len(values) == 1
+    assert values[0] == "foo bar"
+
+
+def test_builtin_conditions_query_tags_one():
+    request = make_mocked_request(
+        'GET', '/runs?_tags=foo')
+
+    conditions, values = builtin_conditions_query(request)
+
+    assert len(conditions) == 1
+    assert conditions[0] == "to_tsvector('simple', (tags||system_tags)) @@ plainto_tsquery('simple', %s)"
+
+    assert len(values) == 1
     assert values[0] == "foo"
-    assert values[1] == "bar"
 
 
 def test_builtin_conditions_query_tags_all_explicit():
@@ -171,11 +183,10 @@ def test_builtin_conditions_query_tags_all_explicit():
     conditions, values = builtin_conditions_query(request)
 
     assert len(conditions) == 1
-    assert conditions[0] == "tags||system_tags ?& array[%s,%s]"
+    assert conditions[0] == "to_tsvector('simple', (tags||system_tags)) @@ plainto_tsquery('simple', %s)"
 
-    assert len(values) == 2
-    assert values[0] == "foo"
-    assert values[1] == "bar"
+    assert len(values) == 1
+    assert values[0] == "foo bar"
 
 
 def test_builtin_conditions_query_tags_any():


### PR DESCRIPTION
Expects index

```CREATE INDEX runs_v3_idx_gin_tags_combined_tsvector ON runs_v3 USING gin (to_tsvector('simple', (tags||system_tags)));```

from PR https://github.com/Netflix/metaflow-service/pull/106