### PR TITLE
Fix task attempts finished_at and duration logic to account for successive attempts

### DIFF
--- a/services/data/postgres_async_db.py
+++ b/services/data/postgres_async_db.py
@@ -948,9 +948,7 @@ class AsyncTaskTablePostgres(AsyncPostgresTable):
         "start.ts_epoch as started_at",
         """
         (CASE
-        WHEN done.ts_epoch IS NULL
-            AND task_ok.ts_epoch IS NULL
-            AND attempt_ok.ts_epoch IS NULL
+        WHEN {finished_at_column} IS NULL
             AND {table_name}.last_heartbeat_ts IS NOT NULL
             AND @(extract(epoch from now())-{table_name}.last_heartbeat_ts)>{heartbeat_threshold}
         THEN {table_name}.last_heartbeat_ts*1000

--- a/services/ui_backend_service/tests/integration_tests/tasks_test.py
+++ b/services/ui_backend_service/tests/integration_tests/tasks_test.py
@@ -430,7 +430,7 @@ async def test_task_attempt_status_running(cli, db):
 #     The timestamp in the heartbeat column for the task if no subsequent attempt is detected
 #     If a subsequent attempt exists, use the start time of the subsequent attempt
 
-async def xtest_task_attempt_status_failed_with_existing_subsequent_attempt(cli, db):
+async def test_task_attempt_status_failed_with_existing_subsequent_attempt(cli, db):
     _task = await create_task(db, last_heartbeat_ts=get_heartbeat_ts())
     _task['duration'] = _task['last_heartbeat_ts'] * 1000 - _task['ts_epoch']
     await _test_list_resources(cli, db, "/flows/{flow_id}/runs/{run_number}/steps/{step_name}/tasks/{task_id}/attempts".format(**_task), 200, [_task])

--- a/services/ui_backend_service/tests/integration_tests/tasks_test.py
+++ b/services/ui_backend_service/tests/integration_tests/tasks_test.py
@@ -451,7 +451,13 @@ async def test_task_attempt_status_failed_with_existing_subsequent_attempt(cli, 
     _second_attempt['attempt_id'] = 1
     _second_attempt['started_at'] = _second_attempt_meta['ts_epoch']
     _second_attempt['duration'] = _second_attempt['last_heartbeat_ts'] * 1000 - _second_attempt['started_at']
+
+    # first attempt should be failed due to second attempt existing.
+    # finished_at timestamp should be the started_at of the second attempt due to it existing.
     _first_attempt['status'] = 'failed'
+    _first_attempt['finished_at'] = _second_attempt['started_at']
+    _first_attempt['duration'] = _first_attempt['finished_at'] - _first_attempt['started_at']
+
     await _test_list_resources(cli, db, "/flows/{flow_id}/runs/{run_number}/steps/{step_name}/tasks/{task_id}/attempts".format(**_task), 200, [_second_attempt, _first_attempt])
 
 


### PR DESCRIPTION
changes task attempt finished_at, status and duration heuristics to account for successive attempts
- if a successive attempt exists, the current attempt status is automatically `failed`
- if no `finished_at` can be determined for current attempt, the `started_at` of the next attempt is used.
- duration is calculated with `finished_at - started_at` always, never relying on task `ts_epoch`