### PR TITLE
Fix/cache improvements

### DIFF
--- a/services/ui_backend_service/data/cache/get_artifacts_action.py
+++ b/services/ui_backend_service/data/cache/get_artifacts_action.py
@@ -109,6 +109,7 @@ class GetArtifacts(CacheAction):
                                 # therefore we do not want to write anything to the cache for these artifacts.
                                 stream_error(str(ex), "artifact-handle-failed", get_traceback_str())
                         else:
+                            # TODO: does this case need to raise an error as well? As is, the fetch simply fails silently.
                             results[artifact_key] = json.dumps([False, 'object is too large'])
                 except MetaflowS3AccessDenied as ex:
                     stream_error(str(ex), "s3-access-denied")
@@ -122,10 +123,8 @@ class GetArtifacts(CacheAction):
                     stream_error(str(ex), "s3-generic-error", get_traceback_str())
         # Skip the inaccessible locations
         other_locations = [loc for loc in locations_to_fetch if not loc.startswith("s3://")]
-        for loc in other_locations:
-            artifact_key = artifact_cache_id(loc)
+        for _ in other_locations:
             stream_error("Artifact is not accessible", "artifact-not-accessible")
-            results[artifact_key] = json.dumps([False, 'object is not accessible'])
 
         return results
 

--- a/services/ui_backend_service/data/cache/get_artifacts_action.py
+++ b/services/ui_backend_service/data/cache/get_artifacts_action.py
@@ -123,8 +123,8 @@ class GetArtifacts(CacheAction):
                     stream_error(str(ex), "s3-generic-error", get_traceback_str())
         # Skip the inaccessible locations
         other_locations = [loc for loc in locations_to_fetch if not loc.startswith("s3://")]
-        for _ in other_locations:
-            stream_error("Artifact is not accessible", "artifact-not-accessible")
+        for loc in other_locations:
+            stream_error("Artifact is not accessible at URL: {}".format(loc), "artifact-not-accessible")
 
         return results
 

--- a/services/ui_backend_service/tests/unit_tests/get_artifacts_action_test.py
+++ b/services/ui_backend_service/tests/unit_tests/get_artifacts_action_test.py
@@ -1,6 +1,6 @@
 import pytest
 
-from services.ui_backend_service.data.cache.get_artifacts_action import lookup_id
+from services.ui_backend_service.data.cache.get_artifacts_action import lookup_id, artifact_cache_id, artifact_location_from_key
 
 pytestmark = [pytest.mark.unit_tests]
 
@@ -11,3 +11,17 @@ async def test_cache_key_independent_of_location_order():
     b = lookup_id(reversed(locs))
 
     assert a == b
+
+
+async def test_artifact_cache_key_and_location_from_key():
+    # first generate an artifact cache key with any location
+    _loc = "s3://test-s3-locations/artifact_location/for/cache/1"
+
+    key = artifact_cache_id(_loc)
+
+    assert _loc in key
+
+    # We need to be able to extract the location from a cache key, to form correctly keyed responses
+    _extracted_loc = artifact_location_from_key(key)
+
+    assert _extracted_loc == _loc


### PR DESCRIPTION
- removes unnecessary result key from get_artifacts cache action. Saves on cache storage space as a result, and should produce less churn on disk as well. get_artifacts results are now compiled in the response function from existing artifact cache keys on-the-fly. Should also improve TaskRefiner performance on websocket broadcasts.
- change to not store any result on failed artifact fetch keys. fixes flaky run parameters fetching behavior for inaccessible locations.
- add unit test to cover artifact location extraction from cache key.