### PR TITLE
Fix: Cleanup error logging in handle_exceptions wrapper and add unit tests

### DIFF
--- a/services/ui_backend_service/tests/integration_tests/grouped_runs_test.py
+++ b/services/ui_backend_service/tests/integration_tests/grouped_runs_test.py
@@ -70,7 +70,7 @@ async def create_n_runs(db, n=1, flow_id="TestFlow", user="TestUser"):
         _run = (await add_run(db, flow_id=flow_id, user_name=user, system_tags=["runtime:dev", "user:{}".format(user)])).body
         _run["run"] = _run["run_number"]
         _run["status"] = "running"
-        _run["duration"] = int(round(time.time() * 1000)) - _run["ts_epoch"]
+        _run["duration"] = max(int(round(time.time() * 1000)) - _run["ts_epoch"], 1)  # approx assert breaks in the odd case when duration==0
         _run["user"] = user
         created_runs.append(_run)
     return created_runs

--- a/services/utils/__init__.py
+++ b/services/utils/__init__.py
@@ -75,10 +75,13 @@ def handle_exceptions(func):
             return await func(*args, **kwargs)
         except Exception as err:
             # pass along an id for the error
-            err_id = getattr(err, 'id', 'generic-error')
+            err_id = getattr(err, 'id', None)
             # either use provided traceback from subprocess, or generate trace from current process
             err_trace = getattr(err, 'traceback_str', None) or get_traceback_str()
-            logging.error(err_trace)
+            if not err_id:
+                # Log error only in case it is not a known case.
+                err_id = 'generic-error'
+                logging.error(err_trace)
             return http_500(str(err), err_id, err_trace)
 
     return wrapper

--- a/services/utils/tests/unit_tests/utils_test.py
+++ b/services/utils/tests/unit_tests/utils_test.py
@@ -1,8 +1,9 @@
 import pytest
 import os
 import contextlib
+import json
 from aiohttp.test_utils import make_mocked_request
-from services.utils import format_qs, format_baseurl, DBConfiguration
+from services.utils import format_qs, format_baseurl, DBConfiguration, handle_exceptions
 
 pytestmark = [pytest.mark.unit_tests]
 
@@ -132,3 +133,38 @@ def test_db_conf_timeout():
     with set_env():
         db_conf = DBConfiguration(timeout=5)
         assert db_conf.timeout == 5
+
+
+async def test_handle_exceptions():
+    class FakeException(Exception):
+        def __init__(self, id, trace):
+            self.id = id
+            self.traceback_str = trace
+
+    @handle_exceptions
+    async def do_not_raise():
+        return True
+
+    @handle_exceptions
+    async def raise_with_id():
+        raise FakeException("test-id", "test-trace")
+
+    @handle_exceptions
+    async def raise_without_id():
+        raise Exception()
+
+    # wrapper should not touch successful calls.
+    assert (await do_not_raise())
+
+    # NOTE: aiohttp Response StringPayload only has the internal property _value for accessing the payload value.
+    response_with_id = await raise_with_id()
+    assert response_with_id.status == 500
+    _body = json.loads(response_with_id.body._value)
+    assert _body['id'] == 'test-id'
+    assert _body['traceback'] == 'test-trace'
+
+    response_without_id = await raise_without_id()
+    assert response_without_id.status == 500
+    _body = json.loads(response_without_id.body._value)
+    assert _body['id'] == 'generic-error'
+    assert _body['traceback'] is not None


### PR DESCRIPTION
- change error logging to only happen for unknown generic errors (exclude errors with a custom error-id from logging)
- add unit tests to cover the handle_exceptions wrapper functionality 
- fix flaky grouped_runs test issue.