### PR TITLE
fix: Enable triggers always and use periodic ping for NOTIFY.

### DIFF
--- a/docker-compose.development.yml
+++ b/docker-compose.development.yml
@@ -43,6 +43,7 @@ services:
       - FEATURE_HEARTBEAT_DISABLE=0
       - FEATURE_DB_LISTEN_DISABLE=0
       - CUSTOM_QUICKLINKS=$CUSTOM_QUICKLINKS
+      - GA_TRACKING_ID=none
     depends_on:
       - db
   metadata:
@@ -86,7 +87,7 @@ services:
       - db
   db:
     image: "postgres:11"
-    command: ["postgres", "-c", "log_statement=none"]
+    command: ["postgres", "-c", "log_statement=mod", "-c", "wal_level=logical"]
     environment:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres

--- a/services/data/postgres_async_db.py
+++ b/services/data/postgres_async_db.py
@@ -422,6 +422,12 @@ class PostgresUtils(object):
             table=table_name,
             events=" OR ".join(operations)
         )]
+        # This enables trigger on both replica and non-replica mode
+        _commands += ["ALTER TABLE {schema}.{table} ENABLE ALWAYS TRIGGER {prefix}_{table};".format(
+            schema=schema,
+            prefix=name_prefix,
+            table=table_name
+        )]
 
         with (await db.pool.cursor()) as cur:
             for _command in _commands:

--- a/services/ui_backend_service/api/config.py
+++ b/services/ui_backend_service/api/config.py
@@ -1,8 +1,6 @@
 import os
 from services.utils import handle_exceptions, web_response
 
-from ..features import get_features
-
 # These environment values will be available to the frontend
 ALLOWED_CONFIG_KEYS = [
     'GA_TRACKING_ID'


### PR DESCRIPTION
This PR is a workaround for PostgreSQL bug in logical replication mode where notifications via triggers were not delivered properly.

Solution here is to manually `NOTIFY ping` channel in intervals so that the main `NOTIFY notify` channel "buffer" is delivered along with the ping channel. It doesn't matter which channel is notified, important thing here is that the notification originates from non-replication source. This bug is present in at least PostgreSQL versions 10 - 13.

`NOTIFY ping` is executed every 1 second, so all replication notifications will be delivered in 1 second intervals in this special use-case.

Read more about the bug here: https://www.postgresql.org/message-id/153243441449.1404.2274116228506175596%40wrigleys.postgresql.org

This PR also enables WAL level `logical` on development mode for any future replication tests.