### PR TITLE
feat: DB table name environment variable configuration

### DIFF
--- a/services/data/postgres_async_db.py
+++ b/services/data/postgres_async_db.py
@@ -213,7 +213,7 @@ class AsyncPostgresTable(object):
                 rows = []
                 records = await cur.fetchall()
                 for record in records:
-                    row = self._row_type(**record)
+                    row = self._row_type(**record)  # pylint: disable=not-callable
                     rows.append(row.serialize(expanded))
 
                 count = len(rows)
@@ -249,7 +249,7 @@ class AsyncPostgresTable(object):
         values.append(get_db_ts_epoch_str())
 
         str_format = []
-        for col in cols:
+        for _ in cols:
             str_format.append("%s")
 
         seperator = ", "
@@ -276,7 +276,7 @@ class AsyncPostgresTable(object):
                 for key, value in record.items():
                     if key in self.keys:
                         filtered_record[key] = value
-                response_body = self._row_type(**filtered_record).serialize()
+                response_body = self._row_type(**filtered_record).serialize()  # pylint: disable=not-callable
                 # todo make sure connection is closed even with error
                 cur.close()
             return DBResponse(response_code=200, body=response_body)
@@ -693,7 +693,6 @@ class AsyncMetadataTablePostgres(AsyncPostgresTable):
     _current_count = 0
     _row_type = MetadataRow
     table_name = METADATA_TABLE_NAME
-    task_table_name = AsyncTaskTablePostgres.table_name
     keys = ["flow_id", "run_number", "run_id", "step_name", "task_id", "task_name", "id",
             "field_name", "value", "type", "user_name", "ts_epoch", "tags", "system_tags"]
     primary_keys = ["flow_id", "run_number",
@@ -719,9 +718,7 @@ class AsyncMetadataTablePostgres(AsyncPostgresTable):
         system_tags JSONB,
         PRIMARY KEY(id, flow_id, run_number, step_name, task_id, field_name)
     )
-    """.format(
-        table_name, task_table_name
-    )
+    """.format(table_name)
 
     async def add_metadata(
         self,
@@ -783,7 +780,6 @@ class AsyncArtifactTablePostgres(AsyncPostgresTable):
     current_count = 0
     _row_type = ArtifactRow
     table_name = ARTIFACT_TABLE_NAME
-    task_table_name = AsyncTaskTablePostgres.table_name
     ordering = ["attempt_id DESC"]
     keys = ["flow_id", "run_number", "run_id", "step_name", "task_id", "task_name", "name", "location",
             "ds_type", "sha", "type", "content_type", "user_name", "attempt_id", "ts_epoch", "tags", "system_tags"]
@@ -813,7 +809,7 @@ class AsyncArtifactTablePostgres(AsyncPostgresTable):
         PRIMARY KEY(flow_id, run_number, step_name, task_id, attempt_id, name)
     )
     """.format(
-        table_name, task_table_name
+        table_name
     )
 
     async def add_artifact(

--- a/services/data/postgres_async_db.py
+++ b/services/data/postgres_async_db.py
@@ -23,6 +23,15 @@ WAIT_TIME = 10
 # Enable with env variable `DB_TRIGGER_CREATE=1`
 DB_TRIGGER_CREATE = os.environ.get("DB_TRIGGER_CREATE", 0) == "1"
 
+# Configure DB Table names. Custom names can be supplied through environment variables,
+# in case the deployment differs from the default naming scheme from the supplied migrations.
+FLOW_TABLE_NAME = os.environ.get("DB_TABLE_NAME_FLOWS", "flows_v3")
+RUN_TABLE_NAME = os.environ.get("DB_TABLE_NAME_RUNS", "runs_v3")
+STEP_TABLE_NAME = os.environ.get("DB_TABLE_NAME_STEPS", "steps_v3")
+TASK_TABLE_NAME = os.environ.get("DB_TABLE_NAME_TASKS", "tasks_v3")
+METADATA_TABLE_NAME = os.environ.get("DB_TABLE_NAME_METADATA", "metadata_v3")
+ARTIFACT_TABLE_NAME = os.environ.get("DB_TABLE_NAME_ARTIFACT", "artifact_v3")
+
 
 class _AsyncPostgresDB(object):
     connection = None
@@ -435,7 +444,6 @@ class PostgresUtils(object):
             cur.close()
 
 
-FLOW_TABLE_NAME = os.environ.get("DB_TABLE_NAME_FLOWS", "flows_v3")
 class AsyncFlowTablePostgres(AsyncPostgresTable):
     flow_dict = {}
     table_name = FLOW_TABLE_NAME
@@ -473,7 +481,6 @@ class AsyncFlowTablePostgres(AsyncPostgresTable):
         return await self.get_records()
 
 
-RUN_TABLE_NAME = os.environ.get("DB_TABLE_NAME_RUNS", "runs_v3")
 class AsyncRunTablePostgres(AsyncPostgresTable):
     run_dict = {}
     run_by_flow_dict = {}
@@ -539,7 +546,6 @@ class AsyncRunTablePostgres(AsyncPostgresTable):
                           body=json.dumps(body))
 
 
-STEP_TABLE_NAME = os.environ.get("DB_TABLE_NAME_STEPS", "steps_v3")
 class AsyncStepTablePostgres(AsyncPostgresTable):
     step_dict = {}
     run_to_step_dict = {}
@@ -597,7 +603,6 @@ class AsyncStepTablePostgres(AsyncPostgresTable):
         return await self.get_records(filter_dict=filter_dict, fetch_single=True)
 
 
-TASK_TABLE_NAME = os.environ.get("DB_TABLE_NAME_TASKS", "tasks_v3")
 class AsyncTaskTablePostgres(AsyncPostgresTable):
     task_dict = {}
     step_to_task_dict = {}
@@ -686,7 +691,6 @@ class AsyncTaskTablePostgres(AsyncPostgresTable):
                           body=json.dumps(body))
 
 
-METADATA_TABLE_NAME = os.environ.get("DB_TABLE_NAME_METADATA", "metadata_v3")
 class AsyncMetadataTablePostgres(AsyncPostgresTable):
     metadata_dict = {}
     run_to_metadata_dict = {}
@@ -771,7 +775,6 @@ class AsyncMetadataTablePostgres(AsyncPostgresTable):
         return await self.get_records(filter_dict=filter_dict)
 
 
-ARTIFACT_TABLE_NAME = os.environ.get("DB_TABLE_NAME_ARTIFACT", "artifact_v3")
 class AsyncArtifactTablePostgres(AsyncPostgresTable):
     artifact_dict = {}
     run_to_artifact_dict = {}

--- a/services/data/postgres_async_db.py
+++ b/services/data/postgres_async_db.py
@@ -435,9 +435,10 @@ class PostgresUtils(object):
             cur.close()
 
 
+FLOW_TABLE_NAME = os.environ.get("DB_TABLE_NAME_FLOWS", "flows_v3")
 class AsyncFlowTablePostgres(AsyncPostgresTable):
     flow_dict = {}
-    table_name = "flows_v3"
+    table_name = FLOW_TABLE_NAME
     keys = ["flow_id", "user_name", "ts_epoch", "tags", "system_tags"]
     primary_keys = ["flow_id"]
     trigger_keys = primary_keys
@@ -472,12 +473,13 @@ class AsyncFlowTablePostgres(AsyncPostgresTable):
         return await self.get_records()
 
 
+RUN_TABLE_NAME = os.environ.get("DB_TABLE_NAME_RUNS", "runs_v3")
 class AsyncRunTablePostgres(AsyncPostgresTable):
     run_dict = {}
     run_by_flow_dict = {}
     _current_count = 0
     _row_type = RunRow
-    table_name = "runs_v3"
+    table_name = RUN_TABLE_NAME
     keys = ["flow_id", "run_number", "run_id",
             "user_name", "ts_epoch", "last_heartbeat_ts", "tags", "system_tags"]
     primary_keys = ["flow_id", "run_number"]
@@ -537,11 +539,12 @@ class AsyncRunTablePostgres(AsyncPostgresTable):
                           body=json.dumps(body))
 
 
+STEP_TABLE_NAME = os.environ.get("DB_TABLE_NAME_STEPS", "steps_v3")
 class AsyncStepTablePostgres(AsyncPostgresTable):
     step_dict = {}
     run_to_step_dict = {}
     _row_type = StepRow
-    table_name = "steps_v3"
+    table_name = STEP_TABLE_NAME
     keys = ["flow_id", "run_number", "run_id", "step_name",
             "user_name", "ts_epoch", "tags", "system_tags"]
     primary_keys = ["flow_id", "run_number", "step_name"]
@@ -594,12 +597,13 @@ class AsyncStepTablePostgres(AsyncPostgresTable):
         return await self.get_records(filter_dict=filter_dict, fetch_single=True)
 
 
+TASK_TABLE_NAME = os.environ.get("DB_TABLE_NAME_TASKS", "tasks_v3")
 class AsyncTaskTablePostgres(AsyncPostgresTable):
     task_dict = {}
     step_to_task_dict = {}
     _current_count = 0
     _row_type = TaskRow
-    table_name = "tasks_v3"
+    table_name = TASK_TABLE_NAME
     keys = ["flow_id", "run_number", "run_id", "step_name", "task_id",
             "task_name", "user_name", "ts_epoch", "last_heartbeat_ts", "tags", "system_tags"]
     primary_keys = ["flow_id", "run_number", "step_name", "task_id"]
@@ -682,12 +686,13 @@ class AsyncTaskTablePostgres(AsyncPostgresTable):
                           body=json.dumps(body))
 
 
+METADATA_TABLE_NAME = os.environ.get("DB_TABLE_NAME_METADATA", "metadata_v3")
 class AsyncMetadataTablePostgres(AsyncPostgresTable):
     metadata_dict = {}
     run_to_metadata_dict = {}
     _current_count = 0
     _row_type = MetadataRow
-    table_name = "metadata_v3"
+    table_name = METADATA_TABLE_NAME
     task_table_name = AsyncTaskTablePostgres.table_name
     keys = ["flow_id", "run_number", "run_id", "step_name", "task_id", "task_name", "id",
             "field_name", "value", "type", "user_name", "ts_epoch", "tags", "system_tags"]
@@ -769,6 +774,7 @@ class AsyncMetadataTablePostgres(AsyncPostgresTable):
         return await self.get_records(filter_dict=filter_dict)
 
 
+ARTIFACT_TABLE_NAME = os.environ.get("DB_TABLE_NAME_ARTIFACT", "artifact_v3")
 class AsyncArtifactTablePostgres(AsyncPostgresTable):
     artifact_dict = {}
     run_to_artifact_dict = {}
@@ -776,7 +782,7 @@ class AsyncArtifactTablePostgres(AsyncPostgresTable):
     task_to_artifact_dict = {}
     current_count = 0
     _row_type = ArtifactRow
-    table_name = "artifact_v3"
+    table_name = ARTIFACT_TABLE_NAME
     task_table_name = AsyncTaskTablePostgres.table_name
     ordering = ["attempt_id DESC"]
     keys = ["flow_id", "run_number", "run_id", "step_name", "task_id", "task_name", "name", "location",

--- a/services/ui_backend_service/api/notify.py
+++ b/services/ui_backend_service/api/notify.py
@@ -3,6 +3,9 @@ import time
 import asyncio
 from typing import Dict, List
 from services.utils import logging
+from services.data.postgres_async_db import (
+    FLOW_TABLE_NAME, RUN_TABLE_NAME, STEP_TABLE_NAME, TASK_TABLE_NAME
+)
 from pyee import AsyncIOEventEmitter
 
 
@@ -129,20 +132,20 @@ class ListenNotify(object):
 
 def resource_list(table_name: str, data: Dict):
     resource_paths = {
-        "flows_v3": [
+        FLOW_TABLE_NAME: [
             "/flows",
             "/flows/{flow_id}"
         ],
-        "runs_v3": [
+        RUN_TABLE_NAME: [
             "/runs",
             "/flows/{flow_id}/runs",
             "/flows/{flow_id}/runs/{run_number}"
         ],
-        "steps_v3": [
+        STEP_TABLE_NAME: [
             "/flows/{flow_id}/runs/{run_number}/steps",
             "/flows/{flow_id}/runs/{run_number}/steps/{step_name}"
         ],
-        "tasks_v3": [
+        TASK_TABLE_NAME: [
             "/flows/{flow_id}/runs/{run_number}/tasks",
             "/flows/{flow_id}/runs/{run_number}/steps/{step_name}/tasks",
             "/flows/{flow_id}/runs/{run_number}/steps/{step_name}/tasks/{task_id}",

--- a/services/ui_backend_service/data/db/tables/run.py
+++ b/services/ui_backend_service/data/db/tables/run.py
@@ -51,15 +51,15 @@ class AsyncRunTablePostgres(AsyncPostgresTable):
         # User should be considered NULL when 'user:*' tag is missing
         # This is usually the case with AWS Step Functions
         return ["{table_name}.{col} AS {col}".format(table_name=self.table_name, col=k) for k in self.keys] \
-        + ["""
-            (CASE
-                WHEN system_tags ? ('user:' || user_name)
-                THEN user_name
-                ELSE NULL
-            END) AS user"""] \
-        + ["""
-            COALESCE({table_name}.run_id, {table_name}.run_number::text) AS run
-            """.format(table_name=self.table_name)]
+            + ["""
+                (CASE
+                    WHEN system_tags ? ('user:' || user_name)
+                    THEN user_name
+                    ELSE NULL
+                END) AS user"""] \
+            + ["""
+                COALESCE({table_name}.run_id, {table_name}.run_number::text) AS run
+                """.format(table_name=self.table_name)]
 
     join_columns = [
         """

--- a/services/ui_backend_service/data/db/tables/step.py
+++ b/services/ui_backend_service/data/db/tables/step.py
@@ -17,7 +17,6 @@ class AsyncStepTablePostgres(AsyncPostgresTable):
     keys = MetadataStepTable.keys
     primary_keys = MetadataStepTable.primary_keys
     trigger_keys = MetadataStepTable.trigger_keys
-    select_columns = ["steps_v3.{0} AS {0}".format(k) for k in keys]
     run_table_name = MetadataRunTable.table_name
     _command = MetadataStepTable._command
     task_table_name = MetadataTaskTable.table_name
@@ -54,7 +53,12 @@ class AsyncStepTablePostgres(AsyncPostgresTable):
             artifact_table=artifact_table_name
         )
     ]
-    select_columns = ["steps_v3.{0} AS {0}".format(k) for k in keys]
+
+    @property
+    def select_columns(self):
+        "We must use a function scope in order to be able to access the table_name variable for list comprehension."
+        return ["{table_name}.{col} AS {col}".format(table_name=self.table_name, col=k) for k in self.keys]
+
     join_columns = [
         """
         GREATEST(

--- a/services/ui_backend_service/data/db/tables/task.py
+++ b/services/ui_backend_service/data/db/tables/task.py
@@ -3,7 +3,11 @@ from .step import AsyncStepTablePostgres
 from ..models import TaskRow
 from services.data.db_utils import DBPagination, DBResponse, translate_run_key, translate_task_key
 # use schema constants from the .data module to keep things consistent
-from services.data.postgres_async_db import AsyncTaskTablePostgres as MetadataTaskTable
+from services.data.postgres_async_db import (
+    AsyncTaskTablePostgres as MetadataTaskTable,
+    AsyncArtifactTablePostgres as MetadataArtifactTable,
+    AsyncMetadataTablePostgres as MetaMetadataTable
+)
 from typing import List, Callable
 import json
 import datetime
@@ -12,6 +16,8 @@ import datetime
 class AsyncTaskTablePostgres(AsyncPostgresTable):
     _row_type = TaskRow
     table_name = MetadataTaskTable.table_name
+    artifact_table = MetadataArtifactTable.table_name
+    metadata_table = MetaMetadataTable.table_name
     keys = MetadataTaskTable.keys
     primary_keys = MetadataTaskTable.primary_keys
     trigger_keys = MetadataTaskTable.trigger_keys
@@ -70,11 +76,16 @@ class AsyncTaskTablePostgres(AsyncPostgresTable):
         )
         """.format(
             table_name=table_name,
-            metadata_table="metadata_v3",
-            artifact_table="artifact_v3"
+            metadata_table=metadata_table,
+            artifact_table=artifact_table
         ),
     ]
-    select_columns = ["tasks_v3.{0} AS {0}".format(k) for k in keys]
+
+    @property
+    def select_columns(self):
+        "We must use a function scope in order to be able to access the table_name variable for list comprehension."
+        return ["{table_name}.{col} AS {col}".format(table_name=self.table_name, col=k) for k in self.keys]
+
     join_columns = [
         "{table_name}.attempt_id as attempt_id".format(table_name=table_name),
         "start.ts_epoch as started_at",
@@ -150,7 +161,9 @@ class AsyncTaskTablePostgres(AsyncPostgresTable):
                            benchmark: bool = False, overwrite_select_from: str = None
                            ) -> (DBResponse, DBPagination):
         if enable_joins:
-            overwrite_select_from = "(SELECT *, UNNEST('{0, 1, 2, 3, 4}'::int[]) as attempt_id FROM tasks_v3) as tasks_v3"
+            # python format strings require double curlies for escaping.
+            overwrite_select_from = "(SELECT *, UNNEST('{{0, 1, 2, 3, 4}}'::int[]) as attempt_id FROM {table_name}) as {table_name}".format(
+                table_name=self.table_name)
             conditions.append("NOT (attempt_id > 0 AND started_at IS NULL AND task_ok IS NULL)")
         return await super().find_records(
             conditions, values, fetch_single,


### PR DESCRIPTION
- Adds possibility to configure custom table names (instead of the default `*_v3` ones) through environment variables.
- cleans up `async_postgres_db` from unused variables and false positive pylint warnings.

Possible environment variables are:
`
DB_TABLE_NAME_FLOWS    
DB_TABLE_NAME_RUNS    
DB_TABLE_NAME_STEPS    
DB_TABLE_NAME_TASKS  
DB_TABLE_NAME_METADATA  
DB_TABLE_NAME_ARTIFACT  
`