### PR TITLE
feat: Autocomplete endpoints for UI

### DIFF
--- a/services/ui_backend_service/api/__init__.py
+++ b/services/ui_backend_service/api/__init__.py
@@ -1,5 +1,6 @@
 # api routes
 from .admin import AdminApi
+from .autocomplete import AutoCompleteApi
 from .artifact import ArtificatsApi
 from .artifactsearch import ArtifactSearchApi
 from .dag import DagApi

--- a/services/ui_backend_service/api/autocomplete.py
+++ b/services/ui_backend_service/api/autocomplete.py
@@ -1,0 +1,53 @@
+from services.utils import handle_exceptions, web_response
+import asyncio
+
+class AutoCompleteApi(object):
+
+    def __init__(self, app, db):
+        self.db = db
+        # Cached resources
+        app.router.add_route("GET", "/autocomplete/tags", self.get_all_tags)
+        app.router.add_route("GET", "/autocomplete/flows", self.get_all_flows)
+        # Non-cached resources
+        app.router.add_route("GET", "/autocomplete/flows/{flow_id}/runs", self.get_runs_for_flow)
+        app.router.add_route("GET", "/autocomplete/flows/{flow_id}/runs/{run_id}/steps", self.get_steps_for_run)
+        self._async_table = self.db.run_table_postgres
+        self.loop = asyncio.get_event_loop()
+        self.loop.create_task(self.setup_tags())
+        self.loop.create_task(self.setup_flows())
+
+    @handle_exceptions
+    async def setup_tags(self):
+        db_response = await self._async_table.get_tags()
+        self.tags = db_response.body
+
+    @handle_exceptions
+    async def setup_flows(self):
+        db_response = await self._async_table.get_field_from(field="flow_id", table="flows_v3")
+        self.flows = db_response.body
+
+    @handle_exceptions
+    async def get_all_tags(self, request):
+        return web_response(200, self.tags)
+
+    @handle_exceptions
+    async def get_all_flows(self, request):
+        return web_response(200, self.flows)
+
+    @handle_exceptions
+    async def get_runs_for_flow(self, request):
+        flowid = request.match_info.get("flow_id")
+        sql_conditions = ["flow_id=%s"]
+        db_response = await self._async_table.get_field_from(field="COALESCE(run_id, run_number::text)", table="runs_v3", conditions=sql_conditions, values=[flowid])
+        return web_response(db_response.response_code, db_response.body)
+
+    @handle_exceptions
+    async def get_steps_for_run(self, request):
+        flowid = request.match_info.get("flow_id")
+        runid = request.match_info.get("run_id")
+        sql_conditions = ["flow_id=%s", "(run_number=%s OR run_id=%s)"]
+
+        db_response = await self._async_table.get_field_from(field="step_name", table="steps_v3", conditions=sql_conditions, values=[flowid, runid, runid])
+        return web_response(db_response.response_code, db_response.body)
+
+    

--- a/services/ui_backend_service/api/autocomplete.py
+++ b/services/ui_backend_service/api/autocomplete.py
@@ -13,11 +13,11 @@ class AutoCompleteApi(object):
     def __init__(self, app, db):
         self.db = db
         # Cached resources
-        app.router.add_route("GET", "/autocomplete/tags", self.get_all_tags)
+        app.router.add_route("GET", "/tags/autocomplete", self.get_all_tags)
         # Non-cached resources
-        app.router.add_route("GET", "/autocomplete/flows", self.get_all_flows)
-        app.router.add_route("GET", "/autocomplete/flows/{flow_id}/runs", self.get_runs_for_flow)
-        app.router.add_route("GET", "/autocomplete/flows/{flow_id}/runs/{run_id}/steps", self.get_steps_for_run)
+        app.router.add_route("GET", "/flows/autocomplete", self.get_all_flows)
+        app.router.add_route("GET", "/flows/{flow_id}/runs/autocomplete", self.get_runs_for_flow)
+        app.router.add_route("GET", "/flows/{flow_id}/runs/{run_id}/steps/autocomplete", self.get_steps_for_run)
         self._flow_table = self.db.flow_table_postgres
         self._run_table = self.db.run_table_postgres
         self._step_table = self.db.step_table_postgres

--- a/services/ui_backend_service/api/autocomplete.py
+++ b/services/ui_backend_service/api/autocomplete.py
@@ -2,7 +2,6 @@ from services.utils import handle_exceptions
 from services.data.db_utils import translate_run_key
 from .utils import format_response, web_response
 import asyncio
-import threading
 
 
 # Interval for refetching tags from database. Tags data is cached since requesting all of them might take a while.

--- a/services/ui_backend_service/api/autocomplete.py
+++ b/services/ui_backend_service/api/autocomplete.py
@@ -18,7 +18,9 @@ class AutoCompleteApi(object):
         app.router.add_route("GET", "/autocomplete/flows", self.get_all_flows)
         app.router.add_route("GET", "/autocomplete/flows/{flow_id}/runs", self.get_runs_for_flow)
         app.router.add_route("GET", "/autocomplete/flows/{flow_id}/runs/{run_id}/steps", self.get_steps_for_run)
-        self._async_table = self.db.run_table_postgres
+        self._flow_table = self.db.flow_table_postgres
+        self._run_table = self.db.run_table_postgres
+        self._step_table = self.db.step_table_postgres
         self.loop = asyncio.get_event_loop()
         self.loop.create_task(self.fill_tags_cache())
 
@@ -30,7 +32,7 @@ class AutoCompleteApi(object):
         '''
         while True:
             # Get all tags taht are mentioned in runs table
-            db_response = await self._async_table.get_tags()
+            db_response = await self._run_table.get_tags()
             if db_response.response_code == 200:
                 self.tags = db_response.body
             # Check tags again after some sleep
@@ -70,7 +72,7 @@ class AutoCompleteApi(object):
                 items:
                     type: string
         """
-        db_response = await self._async_table.get_field_from(field="flow_id", table="flows_v3")
+        db_response = await self._flow_table.get_field_from(field="flow_id")
         return web_response(db_response.response_code, db_response.body)
 
     @handle_exceptions
@@ -91,7 +93,7 @@ class AutoCompleteApi(object):
         """
         flowid = request.match_info.get("flow_id")
         sql_conditions = ["flow_id=%s"]
-        db_response = await self._async_table.get_field_from(field="COALESCE(run_id, run_number::text)", table="runs_v3", conditions=sql_conditions, values=[flowid])
+        db_response = await self._run_table.get_field_from(field="COALESCE(run_id, run_number::text)", conditions=sql_conditions, values=[flowid])
         return web_response(db_response.response_code, db_response.body)
 
     @handle_exceptions
@@ -114,5 +116,5 @@ class AutoCompleteApi(object):
         runid = request.match_info.get("run_id")
         sql_conditions = ["flow_id=%s", "(run_number=%s OR run_id=%s)"]
 
-        db_response = await self._async_table.get_field_from(field="step_name", table="steps_v3", conditions=sql_conditions, values=[flowid, runid, runid])
+        db_response = await self._step_table.get_field_from(field="step_name", conditions=sql_conditions, values=[flowid, runid, runid])
         return web_response(db_response.response_code, db_response.body)

--- a/services/ui_backend_service/api/autocomplete.py
+++ b/services/ui_backend_service/api/autocomplete.py
@@ -22,7 +22,10 @@ class AutoCompleteApi(object):
     @handle_exceptions
     async def setup_tags(self):
         db_response = await self._async_table.get_tags()
-        self.tags = db_response.body
+        
+        if db_response.response_code == 200:
+            self.tags = db_response.body
+
         self.loop.call_later(300, lambda x: self.loop.create_task(self.setup_tags()), self)
 
     @handle_exceptions

--- a/services/ui_backend_service/api/autocomplete.py
+++ b/services/ui_backend_service/api/autocomplete.py
@@ -11,8 +11,8 @@ class AutoCompleteApi(object):
         self.db = db
         # Cached resources
         app.router.add_route("GET", "/autocomplete/tags", self.get_all_tags)
-        app.router.add_route("GET", "/autocomplete/flows", self.get_all_flows)
         # Non-cached resources
+        app.router.add_route("GET", "/autocomplete/flows", self.get_all_flows)
         app.router.add_route("GET", "/autocomplete/flows/{flow_id}/runs", self.get_runs_for_flow)
         app.router.add_route("GET", "/autocomplete/flows/{flow_id}/runs/{run_id}/steps", self.get_steps_for_run)
         self._async_table = self.db.run_table_postgres
@@ -22,23 +22,65 @@ class AutoCompleteApi(object):
     @handle_exceptions
     async def setup_tags(self):
         db_response = await self._async_table.get_tags()
-        
+
         if db_response.response_code == 200:
             self.tags = db_response.body
-
+        # Check tags again in 5 minutes
         self.loop.call_later(300, lambda x: self.loop.create_task(self.setup_tags()), self)
 
     @handle_exceptions
     async def get_all_tags(self, request):
+        """
+        ---
+        description: Get all available tags
+        tags:
+        - Autocomplete
+        produces:
+        - application/json
+        responses:
+            "200":
+                description: Returns string list of all tags
+                type: array
+                items:
+                    type: string
+        """
         return web_response(200, self.tags)
 
     @handle_exceptions
     async def get_all_flows(self, request):
+        """
+        ---
+        description: Get all flow id's as a list
+        tags:
+        - Autocomplete
+        produces:
+        - application/json
+        responses:
+            "200":
+                description: Returns string list of all flow id's
+                type: array
+                items:
+                    type: string
+        """
         db_response = await self._async_table.get_field_from(field="flow_id", table="flows_v3")
         return web_response(db_response.response_code, db_response.body)
 
     @handle_exceptions
     async def get_runs_for_flow(self, request):
+        """
+        ---
+        description: Get all run id's for single flow
+        tags:
+        - Autocomplete
+        produces:
+        - application/json
+        responses:
+            "200":
+                description: Returns string list of run ids
+                type: array
+                items:
+                    type: string
+        """
         flowid = request.match_info.get("flow_id")
         sql_conditions = ["flow_id=%s"]
         db_response = await self._async_table.get_field_from(field="COALESCE(run_id, run_number::text)", table="runs_v3", conditions=sql_conditions, values=[flowid])
@@ -46,6 +88,20 @@ class AutoCompleteApi(object):
 
     @handle_exceptions
     async def get_steps_for_run(self, request):
+        """
+        ---
+        description: Get all step names for single run
+        tags:
+        - Autocomplete
+        produces:
+        - application/json
+        responses:
+            "200":
+                description: Returns string list of step names
+                type: array
+                items:
+                    type: string
+        """
         flowid = request.match_info.get("flow_id")
         runid = request.match_info.get("run_id")
         sql_conditions = ["flow_id=%s", "(run_number=%s OR run_id=%s)"]

--- a/services/ui_backend_service/data/db/tables/base.py
+++ b/services/ui_backend_service/data/db/tables/base.py
@@ -257,10 +257,10 @@ class AsyncPostgresTable(MetadataAsyncPostgresTable):
             self.db.logger.exception("Exception occured")
             return aiopg_exception_handling(error)
 
-    async def get_field_from(self, field: str, table: str, conditions: List[str] = [], values: List[str] = []):
+    async def get_field_from(self, field: str, conditions: List[str] = [], values: List[str] = []):
         sql_template = "SELECT {field_name} FROM {table_name} {conditions}"
         select_sql = sql_template.format(
-            table_name=table,
+            table_name=self.table_name,
             field_name=field,
             conditions=("WHERE {}".format(" AND ".join(conditions)) if conditions else "")
         )

--- a/services/ui_backend_service/data/db/tables/base.py
+++ b/services/ui_backend_service/data/db/tables/base.py
@@ -256,3 +256,29 @@ class AsyncPostgresTable(MetadataAsyncPostgresTable):
         except (Exception, psycopg2.DatabaseError) as error:
             self.db.logger.exception("Exception occured")
             return aiopg_exception_handling(error)
+
+    async def get_field_from(self, field: str, table: str, conditions: List[str] = [], values: List[str] = []):
+        sql_template = "SELECT {field_name} FROM {table_name} {conditions}"
+        select_sql = sql_template.format(
+            table_name=table,
+            field_name=field,
+            conditions=("WHERE {}".format(" AND ".join(conditions)) if conditions else "")
+        )
+
+        try:
+            with (
+                await self.db.pool.cursor(
+                    cursor_factory=psycopg2.extras.DictCursor
+                )
+            ) as cur:
+                await cur.execute(select_sql, values)
+
+                items = []
+                records = await cur.fetchall()
+                for record in records:
+                    items += record
+                cur.close()
+                return DBResponse(response_code=200, body=items)
+        except (Exception, psycopg2.DatabaseError) as error:
+            self.db.logger.exception("Exception occured")
+            return aiopg_exception_handling(error)

--- a/services/ui_backend_service/data/db/tables/base.py
+++ b/services/ui_backend_service/data/db/tables/base.py
@@ -258,7 +258,7 @@ class AsyncPostgresTable(MetadataAsyncPostgresTable):
             return aiopg_exception_handling(error)
 
     async def get_field_from(self, field: str, conditions: List[str] = [], values: List[str] = []):
-        sql_template = "SELECT {field_name} FROM {table_name} {conditions}"
+        sql_template = "SELECT DISTINCT {field_name} FROM {table_name} {conditions}"
         select_sql = sql_template.format(
             table_name=self.table_name,
             field_name=field,

--- a/services/ui_backend_service/tests/integration_tests/autocomplete_test.py
+++ b/services/ui_backend_service/tests/integration_tests/autocomplete_test.py
@@ -23,30 +23,30 @@ async def db(cli):
 
 
 async def test_flows_autocomplete(cli, db):
-    await _test_list_resources(cli, db, '/flows/autocomplete', 200, [], data_field=None)
+    await _test_list_resources(cli, db, '/flows/autocomplete', 200, [])
     await add_flow(db, flow_id="HelloFlow")
-    await _test_list_resources(cli, db, '/flows/autocomplete', 200, ['HelloFlow'], data_field=None)
+    await _test_list_resources(cli, db, '/flows/autocomplete', 200, ['HelloFlow'])
 
 
 async def test_runs_autocomplete(cli, db):
-    await _test_list_resources(cli, db, '/flows/HelloFlow/runs/autocomplete', 200, [], data_field=None)
+    await _test_list_resources(cli, db, '/flows/HelloFlow/runs/autocomplete', 200, [])
     await add_flow(db, flow_id="HelloFlow")
     await add_run(db, flow_id="HelloFlow", run_id="HelloRun")
-    await _test_list_resources(cli, db, '/flows/HelloFlow/runs/autocomplete', 200, ['HelloRun'], data_field=None)
+    await _test_list_resources(cli, db, '/flows/HelloFlow/runs/autocomplete', 200, ['HelloRun'])
 
 
 async def test_steps_autocomplete(cli, db):
     _flow = (await add_flow(db, flow_id="HelloFlow")).body
     _run = (await add_run(db, flow_id=_flow.get("flow_id"))).body
     _step = (await add_step(db, flow_id=_run.get("flow_id"), step_name="end", run_number=_run.get("run_number"), run_id=_run.get("run_id"))).body
-    await _test_list_resources(cli, db, '/flows/{flowid}/runs/{runid}/steps/autocomplete'.format(flowid=_step.get('flow_id'), runid=_step.get('run_number')), 200, [_step.get('step_name')], data_field=None)
+    await _test_list_resources(cli, db, '/flows/{flowid}/runs/{runid}/steps/autocomplete'.format(flowid=_step.get('flow_id'), runid=_step.get('run_number')), 200, [_step.get('step_name')])
 
 
 async def test_tags_autocomplete(cli, db):
-    await _test_list_resources(cli, db, '/tags/autocomplete', 200, [], data_field=None)
+    await _test_list_resources(cli, db, '/tags/autocomplete', 200, [])
     await add_flow(db, flow_id="HelloFlow")
     await add_run(db, flow_id="HelloFlow", run_id="HelloRun", tags=["tag:something"])
     # Manually trigger tag filling function. Usually this would happen in defined interval
     await cli.app.AutoCompleteApi.query_tags()
     # Note that runtime:dev tags gets assigned automatically
-    await _test_list_resources(cli, db, '/tags/autocomplete', 200, ['tag:something', 'runtime:dev'], data_field=None)
+    await _test_list_resources(cli, db, '/tags/autocomplete', 200, ['tag:something', 'runtime:dev'])

--- a/services/ui_backend_service/tests/integration_tests/autocomplete_test.py
+++ b/services/ui_backend_service/tests/integration_tests/autocomplete_test.py
@@ -23,21 +23,30 @@ async def db(cli):
 
 
 async def test_flows_autocomplete(cli, db):
-    await _test_list_resources(cli, db, '/flows/autocomplete', 200, [])
-    _flow = (await add_flow(db, flow_id="HelloFlow")).body
-    await _test_list_resources(cli, db, '/flows/autocomplete', 200, ['HelloFlow'])
+    await _test_list_resources(cli, db, '/flows/autocomplete', 200, [], data_field=None)
+    await add_flow(db, flow_id="HelloFlow")
+    await _test_list_resources(cli, db, '/flows/autocomplete', 200, ['HelloFlow'], data_field=None)
 
 
 async def test_runs_autocomplete(cli, db):
-    await _test_list_resources(cli, db, '/flows/HelloFlow/runs/autocomplete', 200, [])
+    await _test_list_resources(cli, db, '/flows/HelloFlow/runs/autocomplete', 200, [], data_field=None)
     await add_flow(db, flow_id="HelloFlow")
-    _run = (await add_run(db, flow_id="HelloFlow", run_id="HelloRun")).body
-    await _test_list_resources(cli, db, '/flows/HelloFlow/runs/autocomplete', 200, ['HelloRun'])
+    await add_run(db, flow_id="HelloFlow", run_id="HelloRun")
+    await _test_list_resources(cli, db, '/flows/HelloFlow/runs/autocomplete', 200, ['HelloRun'], data_field=None)
 
 
 async def test_steps_autocomplete(cli, db):
-    await _test_list_resources(cli, db, '/flows/HelloFlow/runs/HelloRun/steps/autocomplete', 200, [])
+    _flow = (await add_flow(db, flow_id="HelloFlow")).body
+    _run = (await add_run(db, flow_id=_flow.get("flow_id"))).body
+    _step = (await add_step(db, flow_id=_run.get("flow_id"), step_name="end", run_number=_run.get("run_number"), run_id=_run.get("run_id"))).body
+    await _test_list_resources(cli, db, '/flows/{flowid}/runs/{runid}/steps/autocomplete'.format(flowid=_step.get('flow_id'), runid=_step.get('run_number')), 200, [_step.get('step_name')], data_field=None)
+
+
+async def test_tags_autocomplete(cli, db):
+    await _test_list_resources(cli, db, '/tags/autocomplete', 200, [], data_field=None)
     await add_flow(db, flow_id="HelloFlow")
-    await add_run(db, flow_id="HelloFlow", run_id="HelloRun")
-    _step = (await add_step(db, flow_id="HelloFlow", run_id="HelloRun", step_name="HelloStep")).body
-    await _test_list_resources(cli, db, '/flows/HelloFlow/runs/HelloRun/steps/autocomplete', 200, ['HelloStep'])
+    await add_run(db, flow_id="HelloFlow", run_id="HelloRun", tags=["tag:something"])
+    # Manually trigger tag filling function. Usually this would happen in defined interval
+    await cli.app.AutoCompleteApi.query_tags()
+    # Note that runtime:dev tags gets assigned automatically
+    await _test_list_resources(cli, db, '/tags/autocomplete', 200, ['tag:something', 'runtime:dev'], data_field=None)

--- a/services/ui_backend_service/tests/integration_tests/autocomplete_test.py
+++ b/services/ui_backend_service/tests/integration_tests/autocomplete_test.py
@@ -1,0 +1,43 @@
+import pytest
+from .utils import (
+    init_app, init_db, add_flow, clean_db, _test_list_resources, add_run, add_step
+)
+pytestmark = [pytest.mark.integration_tests]
+
+# Fixtures begin
+
+
+@pytest.fixture
+def cli(loop, aiohttp_client):
+    return init_app(loop, aiohttp_client)
+
+
+@pytest.fixture
+async def db(cli):
+    async_db = await init_db(cli)
+    yield async_db
+    await clean_db(async_db)
+
+
+# Fixtures end
+
+
+async def test_flows_autocomplete(cli, db):
+    await _test_list_resources(cli, db, '/flows/autocomplete', 200, [])
+    _flow = (await add_flow(db, flow_id="HelloFlow")).body
+    await _test_list_resources(cli, db, '/flows/autocomplete', 200, ['HelloFlow'])
+
+
+async def test_runs_autocomplete(cli, db):
+    await _test_list_resources(cli, db, '/flows/HelloFlow/runs/autocomplete', 200, [])
+    await add_flow(db, flow_id="HelloFlow")
+    _run = (await add_run(db, flow_id="HelloFlow", run_id="HelloRun")).body
+    await _test_list_resources(cli, db, '/flows/HelloFlow/runs/autocomplete', 200, ['HelloRun'])
+
+
+async def test_steps_autocomplete(cli, db):
+    await _test_list_resources(cli, db, '/flows/HelloFlow/runs/HelloRun/steps/autocomplete', 200, [])
+    await add_flow(db, flow_id="HelloFlow")
+    await add_run(db, flow_id="HelloFlow", run_id="HelloRun")
+    _step = (await add_step(db, flow_id="HelloFlow", run_id="HelloRun", step_name="HelloStep")).body
+    await _test_list_resources(cli, db, '/flows/HelloFlow/runs/HelloRun/steps/autocomplete', 200, ['HelloStep'])

--- a/services/ui_backend_service/tests/integration_tests/utils.py
+++ b/services/ui_backend_service/tests/integration_tests/utils.py
@@ -12,7 +12,8 @@ from services.utils import DBConfiguration
 from services.ui_backend_service.api import (
     FlowApi, RunApi, StepApi, TaskApi,
     MetadataApi, ArtificatsApi, TagApi,
-    Websocket, AdminApi, FeaturesApi
+    Websocket, AdminApi, FeaturesApi,
+    AutoCompleteApi
 )
 
 from services.ui_backend_service.data.db.models import FlowRow, RunRow, StepRow, TaskRow, MetadataRow, ArtifactRow
@@ -44,6 +45,7 @@ def init_app(loop, aiohttp_client, queue_ttl=30):
     db = AsyncPostgresDB(name='api')
     loop.run_until_complete(db._init(db_conf=db_conf, create_tables=False, create_triggers=False))
 
+    app.AutoCompleteApi = AutoCompleteApi(app, db)
     FlowApi(app, db)
     RunApi(app, db)
     StepApi(app, db)
@@ -239,10 +241,10 @@ def _fill_missing_resource_data(_item):
     return _item
 
 
-async def _test_list_resources(cli, db: AsyncPostgresDB, path: str, expected_status=200, expected_data=[], approx_keys=None):
+async def _test_list_resources(cli, db: AsyncPostgresDB, path: str, expected_status=200, expected_data=[], approx_keys=None, data_field="data"):
     resp = await cli.get(path)
     body = await resp.json()
-    data = body.get("data")
+    data = body.get(data_field) if data_field != None else body
 
     if not expected_status:
         return resp.status, data

--- a/services/ui_backend_service/ui_server.py
+++ b/services/ui_backend_service/ui_server.py
@@ -70,6 +70,7 @@ def app(loop=None, db_conf: DBConfiguration = None):
         loop.run_until_complete(async_db_ws._init(db_conf))
         Websocket(app, db=async_db_ws, event_emitter=event_emitter, cache=cache_store)
 
+    AutoCompleteApi(app, async_db)
     FlowApi(app, async_db)
     RunApi(app, async_db, cache_store)
     StepApi(app, async_db)
@@ -80,7 +81,6 @@ def app(loop=None, db_conf: DBConfiguration = None):
     ArtifactSearchApi(app, async_db, cache_store)
     DagApi(app, async_db, cache_store)
     FeaturesApi(app)
-    AutoCompleteApi(app, async_db)
     ConfigApi(app)
 
     LogApi(app, async_db)

--- a/services/ui_backend_service/ui_server.py
+++ b/services/ui_backend_service/ui_server.py
@@ -7,7 +7,7 @@ from aiohttp_swagger import *
 
 # routes
 from .api import (
-    AdminApi, FlowApi, RunApi, StepApi, TaskApi,
+    AdminApi, FlowApi, RunApi, StepApi, TaskApi, AutoCompleteApi,
     MetadataApi, ArtificatsApi, TagApi, ArtifactSearchApi,
     LogApi, DagApi, FeaturesApi, ConfigApi
 )
@@ -80,6 +80,7 @@ def app(loop=None, db_conf: DBConfiguration = None):
     ArtifactSearchApi(app, async_db, cache_store)
     DagApi(app, async_db, cache_store)
     FeaturesApi(app)
+    AutoCompleteApi(app, async_db)
     ConfigApi(app)
 
     LogApi(app, async_db)


### PR DESCRIPTION
Draft for autocomplete

Autocomplete endpoints:
/autocomplete/tags
/autocomplete/flows
/autocomplete/flows/:flowname/runs
/autocomplete/flows/:flowname/runs/:runid/step

Result for tags endpoint is cached within class and refreshed every 5min since this request might be rather slow to database.