### PR TITLE
refactor: Introduce ParameterRefiner to refine Run parameters.

### DIFF
--- a/services/ui_backend_service/api/heartbeat_monitor.py
+++ b/services/ui_backend_service/api/heartbeat_monitor.py
@@ -146,7 +146,7 @@ class TaskHeartbeatMonitor(HeartbeatMonitor):
         )
         # Table for data fetching for load_and_broadcast and add_to_watch
         self._task_table = self.db.task_table_postgres
-        self.refiner = TaskRefiner(cache=self.cache.artifact_cache if cache else None)
+        self.refiner = TaskRefiner(cache=self.cache.artifact_cache) if cache else None
 
     async def heartbeat_handler(self, action, data):
         if action == "update":

--- a/services/ui_backend_service/api/heartbeat_monitor.py
+++ b/services/ui_backend_service/api/heartbeat_monitor.py
@@ -146,7 +146,7 @@ class TaskHeartbeatMonitor(HeartbeatMonitor):
         )
         # Table for data fetching for load_and_broadcast and add_to_watch
         self._task_table = self.db.task_table_postgres
-        self.refiner = TaskRefiner(cache=self.cache)
+        self.refiner = TaskRefiner(cache=self.cache.artifact_cache if cache else None)
 
     async def heartbeat_handler(self, action, data):
         if action == "update":

--- a/services/ui_backend_service/api/task.py
+++ b/services/ui_backend_service/api/task.py
@@ -28,7 +28,7 @@ class TaskApi(object):
             self.get_task_attempts,
         )
         self._async_table = self.db.task_table_postgres
-        self.refiner = TaskRefiner(cache=cache.artifact_cache if cache else None)
+        self.refiner = TaskRefiner(cache=cache.artifact_cache) if cache else None
 
     @handle_exceptions
     async def get_run_tasks(self, request):

--- a/services/ui_backend_service/api/task.py
+++ b/services/ui_backend_service/api/task.py
@@ -28,7 +28,7 @@ class TaskApi(object):
             self.get_task_attempts,
         )
         self._async_table = self.db.task_table_postgres
-        self.refiner = TaskRefiner(cache=cache)
+        self.refiner = TaskRefiner(cache=cache.artifact_cache if cache else None)
 
     @handle_exceptions
     async def get_run_tasks(self, request):

--- a/services/ui_backend_service/api/ws.py
+++ b/services/ui_backend_service/api/ws.py
@@ -50,7 +50,7 @@ class Websocket(object):
         self.event_emitter = event_emitter or AsyncIOEventEmitter()
         self.db = db
         self.queue = TTLQueue(queue_ttl)
-        self.task_refiner = TaskRefiner(cache=cache) if cache else None
+        self.task_refiner = TaskRefiner(cache=cache.artifact_cache) if cache else None
         self.logger = logging.getLogger("Websocket")
 
         event_emitter.on('notify', self.event_handler)

--- a/services/ui_backend_service/data/cache/store.py
+++ b/services/ui_backend_service/data/cache/store.py
@@ -71,12 +71,12 @@ class ArtifactCacheStore(object):
 
     async def preload_initial_data(self):
         "Preloads some data on cache startup"
-        recent_run_ids = await self.get_recent_run_numbers()
-        await self.preload_data_for_runs(recent_run_ids)
+        recent_run_numbers = await self._run_table.get_recent_run_numbers()
+        await self.preload_data_for_runs(recent_run_numbers)
 
-    async def preload_data_for_runs(self, run_ids):
+    async def preload_data_for_runs(self, run_numbers):
         "preloads artifact data for given run ids. Can be used to prefetch artifacts for newly generated runs"
-        artifact_locations = await self.get_artifact_locations_for_run_ids(run_ids)
+        artifact_locations = await self._artifact_table.get_artifact_locations_for_run_numbers(run_numbers)
 
         logger.info("preloading {} artifacts".format(len(artifact_locations)))
 
@@ -86,12 +86,6 @@ class ArtifactCacheStore(object):
                 logger.error(event)
             else:
                 logger.info(event)
-
-    async def get_recent_run_numbers(self):
-        return await self._run_table.get_recent_run_numbers()
-
-    async def get_artifact_locations_for_run_ids(self, run_ids=[]):
-        return await self._artifact_table.get_artifact_locations_for_run_ids(run_ids)
 
     async def get_run_parameters(self, flow_name, run_number):
         '''Fetches run parameter artifact locations,
@@ -129,9 +123,9 @@ class ArtifactCacheStore(object):
         except:
             logger.error("Run parameter fetching failed")
 
-    async def preload_event_handler(self, run_id):
+    async def preload_event_handler(self, run_number):
         "Handler for event-emitter for preloading artifacts for a run id"
-        asyncio.run_coroutine_threadsafe(self.preload_data_for_runs([run_id]), self.loop)
+        asyncio.run_coroutine_threadsafe(self.preload_data_for_runs([run_number]), self.loop)
 
     async def stop_cache(self):
         await self.cache.stop()

--- a/services/ui_backend_service/data/cache/store.py
+++ b/services/ui_backend_service/data/cache/store.py
@@ -1,9 +1,9 @@
 from .generate_dag_action import GenerateDag
-from services.data.db_utils import translate_run_key
 from pyee import AsyncIOEventEmitter
 from metaflow.client.cache.cache_async_client import CacheAsyncClient
 from .search_artifacts_action import SearchArtifacts
 from .get_artifacts_action import GetArtifacts
+from ..refiner.parameter_refiner import ParameterRefiner, GetParametersFailed
 import asyncio
 import time
 import os
@@ -41,11 +41,6 @@ class CacheStore(object):
         await self.dag_cache.stop_cache()
 
 
-# Prefetch runs since 2 days ago (in seconds), limit maximum of 50 runs
-METAFLOW_ARTIFACT_PREFETCH_RUNS_SINCE = os.environ.get('PREFETCH_RUNS_SINCE', 86400 * 2)
-METAFLOW_ARTIFACT_PREFETCH_RUNS_LIMIT = os.environ.get('PREFETCH_RUNS_LIMIT', 50)
-
-
 class ArtifactCacheStore(object):
     def __init__(self, event_emitter, db):
         self.event_emitter = event_emitter or AsyncIOEventEmitter()
@@ -53,6 +48,8 @@ class ArtifactCacheStore(object):
         self._run_table = db.run_table_postgres
         self.cache = None
         self.loop = asyncio.get_event_loop()
+
+        self.parameter_refiner = ParameterRefiner(cache=self)
 
         # Bind an event handler for when we want to preload artifacts for
         # newly inserted content.
@@ -91,33 +88,10 @@ class ArtifactCacheStore(object):
                 logger.info(event)
 
     async def get_recent_run_numbers(self):
-        _records, *_ = await self._run_table.find_records(
-            conditions=["ts_epoch >= %s"],
-            values=[int(round(time.time() * 1000)) - (int(METAFLOW_ARTIFACT_PREFETCH_RUNS_SINCE) * 1000)],
-            order=['ts_epoch DESC'],
-            limit=METAFLOW_ARTIFACT_PREFETCH_RUNS_LIMIT,
-            expanded=True
-        )
-
-        return [run['run_number'] for run in _records.body]
+        return await self._run_table.get_recent_run_numbers()
 
     async def get_artifact_locations_for_run_ids(self, run_ids=[]):
-        # do not touch DB if no run_ids were given.
-        if len(run_ids) == 0:
-            return []
-        # run_numbers are bigint, so cast the conditions array to the correct type.
-        run_id_cond = "run_number = ANY (array[%s]::bigint[])"
-
-        artifact_loc_cond = "ds_type = %s"
-        artifact_loc = "s3"
-        _records, *_ = await self._artifact_table.find_records(
-            conditions=[run_id_cond, artifact_loc_cond],
-            values=[run_ids, artifact_loc],
-            expanded=True
-        )
-
-        # be sure to return a list of unique locations
-        return list(frozenset(artifact['location'] for artifact in _records.body if 'location' in artifact))
+        return await self._artifact_table.get_artifact_locations_for_run_ids(run_ids)
 
     async def get_run_parameters(self, flow_name, run_number):
         '''Fetches run parameter artifact locations,
@@ -126,65 +100,21 @@ class ArtifactCacheStore(object):
 
         Returns
         -------
-        [
-            {
-                "name": "name_of_parameter",
-                "value": "value-of-parameter-as-string"
+        {
+            "name_of_parameter": {
+                "value": "value_of_parameter"
             }
-        ]
+        }
         OR None
         '''
-        run_id_key, run_id_value = translate_run_key(run_number)
+        db_response, *_ = await self._artifact_table.get_run_parameter_artifacts(flow_name, run_number)
 
-        # '_parameters' step has all the parameters as artifacts. only pick the
-        # public parameters (no underscore prefix)
-        db_response, *_ = await self._artifact_table.find_records(
-            conditions=[
-                "flow_id = %s",
-                "{run_id_key} = %s".format(run_id_key=run_id_key),
-                "step_name = %s",
-                "name NOT LIKE %s",
-                "name <> %s",
-                "name <> %s"
-            ],
-            values=[
-                flow_name,
-                run_id_value,
-                "_parameters",
-                r"\_%",
-                "name",  # exclude the 'name' parameter as this always exists, and contains the FlowName
-                "script_name"  # exclude the internally used 'script_name' parameter.
-            ],
-            fetch_single=False,
-            expanded=True
-        )
         # Return nothing if params artifacts were not found.
         if not db_response.response_code == 200:
             return None
 
-        if FEATURE_PREFETCH_ENABLE and FEATURE_REFINE_ENABLE:
-            # Fetch the values for the given parameters through the cache client.
-            locations = [art["location"] for art in db_response.body if "location" in art]
-            _params = await self.cache.GetArtifacts(locations)
-            if not _params.is_ready():
-                async for event in _params.stream():
-                    if event["type"] == "error":
-                        # raise error, there was an exception during processing.
-                        raise GetParametersFailed(event["message"], event["id"], event["traceback"])
-                await _params.wait()  # wait until results are ready
-            _params = _params.get()
-        else:
-            _params = []
-
-        combined_results = {}
-        for art in db_response.body:
-            if "location" in art and art["location"] in _params:
-                key = art["name"]
-                combined_results[key] = {
-                    "value": _params[art["location"]]
-                }
-
-        return combined_results
+        refined_response = await self.parameter_refiner.postprocess(db_response)
+        return refined_response.body
 
     async def run_parameters_event_handler(self, flow_id, run_number):
         try:
@@ -222,13 +152,3 @@ class DAGCacheStore(object):
 
     async def stop_cache(self):
         await self.cache.stop()
-
-
-class GetParametersFailed(Exception):
-    def __init__(self, msg="Failed to Get Parameters", id="failed-to-get-parameters", traceback_str=None):
-        self.message = msg
-        self.id = id
-        self.traceback_str = traceback_str
-
-    def __str__(self):
-        return self.message

--- a/services/ui_backend_service/data/db/tables/artifact.py
+++ b/services/ui_backend_service/data/db/tables/artifact.py
@@ -17,9 +17,9 @@ class AsyncArtifactTablePostgres(AsyncPostgresTable):
     select_columns = keys
     _command = MetadataArtifactTable._command
 
-    async def get_artifact_locations_for_run_ids(self, run_ids=[]):
-        # do not touch DB if no run_ids were given.
-        if len(run_ids) == 0:
+    async def get_artifact_locations_for_run_numbers(self, run_numbers=[]):
+        # do not touch DB if no run_numbers were given.
+        if len(run_numbers) == 0:
             return []
         # run_numbers are bigint, so cast the conditions array to the correct type.
         run_id_cond = "run_number = ANY (array[%s]::bigint[])"
@@ -28,7 +28,7 @@ class AsyncArtifactTablePostgres(AsyncPostgresTable):
         artifact_loc = "s3"
         _records, *_ = await self.find_records(
             conditions=[run_id_cond, artifact_loc_cond],
-            values=[run_ids, artifact_loc],
+            values=[run_numbers, artifact_loc],
             expanded=True
         )
 

--- a/services/ui_backend_service/data/db/tables/artifact.py
+++ b/services/ui_backend_service/data/db/tables/artifact.py
@@ -35,7 +35,7 @@ class AsyncArtifactTablePostgres(AsyncPostgresTable):
         # be sure to return a list of unique locations
         return list(frozenset(artifact['location'] for artifact in _records.body if 'location' in artifact))
 
-    async def get_run_parameter_artifacts(self, flow_name, run_number):
+    async def get_run_parameter_artifacts(self, flow_name, run_number, postprocess=None):
         run_id_key, run_id_value = translate_run_key(run_number)
 
         # '_parameters' step has all the parameters as artifacts. only pick the
@@ -58,5 +58,6 @@ class AsyncArtifactTablePostgres(AsyncPostgresTable):
                 "script_name"  # exclude the internally used 'script_name' parameter.
             ],
             fetch_single=False,
-            expanded=True
+            expanded=True,
+            postprocess=postprocess
         )

--- a/services/ui_backend_service/data/db/tables/artifact.py
+++ b/services/ui_backend_service/data/db/tables/artifact.py
@@ -3,6 +3,7 @@ from .task import AsyncTaskTablePostgres
 from ..models import ArtifactRow
 # use schema constants from the .data module to keep things consistent
 from services.data.postgres_async_db import AsyncArtifactTablePostgres as MetadataArtifactTable
+from services.data.db_utils import translate_run_key
 
 
 class AsyncArtifactTablePostgres(AsyncPostgresTable):
@@ -15,3 +16,47 @@ class AsyncArtifactTablePostgres(AsyncPostgresTable):
     trigger_keys = MetadataArtifactTable.trigger_keys
     select_columns = keys
     _command = MetadataArtifactTable._command
+
+    async def get_artifact_locations_for_run_ids(self, run_ids=[]):
+        # do not touch DB if no run_ids were given.
+        if len(run_ids) == 0:
+            return []
+        # run_numbers are bigint, so cast the conditions array to the correct type.
+        run_id_cond = "run_number = ANY (array[%s]::bigint[])"
+
+        artifact_loc_cond = "ds_type = %s"
+        artifact_loc = "s3"
+        _records, *_ = await self.find_records(
+            conditions=[run_id_cond, artifact_loc_cond],
+            values=[run_ids, artifact_loc],
+            expanded=True
+        )
+
+        # be sure to return a list of unique locations
+        return list(frozenset(artifact['location'] for artifact in _records.body if 'location' in artifact))
+
+    async def get_run_parameter_artifacts(self, flow_name, run_number):
+        run_id_key, run_id_value = translate_run_key(run_number)
+
+        # '_parameters' step has all the parameters as artifacts. only pick the
+        # public parameters (no underscore prefix)
+        return await self.find_records(
+            conditions=[
+                "flow_id = %s",
+                "{run_id_key} = %s".format(run_id_key=run_id_key),
+                "step_name = %s",
+                "name NOT LIKE %s",
+                "name <> %s",
+                "name <> %s"
+            ],
+            values=[
+                flow_name,
+                run_id_value,
+                "_parameters",
+                r"\_%",
+                "name",  # exclude the 'name' parameter as this always exists, and contains the FlowName
+                "script_name"  # exclude the internally used 'script_name' parameter.
+            ],
+            fetch_single=False,
+            expanded=True
+        )

--- a/services/ui_backend_service/data/refiner/__init__.py
+++ b/services/ui_backend_service/data/refiner/__init__.py
@@ -1,1 +1,2 @@
 from .task_refiner import TaskRefiner
+from .parameter_refiner import ParameterRefiner

--- a/services/ui_backend_service/data/refiner/parameter_refiner.py
+++ b/services/ui_backend_service/data/refiner/parameter_refiner.py
@@ -1,0 +1,57 @@
+from .refinery import Refinery
+from services.data.db_utils import DBResponse
+from functools import reduce
+
+
+class ParameterRefiner(Refinery):
+    """
+    Refiner class for postprocessing artifact rows and extracting parameters.
+
+    Fetches specified content from S3 and cleans up unnecessary fields from response.
+
+    Parameters:
+    -----------
+    cache: An instance of a cache that has the required cache accessors.
+    """
+
+    def __init__(self, cache):
+        super().__init__(field_names=['location'], cache=cache)
+
+    async def fetch_data(self, locations):
+        _res = await self.artifact_store.cache.GetArtifacts(locations)
+        if not _res.is_ready():
+            async for event in _res.stream():
+                if event["type"] == "error":
+                    # raise error, there was an exception during processing.
+                    raise GetParametersFailed(event["message"], event["id"], event["traceback"])
+            await _res.wait()  # wait for results to be ready
+        return _res.get() or {}  # cache get() might return None if no keys are produced.
+
+    async def postprocess(self, response: DBResponse):
+        """Calls the refiner postprocessing to fetch S3 values for content."""
+        refined_response = await self._postprocess(response)
+        if response.response_code != 200 or not response.body:
+            return DBResponse(response_code=response.response_code, body={})
+
+        if not isinstance(refined_response.body, list):
+            refined_response.body = [refined_response.body]
+
+        parameters = dict(
+            (artifact.get('name', None), {'value': artifact.get('location', None)})
+            for artifact in refined_response.body
+        )
+
+        return DBResponse(
+            response_code=refined_response.response_code,
+            body=parameters if parameters else {}
+        )
+
+
+class GetParametersFailed(Exception):
+    def __init__(self, msg="Failed to Get Parameters", id="failed-to-get-parameters", traceback_str=None):
+        self.message = msg
+        self.id = id
+        self.traceback_str = traceback_str
+
+    def __str__(self):
+        return self.message

--- a/services/ui_backend_service/data/refiner/refinery.py
+++ b/services/ui_backend_service/data/refiner/refinery.py
@@ -11,11 +11,11 @@ class Refinery(object):
     Parameters:
     -----------
     field_names: list of field names that contain S3 locations to be replaced with content.
-    cache: An instance of a cache that has the required cache accessors.
+    cache: An instance of a ArtifactCacheStore that has the required cache accessors.
     """
 
     def __init__(self, field_names, cache=None):
-        self.artifact_store = cache.artifact_cache if cache else None
+        self.artifact_store = cache if cache else None
         self.field_names = field_names
         self.logger = logging.getLogger("DataRefiner")
 

--- a/services/ui_backend_service/tests/integration_tests/utils.py
+++ b/services/ui_backend_service/tests/integration_tests/utils.py
@@ -7,6 +7,7 @@ import datetime
 import contextlib
 
 from services.ui_backend_service.data.db import AsyncPostgresDB
+from services.ui_backend_service.data.cache.store import CacheStore
 from services.utils import DBConfiguration
 
 from services.ui_backend_service.api import (
@@ -44,10 +45,12 @@ def init_app(loop, aiohttp_client, queue_ttl=30):
     db = AsyncPostgresDB(name='api')
     loop.run_until_complete(db._init(db_conf=db_conf, create_tables=False, create_triggers=False))
 
+    cache_store = CacheStore(db=db, event_emitter=app.event_emitter)
+
     FlowApi(app, db)
     RunApi(app, db)
     StepApi(app, db)
-    TaskApi(app, db)
+    TaskApi(app, db, cache_store)
     MetadataApi(app, db)
     ArtificatsApi(app, db)
     TagApi(app, db)


### PR DESCRIPTION
- Introduces new `ParameterRefiner`
- `ParameterRefiner` is now used in `ArtifactCacheStore`
   - `GET /flows/{flow_id}/runs/{run_number}/parameters` uses `ArtifactCacheStore` internally
- `CacheStore` table -specific logic moved under `ui_service_backend/data/db/tables/`.