### PR TITLE
refactor: move logic from heartbeat classes to db adapter and improve run heartbeat monitoring.

### DIFF
--- a/services/data/postgres_async_db.py
+++ b/services/data/postgres_async_db.py
@@ -490,7 +490,7 @@ class AsyncRunTablePostgres(AsyncPostgresTable):
     keys = ["flow_id", "run_number", "run_id",
             "user_name", "ts_epoch", "last_heartbeat_ts", "tags", "system_tags"]
     primary_keys = ["flow_id", "run_number"]
-    trigger_keys = primary_keys
+    trigger_keys = primary_keys + ["last_heartbeat_ts"]
     select_columns = keys
     flow_table_name = AsyncFlowTablePostgres.table_name
     _command = """

--- a/services/ui_backend_service/api/heartbeat_monitor.py
+++ b/services/ui_backend_service/api/heartbeat_monitor.py
@@ -3,7 +3,6 @@ import datetime
 from typing import Dict, Callable, Optional
 
 from pyee import AsyncIOEventEmitter
-from services.data.db_utils import translate_run_key, translate_task_key
 
 from ..data.db.tables.base import HEARTBEAT_THRESHOLD
 from ..data.refiner import TaskRefiner

--- a/services/ui_backend_service/api/heartbeat_monitor.py
+++ b/services/ui_backend_service/api/heartbeat_monitor.py
@@ -186,7 +186,8 @@ class TaskHeartbeatMonitor(HeartbeatMonitor):
         Parameters
         ----------
         action : str
-            'update' or 'complete' depending on whether
+            'update' or 'complete' depending on if we want to update(or add) an existing heartbeat,
+            or remove one from monitoring after completion.
         data : Dict
             The task object that the heartbeat event relates to.
         """

--- a/services/ui_backend_service/api/heartbeat_monitor.py
+++ b/services/ui_backend_service/api/heartbeat_monitor.py
@@ -57,15 +57,17 @@ class HeartbeatMonitor(object):
         self.watched.pop(key, None)
 
     async def load_and_broadcast(self, key):
-        '''Triggered when a heartbeat for a key has expired.
-        Loads object based on key from watchlist, and broadcasts content to listeners.'''
+        """
+        Triggered when a heartbeat for a key has expired.
+        Loads object based on key from watchlist, and broadcasts content to listeners.
+        """
         raise NotImplementedError
 
     async def check_heartbeats(self):
-        '''
+        """
         Async Task that is responsible for checking the heartbeats of all monitored runs,
         and triggering handlers in case the heartbeat is too old.
-        '''
+        """
         while True:
             time_now = int(datetime.datetime.utcnow().timestamp())  # same format as the metadata heartbeat uses
             for key, hb in list(self.watched.items()):
@@ -77,7 +79,7 @@ class HeartbeatMonitor(object):
 
 
 class RunHeartbeatMonitor(HeartbeatMonitor):
-    '''
+    """
     Service class for adding objects with heartbeat timestamps to be monitored and acted upon
     when heartbeat becomes too old.
 
@@ -88,7 +90,7 @@ class RunHeartbeatMonitor(HeartbeatMonitor):
     Responds to event_emitter emissions with messages:
       "run-heartbeat", "update", run_id -> updates heartbeat timestamp that is found in database
       "run-heartbeat", "complete" run_id -> removes run from heartbeat checks
-    '''
+    """
 
     def __init__(self, event_emitter=None, db=None):
         # Init the abstract class
@@ -144,7 +146,7 @@ class RunHeartbeatMonitor(HeartbeatMonitor):
 
 
 class TaskHeartbeatMonitor(HeartbeatMonitor):
-    '''
+    """
     Service class for adding objects with heartbeat timestamps to be monitored and acted upon
     when heartbeat becomes too old.
 
@@ -155,7 +157,7 @@ class TaskHeartbeatMonitor(HeartbeatMonitor):
     Responds to event_emitter emissions with messages:
       "task-heartbeat", "update", data -> updates heartbeat timestamp that is found in database
       "task-heartbeat", "complete" data -> removes task from heartbeat checks
-    '''
+    """
 
     def __init__(self, event_emitter=None, db=None, cache=None):
         # Init the abstract class

--- a/services/ui_backend_service/api/notify.py
+++ b/services/ui_backend_service/api/notify.py
@@ -81,7 +81,7 @@ class ListenNotify(object):
 
                 # Heartbeat watcher for Runs.
                 if table.table_name == self.db.run_table_postgres.table_name:
-                    self.event_emitter.emit('run-heartbeat', 'update', data['run_number'])
+                    self.event_emitter.emit('run-heartbeat', 'update', data)
 
                 # Heartbeat watcher for Tasks.
                 if table.table_name == self.db.task_table_postgres.table_name:
@@ -139,7 +139,7 @@ class ListenNotify(object):
                         # Also trigger preload of artifacts after a run finishes.
                         self.event_emitter.emit("preload-artifacts", data['run_number'])
                         # And remove possible heartbeat watchers for completed runs
-                        self.event_emitter.emit("run-heartbeat", "complete", data['run_number'])
+                        self.event_emitter.emit("run-heartbeat", "complete", data)
 
         except Exception:
             self.logger.exception("Exception occurred")

--- a/services/ui_backend_service/api/ws.py
+++ b/services/ui_backend_service/api/ws.py
@@ -148,7 +148,8 @@ class Websocket(object):
                 filter(lambda s: ws != s.ws, self.subscriptions))
 
     async def handle_disconnect(self, ws):
-        """Sets disconnected timestamp on websocket subscription without removing it from the list.
+        """
+        Sets disconnected timestamp on websocket subscription without removing it from the list.
         Removing is handled by event_handler that checks for expired subscriptions before emitting
         """
         self.subscriptions = list(

--- a/services/ui_backend_service/data/db/tables/run.py
+++ b/services/ui_backend_service/data/db/tables/run.py
@@ -1,4 +1,5 @@
 import os
+import time
 from .base import AsyncPostgresTable, HEARTBEAT_THRESHOLD, OLD_RUN_FAILURE_CUTOFF_TIME, WAIT_TIME
 from .flow import AsyncFlowTablePostgres
 from ..models import RunRow

--- a/services/ui_backend_service/data/db/tables/run.py
+++ b/services/ui_backend_service/data/db/tables/run.py
@@ -138,11 +138,19 @@ class AsyncRunTablePostgres(AsyncPostgresTable):
         return [run['run_number'] for run in _records.body]
 
     async def get_expanded_run(self, run_key: str) -> DBResponse:
-        "Fetch run with a given id or number from the DB"
-        # Remember to enable_joins for the query, otherwise the 'status' will be missing from the run
-        # and we can not broadcast an up-to-date status.
-        # NOTE: task being broadcast should contain the same fields as the GET request returns so UI can easily infer changes.
-        # Currently this restricts the use of expanded=True
+        """
+        Fetch run with a given id or number from the DB.
+
+        Parameters
+        ----------
+        run_key : str
+            run number or run id
+
+        Returns
+        -------
+        DBResponse
+            Containing a single run record, if one was found.
+        """
         run_id_key, run_id_value = translate_run_key(run_key)
         result, *_ = await self.find_records(
             conditions=["{column} = %s".format(column=run_id_key)],

--- a/services/ui_backend_service/tests/integration_tests/notify_test.py
+++ b/services/ui_backend_service/tests/integration_tests/notify_test.py
@@ -298,7 +298,8 @@ def assertable_flow(flow):
 def assertable_run(run):
     return {
         "flow_id": run.get("flow_id"),
-        "run_number": int(run.get("run_number"))
+        "run_number": int(run.get("run_number")),
+        "last_heartbeat_ts": run.get("last_heartbeat_ts")
     }
 
 def assertable_step(step, keys = ["step_name"]):


### PR DESCRIPTION
- moves query logic away from heartbeat getters and into db table classes
- add missing import for `time` to run table class
- add docstrings
- add `last_heartbeat_ts` field to be part of Run table trigger message. This completely eliminates the need to do a DB query when adding runs to heartbeat monitoring.