### PR TITLE
feat: running tests with docker-compose and configure codestyles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,11 @@ var/
 .installed.cfg
 *.egg
 *.eggs
+*.zip
+
+# Test artifacts
+.tox/
+.coverage
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/Dockerfile.service.test
+++ b/Dockerfile.service.test
@@ -1,0 +1,12 @@
+FROM golang:latest AS goose
+RUN go get -u github.com/pressly/goose/cmd/goose
+
+FROM python:3.7
+COPY --from=goose /go/bin/goose /usr/local/bin/
+
+RUN pip install tox
+
+COPY . /app
+WORKDIR /app
+
+CMD /app/wait-for-postgres.sh tox

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,5 @@
+include services/metadata_service/requirements.txt
+include services/migration_service/requirements.txt
+include requirements.dev.txt
+include requirements.txt
+include README.md

--- a/README.md
+++ b/README.md
@@ -115,6 +115,34 @@ the latest version of the metadata service compatible with every version of the 
 When the container spins up, the migration service is launched first and determines what virtualenv to activate
 depending on the schema version of the DB. This will determine which version of the metadata service will run.  
 
+### Running tests
+
+Tests are run using [Tox](https://tox.readthedocs.io) and [pytest](https://docs.pytest.org).
+
+Run following command to execute tests in Dockerized environment:
+
+> ```sh
+> docker-compose -f docker-compose.test.yml up -V --abort-on-container-exit
+> ```
+
+Above command will make sure there's PostgreSQL database available.
+
+Usage without Docker:
+
+> ```sh
+> # Run all tests
+> tox
+>
+> # Run unit tests only
+> tox -e unit
+>
+> # Run integration tests only
+> tox -e integration
+>
+> # Run both unit & integrations tests in parallel
+> tox -e unit,integration -p
+> ```
+
 ## Get in Touch
 There are several ways to get in touch with us:
 

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,0 +1,27 @@
+version: "3"
+services:
+  service_test:
+    container_name: service_test
+    build:
+      context: .
+      dockerfile: Dockerfile.service.test
+    volumes:
+      - .:/app
+    environment:
+      - MF_METADATA_DB_HOST=db_test
+      - MF_METADATA_DB_PORT=5432
+      - MF_METADATA_DB_USER=test
+      - MF_METADATA_DB_PSWD=test
+      - MF_METADATA_DB_NAME=test
+      - MF_MIGRATION_ENDPOINTS_ENABLED=1
+    depends_on:
+      - db_test
+  db_test:
+    container_name: db_test
+    image: "postgres:11"
+    environment:
+      POSTGRES_USER: test
+      POSTGRES_PASSWORD: test
+      POSTGRES_DB: test
+    ports:
+      - "5432:5432"

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+markers =
+    unit_tests: Unit tests (deselect with '-m "not unit_tests"')
+    integration_tests: Integration tests (deselect with '-m "not integration_tests"')

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,0 +1,4 @@
+tox==3.20.0
+pytest==6.1.1
+pytest-cov==2.10.1
+pytest-aiohttp==0.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+-r services/metadata_service/requirements.txt
+-r services/migration_service/requirements.txt

--- a/services/metadata_service/requirements.txt
+++ b/services/metadata_service/requirements.txt
@@ -1,3 +1,3 @@
 aiohttp==3.6.2
 aiohttp-swagger==1.0.15
-aiopg==1.0.0
+boto3==1.15.10

--- a/services/metadata_service/tests/integration_tests/placeholder_test.py
+++ b/services/metadata_service/tests/integration_tests/placeholder_test.py
@@ -1,0 +1,6 @@
+import pytest
+pytestmark = [pytest.mark.integration_tests]
+
+
+async def test_placeholder():
+    assert True

--- a/services/migration_service/requirements.txt
+++ b/services/migration_service/requirements.txt
@@ -1,3 +1,4 @@
 aiohttp==3.6.2
 aiohttp-swagger==1.0.15
+psycopg2==2.8.6
 aiopg==1.0.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,9 @@
 [metadata]
 license_files = LICENSE
+
+[pycodestyle]
+count = False
+exclude = *_test.py,.svn,CVS,.bzr,.hg,.git,__pycache__,.tox
+ignore = E722
+max-line-length = 160
+statistics = True

--- a/setup.py
+++ b/setup.py
@@ -1,32 +1,53 @@
+from os.path import dirname, join, exists
 from setuptools import setup, find_packages
+
+
+def open_and_read_if_exists(path: str):
+    try:
+        with open(join(dirname(__file__), path)) as f:
+            return f.read()
+    except:
+        return ""
+
+
+requirements = []
+for service in ['metadata_service', 'migration_service']:
+    requirements += open_and_read_if_exists(
+        "services/{}/requirements.txt".format(service)).splitlines()
+
+requirements_tests = open_and_read_if_exists(
+    'requirements.dev.txt').splitlines()
+
+long_description = open_and_read_if_exists(
+    'README.md')
+
 setup(
-  name = 'metadata_service',
-  version = '2.0.4',
-  license='Apache License 2.0',
-  description = 'Metadata Service: backend service for Metaflow',
-  author = 'Machine Learning Infrastructure Team at Netflix',
-  author_email = 'help@metaflow.org',
-  url = 'https://github.com/Netflix/metaflow-service',
-  keywords = ['metaflow', 'machinelearning', 'ml'],
-  py_modules=['metadata_service'],
-  packages=find_packages(),
-  entry_points='''
+    name='metadata_service',
+    version='2.0.4',
+    license='Apache License 2.0',
+    description='Metadata Service: backend service for Metaflow',
+    long_description=long_description,
+    author='Machine Learning Infrastructure Team at Netflix',
+    author_email='help@metaflow.org',
+    url='https://github.com/Netflix/metaflow-service',
+    keywords=['metaflow', 'machinelearning', 'ml'],
+    py_modules=['services.metadata_service'],
+    packages=find_packages(exclude=('tests',)),
+    entry_points='''
         [console_scripts]
         metadata_service=services.metadata_service.server:main
+        migration_service=services.migration_service.migration_server:main
    ''',
-  install_requires=[
-          'aiohttp',
-          'aiohttp_swagger',
-          'psycopg2',
-          'aiopg',
-          'boto3',
-
-      ],
-  classifiers=[
-    'Development Status :: 5 - Production/Stable',
-    'Intended Audience :: Developers',
-    'Topic :: Software Development :: Build Tools',
-    'License :: OSI Approved :: Apache Software License',
-    'Programming Language :: Python :: 3.7',
-  ],
+    install_requires=requirements,
+    tests_require=requirements + requirements_tests,
+    extras_require={
+        'test': requirements + requirements_tests
+    },
+    classifiers=[
+        'Development Status :: 5 - Production/Stable',
+        'Intended Audience :: Developers',
+        'Topic :: Software Development :: Build Tools',
+        'License :: OSI Approved :: Apache Software License',
+        'Programming Language :: Python :: 3.7',
+    ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,16 @@
+[tox]
+envlist = py37
+
+[testenv]
+deps =
+    -rrequirements.txt
+    -rrequirements.dev.txt
+commands = pytest --cov=services
+passenv = MF_METADATA_DB_HOST MF_METADATA_DB_PORT MF_METADATA_DB_USER MF_METADATA_DB_PSWD MF_METADATA_DB_NAME MF_UI_METADATA_PORT MF_UI_METADATA_HOST
+extras = tests
+
+[testenv:unit]
+commands = pytest --cov=services -m unit_tests
+
+[testenv:integration]
+commands = pytest --cov=services -m integration_tests

--- a/wait-for-postgres.sh
+++ b/wait-for-postgres.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+while !</dev/tcp/${MF_METADATA_DB_HOST}/${MF_METADATA_DB_PORT}; do
+    sleep 1;
+done;
+
+$@

--- a/wait-for-postgres.sh
+++ b/wait-for-postgres.sh
@@ -1,7 +1,17 @@
 #!/bin/bash
+RETRIES=1;
+MAX_RETRIES=${POSTGRES_WAIT_MAX_RETRIES:=5};
+SLEEP_SECONDS=${POSTGRES_WAIT_SLEEP_SECONDS:=1};
 
+# Retry loop for postgres server.
 while !</dev/tcp/${MF_METADATA_DB_HOST}/${MF_METADATA_DB_PORT}; do
-    sleep 1;
+    if (($RETRIES <= $MAX_RETRIES)); then
+        echo "retry $RETRIES out of $MAX_RETRIES"
+        RETRIES=$((RETRIES+1))
+        sleep $SLEEP_SECONDS;
+    else
+        echo "Waiting for postgres server timed out."; exit 1;
+    fi
 done;
 
 $@


### PR DESCRIPTION
Testing and codestyle enhancements originally introduced in the UI development branch. Aim to merge this before #144 so we can write some integration tests for the metadata service.

This PR omits any pointers to `service.ui_backend` and `services.utils` as these are introduced in future PR's and including missing paths would break the test runner.

Changes: 
    * add Tox support and pycodestyle directives
    * update .gitignore for tox temp files
    * add docker-compose and dockerfile for running tests
    * add instructions to README.md for running tests
    * add placeholder test for metadata_service
    * pin service dependency versions
    * add configurable wait time and retry count to postgres server startup waiting.