### PR TITLE
WIP: add metadata service integration tests

### DIFF
--- a/services/metadata_service/tests/integration_tests/__init__.py
+++ b/services/metadata_service/tests/integration_tests/__init__.py
@@ -1,0 +1,4 @@
+import pytest
+
+# we need to register the utils helper for assert rewriting in order to get descriptive assertion errors.
+pytest.register_assert_rewrite("services.metadata_service.tests.integration_tests.utils")

--- a/services/metadata_service/tests/integration_tests/flow_test.py
+++ b/services/metadata_service/tests/integration_tests/flow_test.py
@@ -1,5 +1,4 @@
-from .utils import init_app, init_db, clean_db, assert_api_get_response
-from services.data.models import FlowRow
+from .utils import init_app, init_db, clean_db, assert_api_get_response, add_flow
 import pytest
 import json
 pytestmark = [pytest.mark.integration_tests]
@@ -46,12 +45,8 @@ async def test_flows_post(cli, db):
 
 async def test_flows_get(cli, db):
   # create a few flows for test
-  _first_flow = (await db.flow_table_postgres.add_flow(
-      FlowRow("TestFlow", "test_user-1", ["a_tag", "b_tag"], ["runtime:test"])
-  )).body
-  _second_flow = (await db.flow_table_postgres.add_flow(
-      FlowRow("AnotherTestFlow", "test_user-1", ["a_tag", "b_tag"], ["runtime:test"])
-  )).body
+  _first_flow = (await add_flow(db, flow_id="TestFlow", user_name="test_user-1", tags=["a_tag", "b_tag"], system_tags=["runtime:test"])).body
+  _second_flow = (await add_flow(db, flow_id="AnotherTestFlow", user_name="test_user-1")).body
 
   # try to get all the created flows
   await assert_api_get_response(cli, "/flows", data=[_first_flow, _second_flow])
@@ -59,9 +54,7 @@ async def test_flows_get(cli, db):
 
 async def test_flow_get(cli, db):
   # create flow for test
-  _flow = (await db.flow_table_postgres.add_flow(
-      FlowRow("TestFlow", "test_user-1", ["a_tag", "b_tag"], ["runtime:test"])
-  )).body
+  _flow = (await add_flow(db, flow_id="TestFlow", user_name="test_user-1")).body
 
   # try to get created flow
   await assert_api_get_response(cli, "/flows/TestFlow", data=_flow)

--- a/services/metadata_service/tests/integration_tests/flow_test.py
+++ b/services/metadata_service/tests/integration_tests/flow_test.py
@@ -1,0 +1,46 @@
+from .utils import init_app, init_db, clean_db
+import pytest
+import json
+pytestmark = [pytest.mark.integration_tests]
+
+# Fixtures begin
+
+
+@pytest.fixture
+def cli(loop, aiohttp_client):
+    return init_app(loop, aiohttp_client)
+
+
+@pytest.fixture
+async def db(cli):
+    async_db = await init_db(cli)
+    yield async_db
+    await clean_db(async_db)
+
+# Fixtures end
+
+
+async def test_flows_post(cli, db):
+  payload = {
+      "user_name": "test_user",
+      "tags": ["a_tag", "b_tag"],
+      "system_tags": ["runtime:test"]
+  }
+  response = await cli.post("/flows/{}".format("TestFlow"), json=payload)
+  # body = await response.json() # TODO: api does not respond with correct json content headers.
+
+  assert response.status == 200  # why 200 instead of 201?
+
+  # Record should be found in DB
+  _flow = await db.flow_table_postgres.get_flow(flow_id="TestFlow")
+
+  assert _flow.body["user_name"] == payload["user_name"]
+  assert _flow.body["tags"] == payload["tags"]
+  assert _flow.body["system_tags"] == payload["system_tags"]
+
+  # Second post should fail as flow already exists.
+
+  response = await cli.post("/flows/{}".format("TestFlow"), json=payload)
+  # body = await response.json() # TODO: api fails to respond with correct json content headers
+
+  assert response.status == 409

--- a/services/metadata_service/tests/integration_tests/flow_test.py
+++ b/services/metadata_service/tests/integration_tests/flow_test.py
@@ -1,4 +1,5 @@
-from .utils import init_app, init_db, clean_db
+from .utils import init_app, init_db, clean_db, assert_api_get_response
+from services.data.models import FlowRow
 import pytest
 import json
 pytestmark = [pytest.mark.integration_tests]
@@ -27,7 +28,6 @@ async def test_flows_post(cli, db):
       "system_tags": ["runtime:test"]
   }
   response = await cli.post("/flows/{}".format("TestFlow"), json=payload)
-  # body = await response.json() # TODO: api does not respond with correct json content headers.
 
   assert response.status == 200  # why 200 instead of 201?
 
@@ -39,8 +39,32 @@ async def test_flows_post(cli, db):
   assert _flow.body["system_tags"] == payload["system_tags"]
 
   # Second post should fail as flow already exists.
-
   response = await cli.post("/flows/{}".format("TestFlow"), json=payload)
-  # body = await response.json() # TODO: api fails to respond with correct json content headers
 
   assert response.status == 409
+
+
+async def test_flows_get(cli, db):
+  # create a few flows for test
+  _first_flow = (await db.flow_table_postgres.add_flow(
+      FlowRow("TestFlow", "test_user-1", ["a_tag", "b_tag"], ["runtime:test"])
+  )).body
+  _second_flow = (await db.flow_table_postgres.add_flow(
+      FlowRow("AnotherTestFlow", "test_user-1", ["a_tag", "b_tag"], ["runtime:test"])
+  )).body
+
+  # try to get all the created flows
+  await assert_api_get_response(cli, "/flows", data=[_first_flow, _second_flow])
+
+
+async def test_flow_get(cli, db):
+  # create flow for test
+  _flow = (await db.flow_table_postgres.add_flow(
+      FlowRow("TestFlow", "test_user-1", ["a_tag", "b_tag"], ["runtime:test"])
+  )).body
+
+  # try to get created flow
+  await assert_api_get_response(cli, "/flows/TestFlow", data=_flow)
+
+  # non-existent flow should return 404
+  await assert_api_get_response(cli, "/flows/AnotherFlow", status=404)

--- a/services/metadata_service/tests/integration_tests/placeholder_test.py
+++ b/services/metadata_service/tests/integration_tests/placeholder_test.py
@@ -1,6 +1,0 @@
-import pytest
-pytestmark = [pytest.mark.integration_tests]
-
-
-async def test_placeholder():
-    assert True

--- a/services/metadata_service/tests/integration_tests/utils.py
+++ b/services/metadata_service/tests/integration_tests/utils.py
@@ -71,3 +71,28 @@ async def clean_db(db: AsyncPostgresDB):
         print("DB Cleanup failed after test. This might have adverse effects on further test runs", str(error))
 
 # Test fixture helpers end
+
+
+async def assert_api_get_response(cli, path: str, status: int = 200, data: object = None):
+    """
+    Perform a GET request with the provided http cli to the provided path, assert that the status and data received are correct.
+    Expectation is that the API returns text/plain format json.
+
+    Parameters
+    ----------
+    cli : aiohttp cli
+        aiohttp test client
+    path : str
+        url path to perform GET request to
+    status : int (default 200)
+        http status code to expect from response
+    data : object
+        Any json serializable data type. will undergo json.dumps before asserting with response body.
+    """
+    response = await cli.get(path)
+
+    assert response.status == status
+    body = await response.text()
+
+    if data:
+        assert body == json.dumps(data)

--- a/services/metadata_service/tests/integration_tests/utils.py
+++ b/services/metadata_service/tests/integration_tests/utils.py
@@ -1,0 +1,73 @@
+from aiohttp import web
+import os
+import psycopg2
+import json
+
+from services.data.postgres_async_db import AsyncPostgresDB
+
+# Migration imports
+from services.migration_service.api.admin import AdminApi as MigrationAdminApi
+from services.migration_service.data.postgres_async_db import AsyncPostgresDB as MigrationAsyncPostgresDB
+
+
+from services.metadata_service.api.flow import FlowApi
+from services.metadata_service.api.admin import AuthApi
+
+# Test fixture helpers begin
+
+
+def init_app(loop, aiohttp_client, queue_ttl=30):
+    app = web.Application()
+
+    # Migration routes as a subapp
+    migration_app = web.Application()
+    MigrationAdminApi(migration_app)
+    app.add_subapp("/migration/", migration_app)
+
+    FlowApi(app)
+    AuthApi(app)
+
+    return loop.run_until_complete(aiohttp_client(app))
+
+
+async def init_db(cli):
+    # Make sure migration scripts are applied
+    migration_db = MigrationAsyncPostgresDB.get_instance()
+    await migration_db._init()
+
+    # Apply migrations and make sure "is_up_to_date" == True
+    await cli.patch("/migration/upgrade")
+    # TODO: Api not responding with valid json headers so check fails.
+    # status = await (await cli.get("/migration/db_schema_status")).json()
+    # assert status["is_up_to_date"] is True
+
+    db = AsyncPostgresDB.get_instance()
+    await db._init()
+    return db
+
+
+async def clean_db(db: AsyncPostgresDB):
+    # Tables to clean (order is important due to foreign keys)
+    tables = [
+        db.metadata_table_postgres,
+        db.artifact_table_postgres,
+        db.task_table_postgres,
+        db.step_table_postgres,
+        db.run_table_postgres,
+        db.flow_table_postgres
+    ]
+    try:
+        with (
+            await db.pool.cursor(
+                cursor_factory=psycopg2.extras.DictCursor
+            )
+        ) as cur:
+            for table in tables:
+                cleanup_query = "DELETE FROM {}".format(table.table_name)
+                await cur.execute(cleanup_query)
+
+            cur.close()
+    except Exception as error:
+        print("DB Cleanup failed after test. This might have adverse effects on further test runs", str(error))
+
+# Test fixture helpers end

--- a/services/metadata_service/tests/integration_tests/utils.py
+++ b/services/metadata_service/tests/integration_tests/utils.py
@@ -72,6 +72,115 @@ async def clean_db(db: AsyncPostgresDB):
 
 # Test fixture helpers end
 
+# Row helpers begin
+
+
+async def add_flow(db: AsyncPostgresDB, flow_id="HelloFlow",
+                   user_name="dipper", tags=["foo:bar"], system_tags=["runtime:dev"]):
+    flow = {
+        "flow_id": flow_id,
+        "user_name": user_name,
+        "tags": json.dumps(tags),
+        "system_tags": json.dumps(system_tags)
+    }
+    return await db.flow_table_postgres.create_record(flow)
+
+
+async def add_run(db: AsyncPostgresDB, flow_id="HelloFlow",
+                  run_number: int = None, run_id: str = None,
+                  user_name="dipper", tags=["foo:bar"], system_tags=["runtime:dev"],
+                  last_heartbeat_ts: int = None):
+    run = {
+        "flow_id": flow_id,
+        "run_id": run_id,
+        "user_name": user_name,
+        "tags": json.dumps(tags),
+        "system_tags": json.dumps(system_tags),
+        "last_heartbeat_ts": last_heartbeat_ts
+    }
+    return await db.run_table_postgres.create_record(run)
+
+
+async def add_step(db: AsyncPostgresDB, flow_id="HelloFlow",
+                   run_number: int = None, run_id: str = None, step_name="step",
+                   user_name="dipper", tags=["foo:bar"], system_tags=["runtime:dev"]):
+    step = {
+        "flow_id": flow_id,
+        "run_number": run_number,
+        "run_id": run_id,
+        "step_name": step_name,
+        "user_name": user_name,
+        "tags": json.dumps(tags),
+        "system_tags": json.dumps(system_tags)
+    }
+    return await db.step_table_postgres.create_record(step)
+
+
+async def add_task(db: AsyncPostgresDB, flow_id="HelloFlow",
+                   run_number: int = None, run_id: str = None, step_name="step", task_id=None, task_name=None,
+                   user_name="dipper", tags=["foo:bar"], system_tags=["runtime:dev"],
+                   last_heartbeat_ts: int = None):
+    task = {
+        "flow_id": flow_id,
+        "run_number": run_number,
+        "step_name": step_name,
+        "task_name": task_name,
+        "user_name": user_name,
+        "tags": json.dumps(tags),
+        "system_tags": json.dumps(system_tags),
+        "last_heartbeat_ts": last_heartbeat_ts
+    }
+    return await db.task_table_postgres.create_record(task)
+
+
+async def add_metadata(db: AsyncPostgresDB, flow_id="HelloFlow",
+                       run_number: int = None, run_id: str = None, step_name="step", task_id=None, task_name=None,
+                       metadata={},
+                       user_name="dipper", tags=["foo:bar"], system_tags=["runtime:dev"]):
+    values = {
+        "flow_id": flow_id,
+        "run_number": run_number,
+        "run_id": run_id,
+        "step_name": step_name,
+        "task_id": str(task_id),
+        "task_name": task_name,
+        "field_name": metadata.get("field_name", " "),
+        "value": metadata.get("value", " "),
+        "type": metadata.get("type", " "),
+        "user_name": user_name,
+        "tags": json.dumps(tags),
+        "system_tags": json.dumps(system_tags)
+    }
+    return await db.metadata_table_postgres.create_record(values)
+
+
+async def add_artifact(db: AsyncPostgresDB, flow_id="HelloFlow",
+                       run_number: int = None, run_id: str = None, step_name="step", task_id=None, task_name=None,
+                       artifact={},
+                       user_name="dipper", tags=["foo:bar"], system_tags=["runtime:dev"]):
+    values = {
+        "flow_id": flow_id,
+        "run_number": run_number,
+        "run_id": run_id,
+        "step_name": step_name,
+        "task_id": str(task_id),
+        "task_name": task_name,
+        "name": artifact.get("name", " "),
+        "location": artifact.get("location", " "),
+        "ds_type": artifact.get("ds_type", " "),
+        "sha": artifact.get("sha", " "),
+        "type": artifact.get("type", " "),
+        "content_type": artifact.get("content_type", " "),
+        "attempt_id": artifact.get("attempt_id", 0),
+        "user_name": user_name,
+        "tags": json.dumps(tags),
+        "system_tags": json.dumps(system_tags)
+    }
+    return await db.artifact_table_postgres.create_record(values)
+
+# Row helpers end
+
+# Resource helpers
 
 async def assert_api_get_response(cli, path: str, status: int = 200, data: object = None):
     """

--- a/services/migration_service/api/admin.py
+++ b/services/migration_service/api/admin.py
@@ -4,7 +4,7 @@ from aiohttp import web
 from subprocess import Popen
 from .utils import ApiUtils
 from . import goose_migration_template
-from migration_service.migration_config import host, port, user, password, \
+from ..migration_config import host, port, user, password, \
     database_name
 
 

--- a/services/migration_service/api/utils.py
+++ b/services/migration_service/api/utils.py
@@ -2,7 +2,7 @@ from subprocess import Popen, PIPE
 from ..data.postgres_async_db import PostgresUtils
 from . import version_dict, latest, goose_template, \
     goose_migration_template
-from migration_service.migration_config import host, port, user, password, \
+from ..migration_config import host, port, user, password, \
     database_name
 
 

--- a/services/migration_service/data/postgres_async_db.py
+++ b/services/migration_service/data/postgres_async_db.py
@@ -1,7 +1,7 @@
 import time
 import os
 import aiopg
-from migration_service.migration_config import host, port, user, password, \
+from ..migration_config import host, port, user, password, \
     database_name
 
 class PostgresUtils(object):


### PR DESCRIPTION
Test coverage for the metadata service component. Necessary in order to have some certainty of not breaking basic functionality with future code changes. This branch depends on changes of #145, and is a prerequisite for considering merging of #144

TODO: rebase from master after #145 is introduced, or alternatively merge this onto #145

- configure metadata service test setup and teardown
- add basic business logic test coverage to metadata service api (`CREATE, GET, LIST, HEARTBEAT`) testing both the api responses, and that data is stored in DB.