### PR TITLE
fix: incorrect task websocket data with local datastore

### DIFF
--- a/services/ui_backend_service/data/cache/store.py
+++ b/services/ui_backend_service/data/cache/store.py
@@ -178,7 +178,7 @@ class ArtifactCacheStore(object):
                 [f"/flows/{flow_id}/runs/{run_number}/parameters"],
                 parameters
             )
-        except:
+        except Exception:
             logger.error("Run parameter fetching failed")
 
     async def preload_event_handler(self, run_number: int):

--- a/services/ui_backend_service/data/refiner/refinery.py
+++ b/services/ui_backend_service/data/refiner/refinery.py
@@ -45,11 +45,13 @@ class Refinery(object):
 
     async def fetch_data(self, locations):
         try:
-            _res = await self.artifact_store.cache.GetArtifacts(locations)
+            # only fetch S3 locations, otherwise the long timeout of CacheFuture will cause problems.
+            _locs = [loc for loc in locations if isinstance(loc, str) and loc.startswith("s3://")]
+            _res = await self.artifact_store.cache.GetArtifacts(_locs)
             if not _res.is_ready():
                 await _res.wait()  # wait for results to be ready
             return _res.get() or {}  # cache get() might return None if no keys are produced.
-        except:
+        except Exception:
             self.logger.exception("Exception when fetching artifact data from cache")
             return {}
 

--- a/services/ui_backend_service/data/refiner/task_refiner.py
+++ b/services/ui_backend_service/data/refiner/task_refiner.py
@@ -31,9 +31,9 @@ class TaskRefiner(Refinery):
         -------
         A refined DBResponse, or in case of errors, the original DBResponse
         """
-        refined_response = await self._postprocess(response)
         if response.response_code != 200 or not response.body:
             return response
+        refined_response = await self._postprocess(response)
 
         def _process(item):
             if item['status'] == 'unknown':


### PR DESCRIPTION
Task refiner was passing non-S3 locations to the `GetArtifacts` cache action, which was getting stuck due to the long timeout of `CacheFuture`.

Added a guard to refinery so only valid S3 locations are passed to the cache action, as there is by choice no handling of streamed errors in the fetching.

Also fixed ordering with task refiner no-op guard.