### PR TITLE
chore: release-candidate cleanup

### DIFF
--- a/services/data/db_utils.py
+++ b/services/data/db_utils.py
@@ -61,7 +61,7 @@ def _get_latest_attempt_id_for_tasks(artifacts):
     return attempt_ids
 
 
-def _filter_artifacts_by_attempt_id_for_tasks(artifacts):
+def filter_artifacts_by_attempt_id_for_tasks(artifacts):
     attempt_ids = _get_latest_attempt_id_for_tasks(artifacts)
     result = []
     for artifact in artifacts:

--- a/services/data/postgres_async_db.py
+++ b/services/data/postgres_async_db.py
@@ -101,7 +101,7 @@ class _AsyncPostgresDB(object):
                     raise e
                 time.sleep(connection_retry_wait_time_seconds)
 
-    async def get_table_by_name(self, table_name: str):
+    def get_table_by_name(self, table_name: str):
         for table in self.tables:
             if table.table_name == table_name:
                 return table

--- a/services/data/service_configs.py
+++ b/services/data/service_configs.py
@@ -1,6 +1,6 @@
 import os
 
-max_connection_retires = os.environ.get("MF_SERVICE_CONNECTION_RETRIES", 3)
-connection_retry_wait_time_seconds = os.environ.get("MF_SERVICE_CONNECTION_RETRY_WAITTIME_SECONDS", 1)
-max_startup_retries = os.environ.get("MF_SERVICE_STARTUP_RETRIES", 5)
-startup_retry_wait_time_seconds = os.environ.get("MF_SERVICE_STARTUP_WAITTIME_SECONDS", 1)
+max_connection_retires = int(os.environ.get("MF_SERVICE_CONNECTION_RETRIES", 3))
+connection_retry_wait_time_seconds = int(os.environ.get("MF_SERVICE_CONNECTION_RETRY_WAITTIME_SECONDS", 1))
+max_startup_retries = int(os.environ.get("MF_SERVICE_STARTUP_RETRIES", 5))
+startup_retry_wait_time_seconds = int(os.environ.get("MF_SERVICE_STARTUP_WAITTIME_SECONDS", 1))

--- a/services/metadata_service/api/admin.py
+++ b/services/metadata_service/api/admin.py
@@ -9,6 +9,7 @@ from aiohttp import web
 from botocore.client import Config
 from services.data.postgres_async_db import AsyncPostgresDB
 from services.utils import (
+    web_response,
     get_traceback_str,
     METADATA_SERVICE_VERSION,
     METADATA_SERVICE_HEADER
@@ -89,7 +90,7 @@ class AuthApi(object):
                 status_code = 500
 
             cur.close()
-        return web.Response(status=status_code, body=json.dumps(status))
+        return web_response(status=status_code, body=json.dumps(status))
 
 
     async def get_authorization_token(self, request):

--- a/services/metadata_service/api/artifact.py
+++ b/services/metadata_service/api/artifact.py
@@ -1,6 +1,6 @@
 from aiohttp import web
 from services.data.postgres_async_db import AsyncPostgresDB
-from services.data.db_utils import _filter_artifacts_by_attempt_id_for_tasks
+from services.data.db_utils import filter_artifacts_by_attempt_id_for_tasks
 from services.utils import read_body, format_response, handle_exceptions
 import json
 
@@ -137,7 +137,7 @@ class ArtificatsApi(object):
             flow_name, run_number, step_name, task_id
         )
 
-        filtered_body = _filter_artifacts_by_attempt_id_for_tasks(
+        filtered_body = filter_artifacts_by_attempt_id_for_tasks(
             artifacts.body)
         return web.Response(
             status=artifacts.response_code, body=json.dumps(filtered_body)
@@ -181,7 +181,7 @@ class ArtificatsApi(object):
             flow_name, run_number, step_name
         )
 
-        filtered_body = _filter_artifacts_by_attempt_id_for_tasks(
+        filtered_body = filter_artifacts_by_attempt_id_for_tasks(
             artifacts.body)
         return web.Response(
             status=artifacts.response_code, body=json.dumps(filtered_body)
@@ -216,7 +216,7 @@ class ArtificatsApi(object):
         run_number = request.match_info.get("run_number")
 
         artifacts = await self._async_table.get_artifacts_in_runs(flow_name, run_number)
-        filtered_body = _filter_artifacts_by_attempt_id_for_tasks(
+        filtered_body = filter_artifacts_by_attempt_id_for_tasks(
             artifacts.body)
         return web.Response(
             status=artifacts.response_code, body=json.dumps(filtered_body)


### PR DESCRIPTION
- utility functions cleanup.
- cast service_config environment variables to correct types.
- use web_response helper for json api routes, to make sure correct headers are in place.