### PR TITLE
fix: use internal codepackage name as part of lookup as well.

### DIFF
--- a/services/ui_backend_service/api/dag.py
+++ b/services/ui_backend_service/api/dag.py
@@ -49,9 +49,16 @@ class DagApi(object):
             request.match_info.get("run_number"))
         # 'code-package' value contains json with dstype, sha1 hash and location
         db_response, *_ = await self._metadata_table.find_records(
-            conditions=["flow_id = %s", "{run_id_key} = %s".format(
-                run_id_key=run_id_key), "field_name = %s"],
-            values=[flow_name, run_id_value, "code-package"],
+            conditions=[
+                "flow_id = %s",
+                "{run_id_key} = %s".format(
+                    run_id_key=run_id_key),
+                "(field_name = %s OR field_name = %s)"
+            ],
+            values=[
+                flow_name, run_id_value,
+                "code-package", "code-package-url"
+            ],
             fetch_single=True, expanded=True
         )
         if not db_response.response_code == 200:


### PR DESCRIPTION
- uses 'code-package-url' as part of the query for finding code package location