### PR TITLE
Pin UI service dependencies due to aiohttp websocket regression

### DIFF
--- a/services/ui_backend_service/requirements.txt
+++ b/services/ui_backend_service/requirements.txt
@@ -1,7 +1,8 @@
-aiohttp
-aiohttp-swagger
-boto3
-pyee
-throttler
-psycopg2
-aiopg
+aiohttp==3.6.2
+aiohttp-swagger==1.0.15
+boto3==1.15.10
+pyee==8.0.1
+yarl==1.5.1
+throttler==1.2.0
+psycopg2==2.8.6
+aiopg==1.2.1


### PR DESCRIPTION
Revert recent changes on UI service `requirements.txt` due to `aiohttp` 3.7 websocket regression.

There are multiple reported issues on websocket behaviour:
- https://github.com/aio-libs/aiohttp/issues/5301
- https://github.com/aio-libs/aiohttp/issues/5212
- https://github.com/aio-libs/aiohttp/issues/5182
- https://github.com/aio-libs/aiohttp/issues/5180

Let's keep these dependencies pinned for now and upgrade each of these in controlled manner later on so we can resume realtime functionality.