### PR TITLE
fix: change blocking boto3 to aioboto3 for log fetching

### DIFF
--- a/services/ui_backend_service/api/log.py
+++ b/services/ui_backend_service/api/log.py
@@ -1,7 +1,7 @@
 
 import os
 import json
-import aiobotocore
+import aioboto3
 import botocore
 import heapq
 import io
@@ -333,8 +333,7 @@ async def get_metadata_log(find_records, flow_name, run_number, step_name, task_
 
 
 async def read_and_output(bucket, path):
-    session = aiobotocore.get_session()
-    async with session.create_client('s3') as s3:
+    async with aioboto3.client('s3') as s3:
         obj = await s3.get_object(Bucket=bucket, Key=path)
 
     lines = []
@@ -348,8 +347,7 @@ async def read_and_output(bucket, path):
 
 
 async def read_and_output_ws(bucket, path, ws):
-    session = aiobotocore.get_session()
-    async with session.create_client('s3') as s3:
+    async with aioboto3.client('s3') as s3:
         obj = await s3.get_object(Bucket=bucket, Key=path)
 
     async with obj['Body'] as stream:
@@ -361,9 +359,8 @@ async def read_and_output_ws(bucket, path, ws):
 
 
 async def read_and_output_mflog(paths):
-    session = aiobotocore.get_session()
     logs = []
-    async with session.create_client('s3') as s3:
+    async with aioboto3.client('s3') as s3:
         for bucket, path in paths:
             try:
                 obj = await s3.get_object(Bucket=bucket, Key=path)
@@ -386,9 +383,8 @@ async def read_and_output_mflog(paths):
 
 
 async def read_and_output_mflog_ws(paths, ws):
-    session = aiobotocore.get_session()
     logs = []
-    async with session.create_client('s3') as s3:
+    async with aioboto3.client('s3') as s3:
         for bucket, path in paths:
             obj = await s3.get_object(Bucket=bucket, Key=path)
 

--- a/services/ui_backend_service/requirements.txt
+++ b/services/ui_backend_service/requirements.txt
@@ -3,7 +3,6 @@ aiohttp-swagger==1.0.15
 botocore==1.19.52
 boto3==1.16.52
 aiobotocore==1.2.2
-aioboto3==8.3.0
 pyee==8.0.1
 yarl==1.5.1
 throttler==1.2.0

--- a/services/ui_backend_service/requirements.txt
+++ b/services/ui_backend_service/requirements.txt
@@ -1,8 +1,9 @@
 aiohttp==3.6.2
 aiohttp-swagger==1.0.15
-botocore==1.20.49
-boto3==1.17.49
-aiobotocore==1.3.0
+botocore==1.19.52
+boto3==1.16.52
+aiobotocore==1.2.2
+aioboto3==8.3.0
 pyee==8.0.1
 yarl==1.5.1
 throttler==1.2.0

--- a/services/ui_backend_service/requirements.txt
+++ b/services/ui_backend_service/requirements.txt
@@ -1,6 +1,8 @@
 aiohttp==3.6.2
 aiohttp-swagger==1.0.15
-boto3==1.15.10
+botocore==1.20.49
+boto3==1.17.49
+aiobotocore==1.3.0
 pyee==8.0.1
 yarl==1.5.1
 throttler==1.2.0


### PR DESCRIPTION
Fetching logs from s3 with the boto3 library blocks the request handler, affecting other request processing significantly. Change this to use the aioboto3 wrappers to be able to yield execution while waiting for S3 response.