### PR TITLE
fix: fine tune cutoff logic

### DIFF
--- a/services/ui_backend_service/data/db/tables/run.py
+++ b/services/ui_backend_service/data/db/tables/run.py
@@ -75,11 +75,8 @@ class AsyncRunTablePostgres(AsyncPostgresTable):
             WHEN artifacts.ts_epoch IS NOT NULL
             THEN artifacts.ts_epoch
             WHEN {table_name}.last_heartbeat_ts IS NOT NULL
-            AND @(extract(epoch from now())-{table_name}.last_heartbeat_ts)>{heartbeat_threshold}
+                AND @(extract(epoch from now())-{table_name}.last_heartbeat_ts)>{heartbeat_threshold}
             THEN {table_name}.last_heartbeat_ts*1000
-            WHEN {table_name}.last_heartbeat_ts IS NULL
-            AND @(extract(epoch from now())*1000-{table_name}.ts_epoch)>{cutoff}
-            THEN {table_name}.ts_epoch + {cutoff}
             ELSE NULL
         END) AS finished_at
         """.format(
@@ -115,8 +112,8 @@ class AsyncRunTablePostgres(AsyncPostgresTable):
             WHEN artifacts.ts_epoch IS NOT NULL
             THEN artifacts.ts_epoch - {table_name}.ts_epoch
             WHEN {table_name}.last_heartbeat_ts IS NULL
-            AND @(extract(epoch from now())::bigint*1000-{table_name}.ts_epoch)>{cutoff}
-            THEN {cutoff}
+                AND @(extract(epoch from now())::bigint*1000-{table_name}.ts_epoch)>{cutoff}
+            THEN NULL
             ELSE @(extract(epoch from now())::bigint*1000-{table_name}.ts_epoch)
         END) AS duration
         """.format(

--- a/services/ui_backend_service/data/db/tables/step.py
+++ b/services/ui_backend_service/data/db/tables/step.py
@@ -1,5 +1,5 @@
-from typing import List
-from .base import AsyncPostgresTable
+from typing import List, Tuple
+from .base import AsyncPostgresTable, OLD_RUN_FAILURE_CUTOFF_TIME
 from ..models import StepRow
 from services.data.db_utils import DBResponse, DBPagination
 # use schema constants from the .data module to keep things consistent
@@ -98,7 +98,7 @@ class AsyncStepTablePostgres(AsyncPostgresTable):
     ]
 
     async def get_step_names(self, conditions: List[str] = [],
-                             values: List[str] = [], limit: int = 0, offset: int = 0) -> (DBResponse, DBPagination):
+                             values: List[str] = [], limit: int = 0, offset: int = 0) -> Tuple[DBResponse, DBPagination]:
         """
         Get a paginated set of step names.
 

--- a/services/ui_backend_service/data/db/tables/task.py
+++ b/services/ui_backend_service/data/db/tables/task.py
@@ -74,7 +74,7 @@ class AsyncTaskTablePostgres(AsyncPostgresTable):
                     NULL as task_ok_finished_at,
                     NULL as task_ok_location,
                     value as attempt_ok,
-                    (regexp_matches(tags::text, 'attempt_id:(\d+)'))[1]::int as attempt_id
+                    (regexp_matches(tags::text, 'attempt_id:(\\d+)'))[1]::int as attempt_id
                 FROM {metadata_table} as meta
                 WHERE
                     {table_name}.flow_id = meta.flow_id AND

--- a/services/ui_backend_service/data/db/tables/task.py
+++ b/services/ui_backend_service/data/db/tables/task.py
@@ -21,38 +21,87 @@ class AsyncTaskTablePostgres(AsyncPostgresTable):
     keys = MetadataTaskTable.keys
     primary_keys = MetadataTaskTable.primary_keys
     trigger_keys = MetadataTaskTable.trigger_keys
-    # NOTE: There is a lot of unfortunate backwards compatibility for cases where task metadata, or artifacts
-    # have not been stored correctly.
-    # NOTE: tasks_v3 table does not have a column for 'attempt_id', instead this is added before the join
-    # with a subquery in the FROM.
-    # NOTE: when using these joins, we _must_ clean up the results with a WHERE that discards attempts with
-    # nothing joined, otherwise we end up with ghost attempts for the task.
+    # NOTE: There is a lot of unfortunate backwards compatibility logic for cases where task metadata,
+    # or artifacts have not been stored correctly.
     joins = [
         """
         LEFT JOIN LATERAL (
-            SELECT ts_epoch
-            FROM {metadata_table} as start
-            WHERE
-                {table_name}.flow_id = start.flow_id AND
-                {table_name}.run_number = start.run_number AND
-                {table_name}.step_name = start.step_name AND
-                {table_name}.task_id = start.task_id AND
-                start.field_name = 'attempt' AND
-                {table_name}.attempt_id = start.value::int
-            LIMIT 1
-        ) as start ON true
-        LEFT JOIN LATERAL (
-            SELECT ts_epoch
-            FROM {metadata_table} as done
-            WHERE
-                {table_name}.flow_id = done.flow_id AND
-                {table_name}.run_number = done.run_number AND
-                {table_name}.step_name = done.step_name AND
-                {table_name}.task_id = done.task_id AND
-                done.field_name = 'attempt-done' AND
-                {table_name}.attempt_id = done.value::int
-            LIMIT 1
-        ) as done ON true
+            SELECT
+                max(started_at) as started_at,
+                max(attempt_finished_at) as attempt_finished_at,
+                max(task_ok_finished_at) as task_ok_finished_at,
+                max(task_ok_location) as task_ok_location,
+                attempt_id :: int as attempt_id,
+                max(attempt_ok) :: boolean as attempt_ok,
+                task_id
+            FROM (
+                SELECT
+                    task_id,
+                    ts_epoch as started_at,
+                    NULL::bigint as attempt_finished_at,
+                    NULL::bigint as task_ok_finished_at,
+                    NULL::text as task_ok_location,
+                    NULL::text as attempt_ok,
+                    value::int as attempt_id
+                FROM {metadata_table} as meta
+                WHERE
+                    {table_name}.flow_id = meta.flow_id AND
+                    {table_name}.run_number = meta.run_number AND
+                    {table_name}.step_name = meta.step_name AND
+                    {table_name}.task_id = meta.task_id AND
+                    meta.field_name = 'attempt'
+                UNION
+                SELECT
+                    task_id,
+                    NULL as started_at,
+                    ts_epoch as attempt_finished_at,
+                    NULL as task_ok_finished_at,
+                    NULL as task_ok_location,
+                    NULL as attempt_ok,
+                    value::int as attempt_id
+                FROM {metadata_table} as meta
+                WHERE
+                    {table_name}.flow_id = meta.flow_id AND
+                    {table_name}.run_number = meta.run_number AND
+                    {table_name}.step_name = meta.step_name AND
+                    {table_name}.task_id = meta.task_id AND
+                    meta.field_name = 'attempt-done'
+                UNION
+                SELECT
+                    task_id,
+                    NULL as started_at,
+                    ts_epoch as attempt_finished_at,
+                    NULL as task_ok_finished_at,
+                    NULL as task_ok_location,
+                    value as attempt_ok,
+                    (regexp_matches(tags::text, 'attempt_id:(\d+)'))[1]::int as attempt_id
+                FROM {metadata_table} as meta
+                WHERE
+                    {table_name}.flow_id = meta.flow_id AND
+                    {table_name}.run_number = meta.run_number AND
+                    {table_name}.step_name = meta.step_name AND
+                    {table_name}.task_id = meta.task_id AND
+                    meta.field_name = 'attempt_ok'
+                UNION
+                SELECT
+                    task_id,
+                    NULL as started_at,
+                    NULL as attempt_finished_at,
+                    ts_epoch as task_ok_finished_at,
+                    location as task_ok_location,
+                    NULL as attempt_ok,
+                    attempt_id as attempt_id
+                FROM {artifact_table} as task_ok
+                WHERE
+                    {table_name}.flow_id = task_ok.flow_id AND
+                    {table_name}.run_number = task_ok.run_number AND
+                    {table_name}.step_name = task_ok.step_name AND
+                    {table_name}.task_id = task_ok.task_id AND
+                    task_ok.name = '_task_ok'
+            ) a
+            WHERE a.attempt_id IS NOT NULL
+            GROUP BY a.task_id, a.attempt_id
+        ) as attempt ON true
         LEFT JOIN LATERAL (
             SELECT ts_epoch
             FROM {metadata_table} as next_attempt_start
@@ -62,21 +111,9 @@ class AsyncTaskTablePostgres(AsyncPostgresTable):
                 {table_name}.step_name = next_attempt_start.step_name AND
                 {table_name}.task_id = next_attempt_start.task_id AND
                 next_attempt_start.field_name = 'attempt' AND
-                ({table_name}.attempt_id + 1) = next_attempt_start.value::int
+                (attempt.attempt_id + 1) = next_attempt_start.value::int
             LIMIT 1
         ) as next_attempt_start ON true
-        LEFT JOIN LATERAL (
-            SELECT ts_epoch, value::boolean
-            FROM {metadata_table} as attempt_ok
-            WHERE
-                {table_name}.flow_id = attempt_ok.flow_id AND
-                {table_name}.run_number = attempt_ok.run_number AND
-                {table_name}.step_name = attempt_ok.step_name AND
-                {table_name}.task_id = attempt_ok.task_id AND
-                attempt_ok.field_name = 'attempt_ok' AND
-                attempt_ok.tags ? ('attempt_id:' || {table_name}.attempt_id)
-            LIMIT 1
-        ) as attempt_ok ON true
         LEFT JOIN LATERAL (
             SELECT location
             FROM {artifact_table} as foreach_stack
@@ -85,22 +122,10 @@ class AsyncTaskTablePostgres(AsyncPostgresTable):
                 {table_name}.run_number = foreach_stack.run_number AND
                 {table_name}.step_name = foreach_stack.step_name AND
                 {table_name}.task_id = foreach_stack.task_id AND
-                foreach_stack.name = '_foreach_stack' AND
-                {table_name}.attempt_id = foreach_stack.attempt_id
+                attempt.attempt_id = foreach_stack.attempt_id AND
+                foreach_stack.name = '_foreach_stack'
             LIMIT 1
         ) as foreach_stack ON true
-        LEFT JOIN LATERAL (
-            SELECT ts_epoch, location
-            FROM {artifact_table} as task_ok
-            WHERE
-                {table_name}.flow_id = task_ok.flow_id AND
-                {table_name}.run_number = task_ok.run_number AND
-                {table_name}.step_name = task_ok.step_name AND
-                {table_name}.task_id = task_ok.task_id AND
-                task_ok.name = '_task_ok' AND
-                {table_name}.attempt_id = task_ok.attempt_id
-            LIMIT 1
-        ) as task_ok ON true
         """.format(
             table_name=table_name,
             metadata_table=metadata_table,
@@ -114,8 +139,8 @@ class AsyncTaskTablePostgres(AsyncPostgresTable):
         return ["{table_name}.{col} AS {col}".format(table_name=self.table_name, col=k) for k in self.keys]
 
     join_columns = [
-        "{table_name}.attempt_id as attempt_id".format(table_name=table_name),
-        "start.ts_epoch as started_at",
+        "COALESCE(attempt.attempt_id, 0) as attempt_id",
+        "attempt.started_at as started_at",
         """
         (CASE
         WHEN {finished_at_column} IS NULL
@@ -127,29 +152,29 @@ class AsyncTaskTablePostgres(AsyncPostgresTable):
         """.format(
             table_name=table_name,
             heartbeat_threshold=HEARTBEAT_THRESHOLD,
-            finished_at_column="COALESCE(GREATEST(attempt_ok.ts_epoch, done.ts_epoch, task_ok.ts_epoch), next_attempt_start.ts_epoch)"
+            finished_at_column="COALESCE(GREATEST(attempt.attempt_finished_at, attempt.task_ok_finished_at), next_attempt_start.ts_epoch)"
         ),
-        "attempt_ok.value as attempt_ok",
+        "attempt.attempt_ok as attempt_ok",
         # If 'attempt_ok' is present, we can leave task_ok NULL since
         #   that is used to fetch the artifact value from remote location.
         # This process is performed at TaskRefiner (data_refiner.py)
         """
         (CASE
-            WHEN attempt_ok.ts_epoch IS NOT NULL
+            WHEN attempt.attempt_ok IS NOT NULL
             THEN NULL
-            ELSE task_ok.location
+            ELSE attempt.task_ok_location
         END) as task_ok
         """,
         """
         (CASE
-            WHEN attempt_ok.value IS TRUE
+            WHEN attempt.attempt_ok IS TRUE
             THEN 'completed'
-            WHEN attempt_ok.value IS FALSE
+            WHEN attempt.attempt_ok IS FALSE
             THEN 'failed'
-            WHEN COALESCE(done.ts_epoch, task_ok.ts_epoch) IS NOT NULL
+            WHEN COALESCE(attempt.attempt_finished_at, attempt.task_ok_finished_at) IS NOT NULL
                 AND attempt_ok IS NULL
             THEN 'unknown'
-            WHEN COALESCE(attempt_ok.ts_epoch, done.ts_epoch, task_ok.ts_epoch) IS NOT NULL
+            WHEN COALESCE(attempt.attempt_finished_at, attempt.task_ok_finished_at) IS NOT NULL
             THEN 'completed'
             WHEN next_attempt_start.ts_epoch IS NOT NULL
             THEN 'failed'
@@ -158,7 +183,7 @@ class AsyncTaskTablePostgres(AsyncPostgresTable):
                 AND {finished_at_column} IS NULL
             THEN 'failed'
             WHEN {table_name}.last_heartbeat_ts IS NULL
-                AND @(extract(epoch from now())*1000 - COALESCE(start.ts_epoch, {table_name}.ts_epoch))>{cutoff}
+                AND @(extract(epoch from now())*1000 - COALESCE(attempt.started_at, {table_name}.ts_epoch))>{cutoff}
                 AND {finished_at_column} IS NULL
             THEN 'failed'
             ELSE 'running'
@@ -166,56 +191,32 @@ class AsyncTaskTablePostgres(AsyncPostgresTable):
         """.format(
             table_name=table_name,
             heartbeat_threshold=HEARTBEAT_THRESHOLD,
-            finished_at_column="COALESCE(attempt_ok.ts_epoch, done.ts_epoch, task_ok.ts_epoch)",
+            finished_at_column="COALESCE(attempt.attempt_finished_at, attempt.task_ok_finished_at)",
             cutoff=OLD_RUN_FAILURE_CUTOFF_TIME
         ),
         """
         (CASE
             WHEN {table_name}.last_heartbeat_ts IS NULL
-                AND @(extract(epoch from now())*1000 - COALESCE(start.ts_epoch, {table_name}.ts_epoch))>{cutoff}
+                AND @(extract(epoch from now())*1000 - COALESCE(attempt.started_at, {table_name}.ts_epoch))>{cutoff}
                 AND {finished_at_column} IS NULL
             THEN NULL
             ELSE
                 COALESCE(
-                    GREATEST(attempt_ok.ts_epoch, done.ts_epoch, task_ok.ts_epoch),
+                    GREATEST(attempt.attempt_finished_at, attempt.task_ok_finished_at),
                     next_attempt_start.ts_epoch,
                     {table_name}.last_heartbeat_ts*1000,
                     @(extract(epoch from now())::bigint*1000)
-                ) - COALESCE(start.ts_epoch, {table_name}.ts_epoch)
+                ) - COALESCE(attempt.started_at, {table_name}.ts_epoch)
         END) as duration
         """.format(
             table_name=table_name,
-            finished_at_column="COALESCE(attempt_ok.ts_epoch, done.ts_epoch, task_ok.ts_epoch)",
+            finished_at_column="COALESCE(attempt.attempt_finished_at, attempt.task_ok_finished_at)",
             cutoff=OLD_RUN_FAILURE_CUTOFF_TIME
         ),
         "foreach_stack.location as foreach_stack"
     ]
     step_table_name = AsyncStepTablePostgres.table_name
     _command = MetadataTaskTable._command
-
-    async def find_records(self, conditions: List[str] = None, values=[], fetch_single=False,
-                           limit: int = 0, offset: int = 0, order: List[str] = None, groups: List[str] = None,
-                           group_limit: int = 10, expanded=False, enable_joins=False,
-                           postprocess: Callable[[DBResponse], DBResponse] = None,
-                           benchmark: bool = False, overwrite_select_from: str = None
-                           ) -> Tuple[DBResponse, DBPagination]:
-        if enable_joins:
-            # NOTE: This is a required workaround to be able to JOIN attempt specific records to tasks.
-            # the estimated max_attempts is a best guess, as tasks might have less,
-            # or more (if using a custom client that allows to exceed the default max value)
-            overwrite_select_from = "(SELECT *, generate_series(0,{max_attempts}) as attempt_id FROM {table_name}) as {table_name}".format(
-                table_name=self.table_name,
-                max_attempts=4
-            )
-            # NOTE: Clean up results off non-existent attempts. This is dependent heavily on the JOINs
-            conditions.append("NOT (attempt_id > 0 AND started_at IS NULL AND task_ok IS NULL)")
-        return await super().find_records(
-            conditions, values, fetch_single,
-            limit, offset, order,
-            groups, group_limit, expanded,
-            enable_joins, postprocess, benchmark,
-            overwrite_select_from
-        )
 
     async def get_task_attempt(self, flow_id: str, run_key: str,
                                step_name: str, task_key: str, attempt_id: int = None,

--- a/services/ui_backend_service/data/db/tables/task.py
+++ b/services/ui_backend_service/data/db/tables/task.py
@@ -134,7 +134,7 @@ class AsyncTaskTablePostgres(AsyncPostgresTable):
                 AND {finished_at_column} IS NULL
             THEN 'failed'
             WHEN {table_name}.last_heartbeat_ts IS NULL
-                AND @(extract(epoch from now()) - COALESCE(start.ts_epoch, {table_name}.ts_epoch))>{cutoff}
+                AND @(extract(epoch from now())*1000 - COALESCE(start.ts_epoch, {table_name}.ts_epoch))>{cutoff}
                 AND {finished_at_column} IS NULL
             THEN 'failed'
             ELSE 'running'
@@ -148,7 +148,7 @@ class AsyncTaskTablePostgres(AsyncPostgresTable):
         """
         (CASE
             WHEN {table_name}.last_heartbeat_ts IS NULL
-                AND @(extract(epoch from now()) - COALESCE(start.ts_epoch, {table_name}.ts_epoch))>{cutoff}
+                AND @(extract(epoch from now())*1000 - COALESCE(start.ts_epoch, {table_name}.ts_epoch))>{cutoff}
                 AND {finished_at_column} IS NULL
             THEN NULL
             ELSE

--- a/services/ui_backend_service/tests/integration_tests/runs_test.py
+++ b/services/ui_backend_service/tests/integration_tests/runs_test.py
@@ -269,9 +269,9 @@ async def test_old_run_status_without_heartbeat(cli, db):
         }
     )
     _run_failed["ts_epoch"] = _old_ts
-    # finished at should be the start time + cutoff period
-    _run_failed["finished_at"] = _run_failed["ts_epoch"] + (60 * 60 * 24 * 14 * 1000)
-    _run_failed["duration"] = _run_failed["finished_at"] - _run_failed["ts_epoch"]
+    # finished at should be none, as we can not determine a clear one.
+    _run_failed["finished_at"] = None
+    _run_failed["duration"] = None  # duration should also be none as it is indeterminate.
     _run_failed["status"] = "failed"
     _run_failed["user"] = None
     _run_failed["run"] = _run_failed["run_number"]

--- a/services/ui_backend_service/tests/integration_tests/runs_test.py
+++ b/services/ui_backend_service/tests/integration_tests/runs_test.py
@@ -257,7 +257,7 @@ async def test_old_run_status_without_heartbeat(cli, db):
 
     # A run with no end task and a timestamp older than two weeks should count as failed.
     _run_failed = (await add_run(db, flow_id=_flow.get("flow_id"))).body
-    _old_ts = _run_failed["ts_epoch"] - (60 * 60 * 24 * 14 * 1000 + 20)
+    _old_ts = _run_failed["ts_epoch"] - (60 * 60 * 24 * 14 * 1000 + 3600)
     # TODO: consider mocking get_db_ts_epoch_str() in the database adapter to be able to insert custom epochs.
     await db.run_table_postgres.update_row(
         filter_dict={
@@ -276,7 +276,7 @@ async def test_old_run_status_without_heartbeat(cli, db):
     _run_failed["user"] = None
     _run_failed["run"] = _run_failed["run_number"]
 
-    await _test_single_resource(cli, db, "/flows/{flow_id}/runs/{run_number}".format(**_run_failed), 200, _run_failed, approx_keys=["duration"])
+    await _test_single_resource(cli, db, "/flows/{flow_id}/runs/{run_number}".format(**_run_failed), 200, _run_failed)
 
 
 async def test_single_run_attempt_ok_completed(cli, db):


### PR DESCRIPTION
- further refines the cutoff logic in task queries. if a task has remained in a stuck state for two weeks, the duration will count as null instead of falling back on current time calculations.
- also reworks how task query joins are done, cleaning up attempt detection logic and improving performance

some perf test numbers


| Branch | Cost | Planning | Execution |
|-------|-----|--------|----------|
| UI | 42302.23..52876.51 | 1.017 ms | 282.702 ms |
| current | 446.93..447.03 | 1.001 ms | 119.992 ms |


also noteworthy that current query costs remain acceptable with offsets, whereas UI implementation scales poorly with increases in number of records.