### PR TITLE
UI cache error handling

### DIFF
--- a/services/ui_backend_service/data/cache/client/cache_client.py
+++ b/services/ui_backend_service/data/cache/client/cache_client.py
@@ -67,6 +67,10 @@ class CacheFuture(object):
         def _wait_paths(paths):
             # wait until one of the paths is readable
             while True:
+                # Make sure we still have pending cache worker request
+                if not self.has_pending_request():
+                    return
+
                 for path in paths:
                     if is_safely_readable(path):
                         try:

--- a/services/ui_backend_service/data/cache/client/cache_store.py
+++ b/services/ui_backend_service/data/cache/client/cache_store.py
@@ -193,7 +193,7 @@ class CacheStore(object):
                     f.close()
                     try:
                         os.symlink(dst, src)
-                    except Exception as ex:
+                    except OSError as ex:
                         # two actions may be streaming the same object
                         # simultaneously. We don't consider an existing
                         # symlink (errno 17) to be an error.
@@ -201,11 +201,11 @@ class CacheStore(object):
                             err = "Could not create a symlink %s->%s"\
                                 % (src, dst)
                             self.warn(ex, err)
+                    except Exception as ex:
+                        self.warn(ex, "Unknown error")
                     else:
                         self.active_streams[tmp] = src
                     return tmp
-            else:
-                return tmp
 
     def safe_fileop(self, fun, *args, **kwargs):
         try:

--- a/services/ui_backend_service/data/refiner/parameter_refiner.py
+++ b/services/ui_backend_service/data/refiner/parameter_refiner.py
@@ -19,14 +19,18 @@ class ParameterRefiner(Refinery):
         super().__init__(field_names=['location'], cache=cache)
 
     async def fetch_data(self, locations):
-        _res = await self.artifact_store.cache.GetArtifacts(locations)
-        if not _res.is_ready():
-            async for event in _res.stream():
-                if event["type"] == "error":
-                    # raise error, there was an exception during processing.
-                    raise GetParametersFailed(event["message"], event["id"], event["traceback"])
-            await _res.wait()  # wait for results to be ready
-        return _res.get() or {}  # cache get() might return None if no keys are produced.
+        try:
+            _res = await self.artifact_store.cache.GetArtifacts(locations)
+            if not _res.is_ready():
+                async for event in _res.stream():
+                    if event["type"] == "error":
+                        # raise error, there was an exception during processing.
+                        raise GetParametersFailed(event["message"], event["id"], event["traceback"])
+                await _res.wait()  # wait for results to be ready
+            return _res.get() or {}  # cache get() might return None if no keys are produced.
+        except Exception:
+            self.logger.exception("Exception when fetching artifact data from cache")
+            return {}
 
     async def postprocess(self, response: DBResponse):
         """Calls the refiner postprocessing to fetch S3 values for content."""


### PR DESCRIPTION
This PR introduces following changes:

- Prevent `CacheServerUnreachable` fatal error.
- Cache `max_size` is now considered as a soft limit, GC will eventually delete exceeding data after graceful period.
- Keep track of pending cache actions so that `CacheClient` and `CacheFuture` can provide accurate responses.