### PR TITLE
feat: paginate log requests

### DIFF
--- a/services/ui_backend_service/api/log.py
+++ b/services/ui_backend_service/api/log.py
@@ -435,6 +435,7 @@ def paginate_log_lines(request, lines):
     pagination = DBPagination(limit, offset, len(response.body), page)
     return format_response_list(request, response, pagination, page)
 
+
 class LogException(Exception):
     def __init__(self, msg='Failed to read log', id='log-error'):
         self.message = msg

--- a/services/ui_backend_service/api/log.py
+++ b/services/ui_backend_service/api/log.py
@@ -11,8 +11,9 @@ from collections import namedtuple
 from datetime import datetime
 from urllib.parse import urlparse
 
-from services.data.db_utils import translate_run_key, translate_task_key
+from services.data.db_utils import DBResponse, translate_run_key, translate_task_key, DBPagination, DBResponse
 from services.utils import handle_exceptions, web_response
+from .utils import pagination_query, format_response_list
 
 from aiohttp import web
 
@@ -237,7 +238,9 @@ class LogApi(object):
         if bucket and path:
             try:
                 lines = await read_and_output(self.s3_client, bucket, path)
-                return web_response(200, {'data': lines})
+                # paginate response
+                code, body = paginate_log_lines(request, lines)
+                return web_response(code, body)
             except botocore.exceptions.ClientError as err:
                 raise LogException(
                     err.response['Error']['Message'], 'log-error-s3')
@@ -282,7 +285,9 @@ class LogApi(object):
                         to_fetch.append((bucket, path))
                     bucket = url.netloc
                 lines = await read_and_output_mflog(self.s3_client, to_fetch)
-                return web_response(200, {'data': lines})
+                # paginate response
+                code, body = paginate_log_lines(request, lines)
+                return web_response(code, body)
         return web_response(404, {'data': []})
 
 
@@ -421,6 +426,14 @@ async def aenumerate(stream, start=0):
         yield i, line.decode('utf-8')
         i += 1
 
+
+def paginate_log_lines(request, lines):
+    """Paginates the log lines based on url parameters
+    """
+    page, limit, offset, *_ = pagination_query(request)
+    response = DBResponse(200, lines[-offset:][:limit:])  # Read loglines in reverse order as latest ones are most important.
+    pagination = DBPagination(limit, offset, len(response.body), page)
+    return format_response_list(request, response, pagination, page)
 
 class LogException(Exception):
     def __init__(self, msg='Failed to read log', id='log-error'):

--- a/services/ui_backend_service/doc.py
+++ b/services/ui_backend_service/doc.py
@@ -358,7 +358,7 @@ swagger_definitions = {
             "$ref": "#/definitions/ModelsNotification"
         }
     },
-    "ResponsesLog": response_object("#/definitions/ModelsLog"),
+    "ResponsesLog": response_list("#/definitions/ModelsLogRow"),
     "ResponsesLogError500": response_internal_error(
         {
             "log-error-s3": "Something went wrong with S3 access",
@@ -570,13 +570,6 @@ swagger_definitions = {
             }
         },
         "required": ["type", "box_next", "box_ends", "next"]
-    },
-    "ModelsLog": {
-        "type": "array",
-        "items": {
-            "type": "object",
-            "$ref": "#/definitions/ModelsLogRow"
-        }
     },
     "ModelsLogRow": {
         "type": "object",

--- a/services/ui_backend_service/tests/unit_tests/log_test.py
+++ b/services/ui_backend_service/tests/unit_tests/log_test.py
@@ -1,0 +1,45 @@
+import pytest
+import collections
+
+from services.ui_backend_service.api.log import paginate_log_lines
+
+pytestmark = [pytest.mark.unit_tests]
+
+TEST_LOG = list("log line {}".format(i) for i in range(1, 1001))
+
+
+@pytest.fixture
+def req():
+    "A Dummy request for testing with query parameters"
+    req = collections.namedtuple("Request", ["scheme", "host", "path", "headers", "query"])
+    req.headers = {}
+    req.query = {}
+    return req
+
+
+async def test_log_lines_pagination(req):
+    _, body = paginate_log_lines(req, TEST_LOG)
+
+    # 1000 lines should fit in default pagination
+    assert len(body['data']) == 1000
+    # order should be reverse
+    assert body['data'][0] == "log line 1000"
+
+
+async def test_log_lines_pagination_oob_page(req):
+    req.query["_page"] = 2
+    _, body = paginate_log_lines(req, TEST_LOG)
+
+    assert len(body['data']) == 0
+
+
+async def test_log_lines_pagination_with_limit(req):
+    req.query = {
+        "_limit": 5,
+        "_page": 2
+    }
+
+    _, body = paginate_log_lines(req, TEST_LOG)
+
+    assert len(body['data']) == 5
+    assert body['data'] == list("log line {}".format(i) for i in range(991, 996))[::-1]


### PR DESCRIPTION
Paginate returned logs to deal with possibly huge log files. Primarily meant to alleviate pressure from the frontend side of handling huge log files in the browser. Backend strain still remains due to having to process the whole log in-memory.
Default `_limit` for log routes is set to 1000 log lines per response, with a maximum of 10000

adds unit tests to cover pagination logic