### PR TITLE
Fix/cache streamwriter drain

### DIFF
--- a/services/ui_backend_service/data/cache/client/cache_async_client.py
+++ b/services/ui_backend_service/data/cache/client/cache_async_client.py
@@ -71,7 +71,7 @@ class CacheAsyncClient(CacheClient):
             async with self._drain_lock:
                 await asyncio.wait_for(
                     self._proc.stdin.drain(),
-                    timeout=WAIT_FREQUENCY)
+                    timeout=5)
         except asyncio.TimeoutError:
             print("StreamWriter.drain timeout", flush=True)
         except ConnectionResetError:

--- a/services/ui_backend_service/data/cache/client/cache_async_client.py
+++ b/services/ui_backend_service/data/cache/client/cache_async_client.py
@@ -1,49 +1,28 @@
 import time
 import asyncio
 import json
-import os
-import fcntl
-from datetime import datetime
 from asyncio.subprocess import PIPE, STDOUT
 
 from .cache_client import CacheClient, CacheServerUnreachable
 from .cache_server import OP_WORKER_CREATE, OP_WORKER_TERMINATE
 
+from services.utils import logging
+
 WAIT_FREQUENCY = 0.2
 HEARTBEAT_FREQUENCY = 1
-
-os.environ["PYTHONASYNCIODEBUG"] = "1"
-
-
-def get_object_methods(obj):
-    return [method_name for method_name in dir(obj)
-            if callable(getattr(obj, method_name))]
 
 
 class CacheAsyncClient(CacheClient):
     _drain_lock = asyncio.Lock()
 
     async def start_server(self, cmdline, env):
+        self.logger = logging.getLogger("CacheAsyncClient:{root}".format(root=self._root))
+
         self._proc = await asyncio.create_subprocess_exec(*cmdline,
                                                           env=env,
                                                           stdin=PIPE,
                                                           stdout=PIPE,
                                                           stderr=STDOUT)
-
-        def _make_fd_non_blocking(fd):
-            fl = fcntl.fcntl(fd, fcntl.F_GETFL)
-            fcntl.fcntl(fd, fcntl.F_SETFL, fl | os.O_NONBLOCK)
-
-        self.stdin_pipe = self._proc.stdin.get_extra_info('pipe')
-        self.stdin_fileno = self.stdin_pipe.fileno()
-
-        print("stdin {}".format(get_object_methods(self._proc.stdin)), flush=True)
-        print("stdin_pipe {}".format(get_object_methods(self.stdin_pipe)), flush=True)
-        print("stdin_fileno {}".format(get_object_methods(self.stdin_fileno)), flush=True)
-
-        _make_fd_non_blocking(self.stdin_fileno)
-
-        self._proc.stdin.transport.set_write_buffer_limits(0)
 
         asyncio.gather(
             self._heartbeat(),
@@ -52,20 +31,7 @@ class CacheAsyncClient(CacheClient):
 
     async def _read_pipe(self, src):
         while self._is_alive:
-
-            # try:
-            #     async with self._drain_lock:
-            #         await asyncio.wait_for(
-            #             self._proc.stdin.drain(),
-            #             timeout=WAIT_FREQUENCY)
-            # except asyncio.TimeoutError:
-            #     print("StreamWriter.drain timeout (_read_pipe)", flush=True)
-
             line = await src.readline()
-
-            now = datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%S.%f')
-            print("[{}] stdout ({}) - {}".format(now, self._root, repr(self._proc.stdout)), flush=True)
-
             if not line:
                 await asyncio.sleep(WAIT_FREQUENCY)
                 break
@@ -85,10 +51,8 @@ class CacheAsyncClient(CacheClient):
             else:
                 return
 
-            print("Message {}".format(message), flush=True)
-
-            print("Pending stream keys: {}".format(
-                list(self.pending_requests)), flush=True)
+            self.logger.info("Pending stream keys: {}".format(
+                list(self.pending_requests)))
         except Exception:
             pass
 
@@ -109,15 +73,12 @@ class CacheAsyncClient(CacheClient):
             async with self._drain_lock:
                 await asyncio.wait_for(
                     self._proc.stdin.drain(),
-                    timeout=5)
+                    timeout=WAIT_FREQUENCY)
         except asyncio.TimeoutError:
-            print("StreamWriter.drain timeout", flush=True)
+            self.logger.warn("StreamWriter.drain timeout: {}".format(repr(self._proc.stdin)))
         except ConnectionResetError:
             self._is_alive = False
             raise CacheServerUnreachable()
-        finally:
-            now = datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%S.%f')
-            print("[{}] stdin ({}) - {}".format(now, self._root, repr(self._proc.stdin)), flush=True)
 
     async def wait_iter(self, it, timeout):
         end = time.time() + timeout


### PR DESCRIPTION
- Use `asyncio.Lock()` while draining `StreamWriter` due to concurrency issues.
- Pipe stderr to stdout (single `StreamReader` source instead of two)
- Use `self._is_alive` while reading stdout `StreamReader` output