### PR TITLE
CacheAsyncClient increase pipe buffer

### DIFF
--- a/services/ui_backend_service/data/cache/client/cache_async_client.py
+++ b/services/ui_backend_service/data/cache/client/cache_async_client.py
@@ -23,11 +23,12 @@ class CacheAsyncClient(CacheClient):
                                                           env=env,
                                                           stdin=PIPE,
                                                           stdout=PIPE,
-                                                          stderr=STDOUT)
+                                                          stderr=STDOUT,
+                                                          limit=1024000)  # 1024KB
 
         asyncio.gather(
             self._heartbeat(),
-            self.read_stdout(),
+            self.read_stdout()
         )
 
     async def _read_pipe(self, src):
@@ -45,7 +46,7 @@ class CacheAsyncClient(CacheClient):
     async def read_message(self, line: str):
         try:
             message = json.loads(line)
-            self.logger.info("Operation: {}".format(message))
+            self.logger.info(message)
             if message['op'] == OP_WORKER_CREATE:
                 self.pending_requests.add(message['stream_key'])
             elif message['op'] == OP_WORKER_TERMINATE:

--- a/services/ui_backend_service/data/cache/client/cache_server.py
+++ b/services/ui_backend_service/data/cache/client/cache_server.py
@@ -208,7 +208,7 @@ class Worker(object):
 
     def _worker_details(self):
         return {
-            'keys': self.request['keys'],
+            'keys': len(self.request['keys']),
             'stream_key': self.request['stream_key'],
             'idempotency_token': self.request["idempotency_token"],
         }

--- a/services/ui_backend_service/data/refiner/parameter_refiner.py
+++ b/services/ui_backend_service/data/refiner/parameter_refiner.py
@@ -18,19 +18,19 @@ class ParameterRefiner(Refinery):
     def __init__(self, cache):
         super().__init__(field_names=['location'], cache=cache)
 
-    # async def fetch_data(self, locations):
-    #     try:
-    #         _res = await self.artifact_store.cache.GetArtifacts(locations)
-    #         if not _res.is_ready():
-    #             async for event in _res.stream():
-    #                 if event["type"] == "error":
-    #                     # raise error, there was an exception during processing.
-    #                     raise GetParametersFailed(event["message"], event["id"], event["traceback"])
-    #             await _res.wait()  # wait for results to be ready
-    #         return _res.get() or {}  # cache get() might return None if no keys are produced.
-    #     except Exception:
-    #         self.logger.exception("Exception when fetching artifact data from cache")
-    #         return {}
+    async def fetch_data(self, locations):
+        try:
+            _res = await self.artifact_store.cache.GetArtifacts(locations)
+            if not _res.is_ready():
+                async for event in _res.stream():
+                    if event["type"] == "error":
+                        # raise error, there was an exception during processing.
+                        raise GetParametersFailed(event["message"], event["id"], event["traceback"])
+                await _res.wait()  # wait for results to be ready
+            return _res.get() or {}  # cache get() might return None if no keys are produced.
+        except Exception:
+            self.logger.exception("Exception when fetching artifact data from cache")
+            return {}
 
     async def postprocess(self, response: DBResponse):
         """Calls the refiner postprocessing to fetch S3 values for content."""

--- a/services/ui_backend_service/data/refiner/parameter_refiner.py
+++ b/services/ui_backend_service/data/refiner/parameter_refiner.py
@@ -18,19 +18,19 @@ class ParameterRefiner(Refinery):
     def __init__(self, cache):
         super().__init__(field_names=['location'], cache=cache)
 
-    async def fetch_data(self, locations):
-        try:
-            _res = await self.artifact_store.cache.GetArtifacts(locations)
-            if not _res.is_ready():
-                async for event in _res.stream():
-                    if event["type"] == "error":
-                        # raise error, there was an exception during processing.
-                        raise GetParametersFailed(event["message"], event["id"], event["traceback"])
-                await _res.wait()  # wait for results to be ready
-            return _res.get() or {}  # cache get() might return None if no keys are produced.
-        except Exception:
-            self.logger.exception("Exception when fetching artifact data from cache")
-            return {}
+    # async def fetch_data(self, locations):
+    #     try:
+    #         _res = await self.artifact_store.cache.GetArtifacts(locations)
+    #         if not _res.is_ready():
+    #             async for event in _res.stream():
+    #                 if event["type"] == "error":
+    #                     # raise error, there was an exception during processing.
+    #                     raise GetParametersFailed(event["message"], event["id"], event["traceback"])
+    #             await _res.wait()  # wait for results to be ready
+    #         return _res.get() or {}  # cache get() might return None if no keys are produced.
+    #     except Exception:
+    #         self.logger.exception("Exception when fetching artifact data from cache")
+    #         return {}
 
     async def postprocess(self, response: DBResponse):
         """Calls the refiner postprocessing to fetch S3 values for content."""


### PR DESCRIPTION
- Increase CacheAsyncClient pipe buffer from 64KB to 1024KB
- Prevent passing of individual artifact keys from subprocess to ensure buffer is not exceeded

This PR is a precautionary measure, actual issue which is the cache limit should not be configured to exceed available disk space. Configured with env variables:
- `CACHE_ARTIFACT_STORAGE_LIMIT`
- `CACHE_DAG_STORAGE_LIMIT`