### PR TITLE
fix: tags autocomplete performance enhancement

### DIFF
--- a/services/ui_backend_service/api/autocomplete.py
+++ b/services/ui_backend_service/api/autocomplete.py
@@ -1,21 +1,43 @@
 from services.utils import handle_exceptions
-from services.data.db_utils import translate_run_key
+from services.data.db_utils import DBResponse, DBPagination, translate_run_key
 from .utils import format_response, format_response_list, web_response, custom_conditions_query, pagination_query
+import sys
+import asyncio
+import re
+
+TAGS_FILL_INTERVAL_SECONDS = 60 * 5
 
 
 class AutoCompleteApi(object):
-    # Cache tags so we don't have to request DB everytime
-    tags = None
 
     def __init__(self, app, db):
         self.db = db
         # Cached resources
+        # Cache tags so we don't have to request DB everytime
+        self.tags = []
         app.router.add_route("GET", "/tags/autocomplete", self.get_tags)
         # Non-cached resources
         app.router.add_route("GET", "/flows/autocomplete", self.get_flows)
         app.router.add_route("GET", "/flows/{flow_id}/runs/autocomplete", self.get_runs_for_flow)
         app.router.add_route("GET", "/flows/{flow_id}/runs/{run_id}/steps/autocomplete", self.get_steps_for_run)
         app.router.add_route("GET", "/flows/{flow_id}/runs/{run_id}/artifacts/autocomplete", self.get_artifacts_for_run)
+        loop = asyncio.get_event_loop()
+        loop.create_task(self.periodic_tags_fetch_and_cache())
+
+    async def periodic_tags_fetch_and_cache(self):
+        '''
+        Async task that fill tags cache every 5minutes. Database query might take a while
+        so its better to cache the result.
+        '''
+        while True:
+            # Get all tags that are mentioned in runs table
+            res, _ = await self.db.run_table_postgres.get_tags()
+            if res.response_code == 200:
+                self.tags = sorted(res.body)
+            size = sys.getsizeof(self.tags) // 1024 // 1024
+            print("SIZE OF TAGS IN MEM: {} Mb".format(size), flush=True)
+            # Check tags again after some sleep
+            await asyncio.sleep(TAGS_FILL_INTERVAL_SECONDS)
 
     @handle_exceptions
     async def get_tags(self, request):
@@ -32,7 +54,33 @@ class AutoCompleteApi(object):
                 schema:
                     $ref: '#/definitions/ResponsesAutocompleteTagList'
         """
-        return await resource_response(request, self.db.run_table_postgres.get_tags, allowed_keys=["tag"])
+        # pagination setup
+        page, limit, offset, _, _, _ = pagination_query(request)
+
+        array_filter_ops = {
+            'co': (lambda item, term: term in item),
+            're': (lambda item, pattern: re.compile(pattern).match(item))
+        }
+        for key, val in request.query.items():
+            deconstruct = key.split(":", 1)
+            if len(deconstruct) > 1:
+                field = deconstruct[0]
+                operator = deconstruct[1]
+            else:
+                field = key
+                operator = None
+
+            if field == 'tag' and operator in array_filter_ops:
+                filter_func = array_filter_ops[operator]
+            else:
+                filter_func = None
+
+        tags = [tag for tag in self.tags if filter_func(tag, val)][offset:(offset + limit)]
+        count = len(tags)
+        pagination = DBPagination(limit, offset, count, page)
+
+        status, body = format_response_list(request, DBResponse(200, tags), pagination, page)
+        return web_response(status, body)
 
     @handle_exceptions
     async def get_flows(self, request):

--- a/services/ui_backend_service/api/autocomplete.py
+++ b/services/ui_backend_service/api/autocomplete.py
@@ -1,4 +1,4 @@
-from services.utils import handle_exceptions
+from services.utils import handle_exceptions, logging
 from services.data.db_utils import DBResponse, DBPagination, translate_run_key
 from .utils import format_response, format_response_list, web_response, custom_conditions_query, pagination_query
 import sys
@@ -15,6 +15,7 @@ class AutoCompleteApi(object):
         # Cached resources
         # Cache tags so we don't have to request DB everytime
         self.tags = []
+        self.logger = logging.getLogger("AutoCompleteApi")
         app.router.add_route("GET", "/tags/autocomplete", self.get_tags)
         # Non-cached resources
         app.router.add_route("GET", "/flows/autocomplete", self.get_flows)
@@ -40,7 +41,8 @@ class AutoCompleteApi(object):
         if res.response_code == 200:
             self.tags = sorted(res.body)
         size = sys.getsizeof(self.tags) // 1024 // 1024
-        print("SIZE OF TAGS IN MEM: {} Mb".format(size), flush=True)
+        count = len(self.tags)
+        self.logger.info("{} cached tags in memory consuming {} Mb".format(count, size))
 
     @handle_exceptions
     async def get_tags(self, request):

--- a/services/ui_backend_service/tests/integration_tests/autocomplete_test.py
+++ b/services/ui_backend_service/tests/integration_tests/autocomplete_test.py
@@ -84,8 +84,8 @@ async def test_tags_autocomplete(cli, db):
     # no-match
     await _test_list_resources(cli, db, '/tags/autocomplete?tag:co=nothing', 200, [])
 
-    # Custom match
-    await _test_list_resources(cli, db, '/tags/autocomplete?tag:li=tag:%25thing', 200, ['tag:something'])
+    # Custom match 'tag:.*thing'
+    await _test_list_resources(cli, db, '/tags/autocomplete?tag:re=tag:%46%42thing', 200, ['tag:something'])
 
 
 async def test_artifacts_autocomplete(cli, db):

--- a/services/ui_backend_service/tests/integration_tests/autocomplete_test.py
+++ b/services/ui_backend_service/tests/integration_tests/autocomplete_test.py
@@ -75,6 +75,9 @@ async def test_tags_autocomplete(cli, db):
     await _test_list_resources(cli, db, '/tags/autocomplete', 200, [])
     await add_flow(db, flow_id="HelloFlow")
     await add_run(db, flow_id="HelloFlow", run_id="HelloRun", tags=["tag:something"])
+
+    # manually refresh the cached tags
+    await cli.server.app.AutoCompleteApi.update_cached_tags()
     # Note that runtime:dev tags gets assigned automatically
     await _test_list_resources(cli, db, '/tags/autocomplete', 200, ['runtime:dev', 'tag:something'])
     
@@ -85,7 +88,7 @@ async def test_tags_autocomplete(cli, db):
     await _test_list_resources(cli, db, '/tags/autocomplete?tag:co=nothing', 200, [])
 
     # Custom match 'tag:.*thing'
-    await _test_list_resources(cli, db, '/tags/autocomplete?tag:re=tag:%46%42thing', 200, ['tag:something'])
+    await _test_list_resources(cli, db, '/tags/autocomplete?tag:re=tag:.*thing', 200, ['tag:something'])
 
 
 async def test_artifacts_autocomplete(cli, db):


### PR DESCRIPTION
Changes the tags autocomplete routes to use in-memory cached tags and list operations for filtering. Backend fetches fresh tags periodically. Initial benchmarks show that this performs immensely better than the query-only approach (~300ms vs 5sec latencies)