### PR TITLE
fix[cache]: Get artifact error report for individual items.

### DIFF
--- a/services/ui_backend_service/api/artifact.py
+++ b/services/ui_backend_service/api/artifact.py
@@ -53,6 +53,7 @@ class ArtificatsApi(object):
           - $ref: '#/definitions/Params/Custom/ds_type'
           - $ref: '#/definitions/Params/Custom/attempt_id'
           - $ref: '#/definitions/Params/Custom/postprocess'
+          - $ref: '#/definitions/Params/Custom/invalidate'
           - $ref: '#/definitions/Params/Custom/user_name'
           - $ref: '#/definitions/Params/Custom/ts_epoch'
         produces:
@@ -117,6 +118,7 @@ class ArtificatsApi(object):
           - $ref: '#/definitions/Params/Custom/ds_type'
           - $ref: '#/definitions/Params/Custom/attempt_id'
           - $ref: '#/definitions/Params/Custom/postprocess'
+          - $ref: '#/definitions/Params/Custom/invalidate'
           - $ref: '#/definitions/Params/Custom/user_name'
           - $ref: '#/definitions/Params/Custom/ts_epoch'
         produces:
@@ -176,6 +178,7 @@ class ArtificatsApi(object):
           - $ref: '#/definitions/Params/Custom/ds_type'
           - $ref: '#/definitions/Params/Custom/attempt_id'
           - $ref: '#/definitions/Params/Custom/postprocess'
+          - $ref: '#/definitions/Params/Custom/invalidate'
           - $ref: '#/definitions/Params/Custom/user_name'
           - $ref: '#/definitions/Params/Custom/ts_epoch'
         produces:

--- a/services/ui_backend_service/api/run.py
+++ b/services/ui_backend_service/api/run.py
@@ -1,6 +1,7 @@
 from services.data.db_utils import DBResponse, translate_run_key
 from services.utils import handle_exceptions
-from .utils import find_records, web_response, format_response, builtin_conditions_query, pagination_query
+from .utils import find_records, web_response, format_response,\
+    builtin_conditions_query, pagination_query, query_param_enabled
 
 import json
 
@@ -184,6 +185,7 @@ class RunApi(object):
           parameters:
             - $ref: '#/definitions/Params/Path/flow_id'
             - $ref: '#/definitions/Params/Path/run_number'
+            - $ref: '#/definitions/Params/Custom/invalidate'
           produces:
           - application/json
           responses:
@@ -203,8 +205,11 @@ class RunApi(object):
         flow_name = request.match_info['flow_id']
         run_number = request.match_info.get("run_number")
 
+        invalidate_cache = query_param_enabled(request, "invalidate")
+
         # _artifact_store.get_run_parameters will translate run_number/run_id properly
-        combined_results = await self._artifact_store.get_run_parameters(flow_name, run_number)
+        combined_results = await self._artifact_store.get_run_parameters(
+            flow_name, run_number, invalidate_cache=invalidate_cache)
 
         response = DBResponse(200, combined_results)
         status, body = format_response(request, response)

--- a/services/ui_backend_service/api/task.py
+++ b/services/ui_backend_service/api/task.py
@@ -55,6 +55,7 @@ class TaskApi(object):
           - $ref: '#/definitions/Params/Custom/finished_at'
           - $ref: '#/definitions/Params/Custom/duration'
           - $ref: '#/definitions/Params/Custom/postprocess'
+          - $ref: '#/definitions/Params/Custom/invalidate'
         produces:
         - application/json
         responses:
@@ -112,6 +113,7 @@ class TaskApi(object):
           - $ref: '#/definitions/Params/Custom/finished_at'
           - $ref: '#/definitions/Params/Custom/duration'
           - $ref: '#/definitions/Params/Custom/postprocess'
+          - $ref: '#/definitions/Params/Custom/invalidate'
         produces:
         - application/json
         responses:
@@ -160,6 +162,7 @@ class TaskApi(object):
           - $ref: '#/definitions/Params/Path/step_name'
           - $ref: '#/definitions/Params/Path/task_id'
           - $ref: '#/definitions/Params/Custom/postprocess'
+          - $ref: '#/definitions/Params/Custom/invalidate'
         produces:
         - application/json
         responses:
@@ -223,6 +226,7 @@ class TaskApi(object):
           - $ref: '#/definitions/Params/Custom/finished_at'
           - $ref: '#/definitions/Params/Custom/duration'
           - $ref: '#/definitions/Params/Custom/postprocess'
+          - $ref: '#/definitions/Params/Custom/invalidate'
         produces:
         - application/json
         responses:

--- a/services/ui_backend_service/data/cache/client/cache_action.py
+++ b/services/ui_backend_service/data/cache/client/cache_action.py
@@ -41,8 +41,10 @@ class CacheAction(object):
            doesn't have any streaming results.
         4. `disposable_keys`: a subset of `obj_keys` that will
            be purged from the cache before other objects.
+        5. `invalidate_cache`: boolean to indicate if existing
+           cache keys should be invalidated.
         """
-        # return message, obj_keys, stream_key, disposable_keys
+        # return message, obj_keys, stream_key, disposable_keys, invalidate_cache
         raise NotImplementedError
 
     @classmethod
@@ -76,7 +78,8 @@ class CacheAction(object):
                 message=None,
                 keys=[],
                 existing_keys={},
-                stream_output=None):
+                stream_output=None,
+                invalidate_cache=False):
         """
         Execute an action. This method is called by `cache_worker` to
         execute the action as a subprocess.
@@ -87,6 +90,8 @@ class CacheAction(object):
           available.
         - `stream_output` is a function that can be called to produce
           an output event to the stream object.
+        - `invalidate_cache` boolean to indicate whether to invalidate
+          existing cache keys.
 
         Returns a dictionary that includes a string/byte result
         per key that will be stored in the cache.
@@ -101,7 +106,7 @@ class Check(CacheAction):
     @classmethod
     def format_request(cls, *args, **kwargs):
         key = 'check-%s' % uuid.uuid4()
-        return None, [key], None, [key]
+        return None, [key], None, [key], False
 
     @classmethod
     def response(cls, keys_objs):

--- a/services/ui_backend_service/data/cache/client/cache_async_client.py
+++ b/services/ui_backend_service/data/cache/client/cache_async_client.py
@@ -4,7 +4,7 @@ import asyncio
 import json
 from asyncio.subprocess import PIPE, STDOUT
 
-from .cache_client import CacheClient, CacheServerUnreachable
+from .cache_client import CacheClient, CacheServerUnreachable, CacheClientTimeout
 from .cache_server import OP_WORKER_CREATE, OP_WORKER_TERMINATE
 
 from services.utils import logging

--- a/services/ui_backend_service/data/cache/client/cache_client.py
+++ b/services/ui_backend_service/data/cache/client/cache_client.py
@@ -47,7 +47,7 @@ class CacheFuture(object):
         return bool(self.stream_key)
 
     def wait(self, timeout=FOREVER):
-        return self.client.wait(lambda: True if self.is_ready() else None,
+        return self.client.wait(lambda: None if self.has_pending_request() else True,
                                 timeout)
 
     def get(self):
@@ -183,7 +183,8 @@ class CacheClient(object):
             msg, keys, stream_key, disposable_keys =\
                 cls.format_request(*args, **kwargs)
             future = CacheFuture(keys, stream_key, self, cls, self._root)
-            if future.key_paths_ready():
+            invalidate_cache = msg.get('invalidate_cache', False)
+            if future.key_paths_ready() and not invalidate_cache:
                 # cache hit
                 req = None
             else:

--- a/services/ui_backend_service/data/cache/client/cache_client.py
+++ b/services/ui_backend_service/data/cache/client/cache_client.py
@@ -55,10 +55,12 @@ class CacheFuture(object):
             with open(path, 'rb') as f:
                 return f.read()
 
+        _safe_key_paths = {key: path for key, path in self.key_paths.items() if is_safely_readable(path)}
         if self.key_objs is None and self.is_ready():
             self.key_objs = {key: _read(path)
-                             for key, path in self.key_paths.items()
+                             for key, path in _safe_key_paths.items()
                              if key != self.stream_key}
+
         if self.key_objs:
             return self.action.response(self.key_objs)
 

--- a/services/ui_backend_service/data/cache/client/cache_client.py
+++ b/services/ui_backend_service/data/cache/client/cache_client.py
@@ -180,10 +180,9 @@ class CacheClient(object):
     def _action(self, cls):
 
         def _call(*args, **kwargs):
-            msg, keys, stream_key, disposable_keys =\
+            msg, keys, stream_key, disposable_keys, invalidate_cache =\
                 cls.format_request(*args, **kwargs)
             future = CacheFuture(keys, stream_key, self, cls, self._root)
-            invalidate_cache = msg.get('invalidate_cache', False)
             if future.key_paths_ready() and not invalidate_cache:
                 # cache hit
                 req = None
@@ -199,7 +198,8 @@ class CacheClient(object):
                                  keys=keys,
                                  stream_key=stream_key,
                                  message=msg,
-                                 disposable_keys=disposable_keys)
+                                 disposable_keys=disposable_keys,
+                                 invalidate_cache=invalidate_cache)
 
             return self.request_and_return([req] if req else [], future)
 

--- a/services/ui_backend_service/data/cache/client/cache_server.py
+++ b/services/ui_backend_service/data/cache/client/cache_server.py
@@ -43,7 +43,8 @@ def server_request(op,
                    stream_key=None,
                    message=None,
                    disposable_keys=None,
-                   idempotency_token=None):
+                   idempotency_token=None,
+                   invalidate_cache=False):
 
     if idempotency_token is None:
         fields = [op]
@@ -65,7 +66,8 @@ def server_request(op,
         'stream_key': stream_key,
         'message': message,
         'idempotency_token': token,
-        'disposable_keys': disposable_keys
+        'disposable_keys': disposable_keys,
+        'invalidate_cache': invalidate_cache
     }
 
 
@@ -154,7 +156,8 @@ class Worker(object):
                 'message': self.request['message'],
                 'keys': {key: key_filename(key) for key in keys},
                 'existing_keys': ex_keys,
-                'stream_key': key_filename(stream) if stream else None
+                'stream_key': key_filename(stream) if stream else None,
+                'invalidate_cache': self.request.get('invalidate_cache', False)
             }
             json.dump(request, f)
 

--- a/services/ui_backend_service/data/cache/client/cache_worker.py
+++ b/services/ui_backend_service/data/cache/client/cache_worker.py
@@ -48,7 +48,8 @@ def cli(action_spec, request_file=None):
             message=req['message'],
             keys=keys,
             existing_keys=ex_keys,
-            stream_output=stream_output)
+            stream_output=stream_output,
+            invalidate_cache=req.get('invalidate_cache', False))
 
         # write outputs to keys
         for key, val in res.items():

--- a/services/ui_backend_service/data/cache/generate_dag_action.py
+++ b/services/ui_backend_service/data/cache/generate_dag_action.py
@@ -50,8 +50,7 @@ class GenerateDag(CacheAction):
     def format_request(cls, flow_id, codepackage_location, invalidate_cache=False):
         msg = {
             'location': codepackage_location,
-            'flow_id': flow_id,
-            'invalidate_cache': invalidate_cache
+            'flow_id': flow_id
         }
         result_key = 'dag:result:%s' % hashlib.sha1((flow_id + codepackage_location).encode('utf-8')).hexdigest()
         stream_key = 'dag:stream:%s' % hashlib.sha1((flow_id + codepackage_location).encode('utf-8')).hexdigest()
@@ -59,7 +58,8 @@ class GenerateDag(CacheAction):
         return msg,\
             [result_key],\
             stream_key,\
-            [stream_key]
+            [stream_key],\
+            invalidate_cache
 
     @classmethod
     def response(cls, keys_objs):
@@ -79,6 +79,7 @@ class GenerateDag(CacheAction):
                 keys=None,
                 existing_keys={},
                 stream_output=None,
+                invalidate_cache=False,
                 **kwargs):
 
         results = {}

--- a/services/ui_backend_service/data/cache/generate_dag_action.py
+++ b/services/ui_backend_service/data/cache/generate_dag_action.py
@@ -47,10 +47,11 @@ class GenerateDag(CacheAction):
     """
 
     @classmethod
-    def format_request(cls, flow_id, codepackage_location):
+    def format_request(cls, flow_id, codepackage_location, invalidate_cache=False):
         msg = {
             'location': codepackage_location,
-            'flow_id': flow_id
+            'flow_id': flow_id,
+            'invalidate_cache': invalidate_cache
         }
         result_key = 'dag:result:%s' % hashlib.sha1((flow_id + codepackage_location).encode('utf-8')).hexdigest()
         stream_key = 'dag:stream:%s' % hashlib.sha1((flow_id + codepackage_location).encode('utf-8')).hexdigest()

--- a/services/ui_backend_service/data/cache/get_artifacts_action.py
+++ b/services/ui_backend_service/data/cache/get_artifacts_action.py
@@ -36,8 +36,7 @@ class GetArtifacts(CacheAction):
     def format_request(cls, locations, invalidate_cache=False):
         unique_locs = list(frozenset(sorted(loc for loc in locations if isinstance(loc, str))))
         msg = {
-            'artifact_locations': unique_locs,
-            'invalidate_cache': invalidate_cache
+            'artifact_locations': unique_locs
         }
 
         artifact_keys = []
@@ -50,7 +49,8 @@ class GetArtifacts(CacheAction):
         return msg,\
             artifact_keys,\
             stream_key,\
-            [stream_key]
+            [stream_key],\
+            invalidate_cache
 
     @classmethod
     def response(cls, keys_objs):
@@ -83,6 +83,7 @@ class GetArtifacts(CacheAction):
                 keys=None,
                 existing_keys={},
                 stream_output=None,
+                invalidate_cache=False,
                 **kwargs):
         """
         Execute fetching of artifacts from predefined S3 locations.
@@ -102,7 +103,6 @@ class GetArtifacts(CacheAction):
         Stream error example:
             stream_error(str(ex), "s3-not-found", get_traceback_str(), artifact_key)
         """
-        invalidate_cache = message['invalidate_cache']
         locations = message['artifact_locations']
 
         if invalidate_cache:

--- a/services/ui_backend_service/data/cache/search_artifacts_action.py
+++ b/services/ui_backend_service/data/cache/search_artifacts_action.py
@@ -4,8 +4,9 @@ import json
 from .client import CacheAction
 from services.utils import get_traceback_str
 from .utils import (MetaflowS3AccessDenied, MetaflowS3CredentialsMissing,
-                    MetaflowS3URLException, NoRetryS3, batchiter, decode,
-                    error_event_msg, progress_event_msg)
+                    MetaflowS3NotFound, MetaflowS3Exception,
+                    MetaflowS3URLException, NoRetryS3,
+                    batchiter, decode, error_event_msg, progress_event_msg)
 
 MAX_SIZE = 4096
 S3_BATCH_SIZE = 512

--- a/services/ui_backend_service/data/cache/search_artifacts_action.py
+++ b/services/ui_backend_service/data/cache/search_artifacts_action.py
@@ -40,11 +40,12 @@ class SearchArtifacts(CacheAction):
     """
 
     @classmethod
-    def format_request(cls, locations, searchterm):
+    def format_request(cls, locations, searchterm, invalidate_cache=False):
         unique_locs = list(frozenset(sorted(locations)))
         msg = {
             'artifact_locations': unique_locs,
-            'searchterm': searchterm
+            'searchterm': searchterm,
+            'invalidate_cache': invalidate_cache
         }
 
         artifact_keys = []

--- a/services/ui_backend_service/data/cache/store.py
+++ b/services/ui_backend_service/data/cache/store.py
@@ -147,7 +147,7 @@ class ArtifactCacheStore(object):
             else:
                 logger.info(event)
 
-    async def get_run_parameters(self, flow_id: str, run_number: int) -> Optional[Dict]:
+    async def get_run_parameters(self, flow_id: str, run_number: int, invalidate_cache=False) -> Optional[Dict]:
         """
         Fetches run parameter artifact locations, fetches the artifact content from S3, parses it, and returns
         a formatted dict of names&values
@@ -171,7 +171,8 @@ class ArtifactCacheStore(object):
         """
         db_response, *_ = await self._artifact_table.get_run_parameter_artifacts(
             flow_id, run_number,
-            self.parameter_refiner.postprocess)
+            postprocess=self.parameter_refiner.postprocess,
+            invalidate_cache=invalidate_cache)
 
         # Return nothing if params artifacts were not found.
         if not db_response.response_code == 200:

--- a/services/ui_backend_service/data/cache/utils.py
+++ b/services/ui_backend_service/data/cache/utils.py
@@ -136,13 +136,14 @@ def progress_event_msg(number):
     }
 
 
-def error_event_msg(msg, id, traceback=None):
+def error_event_msg(msg, id, traceback=None, key=None):
     "formatter for cache action error stream messages"
     return {
         "type": "error",
         "message": msg,
         "id": id,
-        "traceback": traceback
+        "traceback": traceback,
+        "key": key
     }
 
 

--- a/services/ui_backend_service/data/db/tables/artifact.py
+++ b/services/ui_backend_service/data/db/tables/artifact.py
@@ -36,7 +36,7 @@ class AsyncArtifactTablePostgres(AsyncPostgresTable):
         # be sure to return a list of unique locations
         return list(frozenset(artifact['location'] for artifact in _records.body if 'location' in artifact))
 
-    async def get_run_parameter_artifacts(self, flow_name, run_number, postprocess=None):
+    async def get_run_parameter_artifacts(self, flow_name, run_number, postprocess=None, invalidate_cache=False):
         run_id_key, run_id_value = translate_run_key(run_number)
 
         # '_parameters' step has all the parameters as artifacts. only pick the
@@ -60,7 +60,8 @@ class AsyncArtifactTablePostgres(AsyncPostgresTable):
             ],
             fetch_single=False,
             expanded=True,
-            postprocess=postprocess
+            postprocess=postprocess,
+            invalidate_cache=invalidate_cache
         )
 
     async def get_artifact_names(self, conditions: List[str] = [],

--- a/services/ui_backend_service/data/db/tables/base.py
+++ b/services/ui_backend_service/data/db/tables/base.py
@@ -59,7 +59,8 @@ class AsyncPostgresTable(MetadataAsyncPostgresTable):
                            limit: int = 0, offset: int = 0, order: List[str] = None, groups: List[str] = None,
                            group_limit: int = 10, expanded=False, enable_joins=False,
                            postprocess: Callable[[DBResponse], DBResponse] = None,
-                           benchmark: bool = False, overwrite_select_from: str = None
+                           invalidate_cache=False, benchmark: bool = False,
+                           overwrite_select_from: str = None
                            ) -> (DBResponse, DBPagination):
         # Grouping not enabled
         if groups is None or len(groups) == 0:
@@ -183,9 +184,9 @@ class AsyncPostgresTable(MetadataAsyncPostgresTable):
         # Modify the response after the fetch has been executed
         if postprocess is not None:
             if iscoroutinefunction(postprocess):
-                result = await postprocess(result)
+                result = await postprocess(result, invalidate_cache=invalidate_cache)
             else:
-                result = postprocess(result)
+                result = postprocess(result, invalidate_cache=invalidate_cache)
 
         return result, pagination, benchmark_results
 

--- a/services/ui_backend_service/data/refiner/artifact_refiner.py
+++ b/services/ui_backend_service/data/refiner/artifact_refiner.py
@@ -1,4 +1,4 @@
-from .refinery import Refinery, unpack_processed_value, format_error_body, GetArtifactsFailed
+from .refinery import Refinery, unpack_processed_value, format_error_body
 from services.data.db_utils import DBResponse
 
 
@@ -16,38 +16,6 @@ class ArtifactRefiner(Refinery):
 
     def __init__(self, cache):
         super().__init__(field_names=["content"], cache=cache)
-
-    async def refine_record(self, record, invalidate_cache=False):
-        _recs = self.refine_records([record], invalidate_cache=invalidate_cache)
-        return _recs[0] if len(_recs) > 0 else record
-
-    async def refine_records(self, records, invalidate_cache=False):
-        locations = [record[field] for field in self.field_names for record in records if field in record]
-        errors = {}
-
-        def _event_stream(event):
-            if event.get("type") == "error" and event.get("key"):
-                loc = artifact_location_from_key(event["key"])
-                errors[loc] = event
-
-        responses = await self.fetch_data(
-            locations, event_stream=_event_stream, invalidate_cache=invalidate_cache)
-
-        _recs = []
-        for rec in records:
-            _rec = rec.copy()
-            for k, v in rec.items():
-                if k in self.field_names:
-                    if v in errors:
-                        _rec["postprocess_error"] = format_error_body(
-                            errors[v].get("id"),
-                            errors[v].get("message"),
-                            errors[v].get("traceback")
-                        )
-                    else:
-                        _rec[k] = responses[v] if v in responses else None
-            _recs.append(_rec)
-        return _recs
 
     async def fetch_data(self, locations, event_stream=None, invalidate_cache=False):
         _res = await self.artifact_store.cache.GetArtifactsWithStatus(
@@ -113,8 +81,3 @@ class ArtifactRefiner(Refinery):
             body = _process(refined_response.body)
 
         return DBResponse(response_code=refined_response.response_code, body=body)
-
-
-def artifact_location_from_key(x):
-    "extract location from the artifact cache key"
-    return x[len("search:artifactdata:"):]

--- a/services/ui_backend_service/data/refiner/artifact_refiner.py
+++ b/services/ui_backend_service/data/refiner/artifact_refiner.py
@@ -18,48 +18,43 @@ class ArtifactRefiner(Refinery):
         super().__init__(field_names=["content"], cache=cache)
 
     async def refine_record(self, record):
-        locations = [record[field] for field in self.field_names if field in record]
-        fetch_error = None
-        try:
-            data = await self.fetch_data(locations)
-        except GetArtifactsFailed as ex:
-            data = {}
-            fetch_error = format_error_body(getattr(ex, "id", None), str(ex))
-
-        _rec = record
-        for k, v in _rec.items():
-            if k in self.field_names:
-                _rec[k] = data[v] if v in data else None
-        if fetch_error:
-            _rec["postprocess_error"] = fetch_error
-        return _rec
+        _recs = self.refine_records([record])
+        return _recs[0] if len(_recs) > 0 else record
 
     async def refine_records(self, records):
         locations = [record[field] for field in self.field_names for record in records if field in record]
-        fetch_error = None
-        try:
-            data = await self.fetch_data(locations)
-        except GetArtifactsFailed as ex:
-            data = {}
-            fetch_error = format_error_body(getattr(ex, "id", None), str(ex))
+        errors = {}
+
+        def _event_stream(event):
+            if event.get("type") == "error" and event.get("key"):
+                loc = artifact_location_from_key(event["key"])
+                errors[loc] = event
+
+        responses = await self.fetch_data(locations, event_stream=_event_stream)
 
         _recs = []
         for rec in records:
+            _rec = rec.copy()
             for k, v in rec.items():
                 if k in self.field_names:
-                    rec[k] = data[v] if v in data else None
-            if fetch_error:
-                rec["postprocess_error"] = fetch_error
-            _recs.append(rec)
+                    if v in errors:
+                        _rec["postprocess_error"] = format_error_body(
+                            errors[v].get("id"),
+                            errors[v].get("message"),
+                            errors[v].get("traceback")
+                        )
+                    else:
+                        _rec[k] = responses[v] if v in responses else None
+            _recs.append(_rec)
         return _recs
 
-    async def fetch_data(self, locations):
+    async def fetch_data(self, locations, event_stream=None):
         _res = await self.artifact_store.cache.GetArtifactsWithStatus(locations)
         if not _res.is_ready():
             async for event in _res.stream():
                 if event["type"] == "error":
-                    # raise error, there was an exception during processing.
-                    raise GetArtifactsFailed(event["message"], event["id"], event["traceback"])
+                    if event_stream:
+                        event_stream(event)
             await _res.wait()  # wait for results to be ready
         return _res.get() or {}  # cache get() might return None if no keys are produced.
 
@@ -114,3 +109,8 @@ class ArtifactRefiner(Refinery):
             body = _process(refined_response.body)
 
         return DBResponse(response_code=refined_response.response_code, body=body)
+
+
+def artifact_location_from_key(x):
+    "extract location from the artifact cache key"
+    return x[len("search:artifactdata:"):]

--- a/services/ui_backend_service/data/refiner/parameter_refiner.py
+++ b/services/ui_backend_service/data/refiner/parameter_refiner.py
@@ -19,7 +19,6 @@ class ParameterRefiner(Refinery):
         super().__init__(field_names=['location'], cache=cache)
 
     async def fetch_data(self, locations, event_stream=None, invalidate_cache=False):
-
         try:
             _res = await self.artifact_store.cache.GetArtifacts(locations, invalidate_cache=invalidate_cache)
             if _res.has_pending_request():

--- a/services/ui_backend_service/data/refiner/refinery.py
+++ b/services/ui_backend_service/data/refiner/refinery.py
@@ -1,4 +1,4 @@
-from typing import Tuple
+from typing import Tuple, Any
 from services.data.db_utils import DBResponse
 from services.ui_backend_service.features import FEATURE_REFINE_DISABLE
 from services.utils import logging
@@ -85,17 +85,31 @@ class Refinery(object):
                           body=body)
 
 
-def unpack_processed_value(value) -> Tuple[bool, str, int]:
+def unpack_processed_value(value) -> Tuple[bool, str, Any]:
+    '''
+    Unpack refined response returning tuple of: success, value, detail
+
+    Defaults to None in case values are not defined.
+
+    Success example:
+        True, 'foo', None
+
+    Failure examples:
+        False, 'failure-id', 'error-details'
+        False, 'failure-id-without-details', None
+        False, None, None
+    '''
     return (list(value) + [None] * 3)[:3]
 
 
-def format_error_body(id, detail):
+def format_error_body(id=None, detail=None, traceback=None):
     '''
     formatter for the "postprocess_error" key added to refined items in case of errors.
     '''
     return {
         "id": id or "artifact-refine-failure",
-        "detail": detail
+        "detail": detail,
+        "traceback": traceback
     }
 
 

--- a/services/ui_backend_service/data/refiner/refinery.py
+++ b/services/ui_backend_service/data/refiner/refinery.py
@@ -1,4 +1,4 @@
-from typing import Tuple, Any
+from typing import Tuple, Optional
 from services.data.db_utils import DBResponse
 from services.ui_backend_service.features import FEATURE_REFINE_DISABLE
 from services.utils import logging
@@ -21,18 +21,13 @@ class Refinery(object):
         self.field_names = field_names
         self.logger = logging.getLogger("DataRefiner")
 
-    async def refine_record(self, record):
-        locations = [record[field] for field in self.field_names if field in record]
-        data = await self.fetch_data(locations)
-        _rec = record
-        for k, v in _rec.items():
-            if k in self.field_names:
-                _rec[k] = data[v] if v in data else None
-        return _rec
+    async def refine_record(self, record, invalidate_cache=False):
+        _recs = self.refine_records([record], invalidate_cache=invalidate_cache)
+        return _recs[0] if len(_recs) > 0 else record
 
-    async def refine_records(self, records):
+    async def refine_records(self, records, invalidate_cache=False):
         locations = [record[field] for field in self.field_names for record in records if field in record]
-        data = await self.fetch_data(locations)
+        data = await self.fetch_data(locations, invalidate_cache=invalidate_cache)
 
         _recs = []
         for rec in records:
@@ -42,19 +37,19 @@ class Refinery(object):
             _recs.append(rec)
         return _recs
 
-    async def fetch_data(self, locations):
+    async def fetch_data(self, locations, event_stream=None, invalidate_cache=False):
         try:
             # only fetch S3 locations, otherwise the long timeout of CacheFuture will cause problems.
             _locs = [loc for loc in locations if isinstance(loc, str) and loc.startswith("s3://")]
-            _res = await self.artifact_store.cache.GetArtifacts(_locs)
-            if not _res.is_ready():
+            _res = await self.artifact_store.cache.GetArtifacts(_locs, invalidate_cache=invalidate_cache)
+            if _res.has_pending_request():
                 await _res.wait()  # wait for results to be ready
             return _res.get() or {}  # cache get() might return None if no keys are produced.
         except Exception:
             self.logger.exception("Exception when fetching artifact data from cache")
             return {}
 
-    async def _postprocess(self, response: DBResponse):
+    async def _postprocess(self, response: DBResponse, invalidate_cache=False):
         """
         Async post processing callback that can be used as the find_records helpers
         postprocessing parameter.
@@ -66,6 +61,8 @@ class Refinery(object):
         ----------
         response : DBResponse
             The DBResponse to be refined
+        invalidate_cache : Bool
+            Invalidate cache before postprocessing
 
         Returns
         -------
@@ -77,15 +74,18 @@ class Refinery(object):
         if response.response_code != 200 or not response.body:
             return response
         if isinstance(response.body, list):
-            body = await self.refine_records(response.body)
+            body = await self.refine_records(response.body, invalidate_cache=invalidate_cache)
         else:
-            body = await self.refine_record(response.body)
+            body = await self.refine_record(response.body, invalidate_cache=invalidate_cache)
 
         return DBResponse(response_code=response.response_code,
                           body=body)
 
+    async def postprocess(self, response: DBResponse, invalidate_cache=False):
+        raise NotImplementedError
 
-def unpack_processed_value(value) -> Tuple[bool, str, Any]:
+
+def unpack_processed_value(value) -> Tuple[bool, Optional[str], Optional[str]]:
     '''
     Unpack refined response returning tuple of: success, value, detail
 

--- a/services/ui_backend_service/data/refiner/refinery.py
+++ b/services/ui_backend_service/data/refiner/refinery.py
@@ -1,4 +1,4 @@
-from typing import Tuple, Optional
+from typing import Any, Tuple, Optional
 from services.data.db_utils import DBResponse
 from services.ui_backend_service.features import FEATURE_REFINE_DISABLE
 from services.utils import logging
@@ -22,7 +22,7 @@ class Refinery(object):
         self.logger = logging.getLogger("DataRefiner")
 
     async def refine_record(self, record, invalidate_cache=False):
-        _recs = self.refine_records([record], invalidate_cache=invalidate_cache)
+        _recs = await self.refine_records([record], invalidate_cache=invalidate_cache)
         return _recs[0] if len(_recs) > 0 else record
 
     async def refine_records(self, records, invalidate_cache=False):
@@ -101,7 +101,7 @@ class Refinery(object):
         raise NotImplementedError
 
 
-def unpack_processed_value(value) -> Tuple[bool, Optional[str], Optional[str]]:
+def unpack_processed_value(value) -> Tuple[bool, Optional[Any], Optional[Any]]:
     '''
     Unpack refined response returning tuple of: success, value, detail
 

--- a/services/ui_backend_service/data/refiner/refinery.py
+++ b/services/ui_backend_service/data/refiner/refinery.py
@@ -1,6 +1,5 @@
+from typing import Tuple
 from services.data.db_utils import DBResponse
-import json
-
 from services.ui_backend_service.features import FEATURE_REFINE_DISABLE
 from services.utils import logging
 
@@ -84,3 +83,27 @@ class Refinery(object):
 
         return DBResponse(response_code=response.response_code,
                           body=body)
+
+
+def unpack_processed_value(value) -> Tuple[bool, str, int]:
+    return (list(value) + [None] * 3)[:3]
+
+
+def format_error_body(id, detail):
+    '''
+    formatter for the "postprocess_error" key added to refined items in case of errors.
+    '''
+    return {
+        "id": id or "artifact-refine-failure",
+        "detail": detail
+    }
+
+
+class GetArtifactsFailed(Exception):
+    def __init__(self, msg="Failed to Get Artifacts", id="get-artifacts-failed", traceback_str=None):
+        self.message = msg
+        self.id = id
+        self.traceback_str = traceback_str
+
+    def __str__(self):
+        return self.message

--- a/services/ui_backend_service/data/refiner/task_refiner.py
+++ b/services/ui_backend_service/data/refiner/task_refiner.py
@@ -1,4 +1,4 @@
-from .refinery import Refinery
+from .refinery import Refinery, unpack_processed_value, format_error_body, GetArtifactsFailed
 from services.data.db_utils import DBResponse
 
 
@@ -16,6 +16,52 @@ class TaskRefiner(Refinery):
 
     def __init__(self, cache):
         super().__init__(field_names=["task_ok", "foreach_stack"], cache=cache)
+
+    async def refine_record(self, record):
+        locations = [record[field] for field in self.field_names if field in record]
+        fetch_error = None
+        try:
+            data = await self.fetch_data(locations)
+        except GetArtifactsFailed as ex:
+            data = {}
+            fetch_error = format_error_body(getattr(ex, "id", None), str(ex))
+
+        _rec = record
+        for k, v in _rec.items():
+            if k in self.field_names:
+                _rec[k] = data[v] if v in data else None
+        if fetch_error:
+            _rec["postprocess_error"] = fetch_error
+        return _rec
+
+    async def refine_records(self, records):
+        locations = [record[field] for field in self.field_names for record in records if field in record]
+        fetch_error = None
+        try:
+            data = await self.fetch_data(locations)
+        except GetArtifactsFailed as ex:
+            data = {}
+            fetch_error = format_error_body(getattr(ex, "id", None), str(ex))
+
+        _recs = []
+        for rec in records:
+            for k, v in rec.items():
+                if k in self.field_names:
+                    rec[k] = data[v] if v in data else None
+            if fetch_error:
+                rec["postprocess_error"] = fetch_error
+            _recs.append(rec)
+        return _recs
+
+    async def fetch_data(self, locations):
+        _res = await self.artifact_store.cache.GetArtifactsWithStatus(locations)
+        if not _res.is_ready():
+            async for event in _res.stream():
+                if event["type"] == "error":
+                    # raise error, there was an exception during processing.
+                    raise GetArtifactsFailed(event["message"], event["id"], event["traceback"])
+            await _res.wait()  # wait for results to be ready
+        return _res.get() or {}  # cache get() might return None if no keys are produced.
 
     async def postprocess(self, response: DBResponse):
         """
@@ -36,19 +82,35 @@ class TaskRefiner(Refinery):
         refined_response = await self._postprocess(response)
 
         def _process(item):
-            if item['status'] == 'unknown':
-                # cover boolean cases explicitly, as S3 refinement might fail,
-                # in which case we want the 'unknown' status to remain.
-                if item['task_ok'] is False:
-                    item['status'] = 'failed'
-                elif item['task_ok'] is True:
-                    item['status'] = 'completed'
+            if item['status'] == 'unknown' and item['task_ok'] is not None:
+                success, value, detail = unpack_processed_value(item['task_ok'])
+                if success:
+                    # cast artifact content to string if it was successfully fetched
+                    # as some artifacts retain their type if they are Json serializable.
+                    if value is False:
+                        item['status'] = 'failed'
+                    elif value is True:
+                        item['status'] = 'completed'
+                else:
+                    item['postprocess_error'] = format_error_body(
+                        value if value else "artifact-handle-failed",
+                        detail if detail else "Unknown error during artifact processing"
+                    )
 
             item.pop('task_ok', None)
 
-            if item['foreach_stack'] and len(item['foreach_stack']) > 0 and len(item['foreach_stack'][0]) >= 4:
-                _, _name, _, _index = item['foreach_stack'][0]
-                item['foreach_label'] = "{}[{}]".format(item['task_id'], _index)
+            if item['foreach_stack']:
+                success, value, detail = unpack_processed_value(item['foreach_stack'])
+                if success:
+                    if len(value) > 0 and len(value[0]) >= 4:
+                        _, _name, _, _index = value[0]
+                        item['foreach_label'] = "{}[{}]".format(item['task_id'], _index)
+                else:
+                    item['postprocess_error'] = format_error_body(
+                        value if value else "artifact-handle-failed",
+                        detail if detail else "Unknown error during artifact processing"
+                    )
+
             item.pop('foreach_stack', None)
             return item
 

--- a/services/ui_backend_service/doc.py
+++ b/services/ui_backend_service/doc.py
@@ -314,6 +314,15 @@ swagger_definitions = {
                 "required": False,
                 "default": False,
                 "type": "boolean",
+            },
+            "invalidate": {
+                "name": "invalidate",
+                "in": "query",
+                "description": "Invalidate cache before fetching new results from S3. Requires refining/postprocessing\
+                    to be effective, usually defined with postprocess=true query parameter.",
+                "required": False,
+                "default": False,
+                "type": "boolean",
             }
         }
     },

--- a/services/ui_backend_service/tests/integration_tests/status_attempts_test.py
+++ b/services/ui_backend_service/tests/integration_tests/status_attempts_test.py
@@ -291,8 +291,8 @@ async def test_attempt_status_failed_attempt_ok_s3(cli, db):
                                                 "value": "0",
                                                 "type": "attempt"})).body
 
-    async def _refine_record(self, record):
-        return {**record, "task_ok": False}
+    async def _refine_record(self, record, invalidate_cache=False):
+        return {**record, "task_ok": [True, False]}  # Success=True, Value=False
 
     with mock.patch(
         "services.ui_backend_service.data.refiner.task_refiner.Refinery.refine_record",

--- a/services/ui_backend_service/tests/integration_tests/status_tasks_test.py
+++ b/services/ui_backend_service/tests/integration_tests/status_tasks_test.py
@@ -225,8 +225,8 @@ async def test_task_status_failed_attempt_ok_s3(cli, db):
                                                 "value": "0",
                                                 "type": "attempt"})).body
 
-    async def _refine_record(self, record):
-        return {**record, "task_ok": False}
+    async def _refine_record(self, record, invalidate_cache=False):
+        return {**record, "task_ok": [True, False]}  # Success=True, Value=False
 
     with mock.patch(
         "services.ui_backend_service.data.refiner.task_refiner.Refinery.refine_record",
@@ -266,8 +266,8 @@ async def test_task_status_failed_attempt_ok_s3_artifact_ts_epoch(cli, db):
                             "attempt_id": 0
         })).body
 
-    async def _refine_record(self, record):
-        return {**record, "task_ok": False}
+    async def _refine_record(self, record, invalidate_cache=False):
+        return {**record, "task_ok": [True, False]}  # Success=True, Value=False
 
     with mock.patch(
         "services.ui_backend_service.data.refiner.task_refiner.Refinery.refine_record",

--- a/services/ui_backend_service/tests/unit_tests/cache_utils_test.py
+++ b/services/ui_backend_service/tests/unit_tests/cache_utils_test.py
@@ -8,16 +8,19 @@ pytestmark = [pytest.mark.unit_tests]
 
 
 def test_error_event_msg():
-  assert error_event_msg("test message", "test-id") == \
-      {"type": "error", "message": "test message", "id": "test-id", "traceback": None}
+    assert error_event_msg("test message", "test-id") == \
+        {"type": "error", "message": "test message", "id": "test-id", "traceback": None, "key": None}
 
-  assert error_event_msg("test message", "test-id", "test-traceback") == \
-      {"type": "error", "message": "test message", "id": "test-id", "traceback": "test-traceback"}
+    assert error_event_msg("test message", "test-id", "test-traceback") == \
+        {"type": "error", "message": "test message", "id": "test-id", "traceback": "test-traceback", "key": None}
+
+    assert error_event_msg("test message", "test-id", "test-traceback", "search:artifact:s3://etc") == \
+        {"type": "error", "message": "test message", "id": "test-id", "traceback": "test-traceback", "key": "search:artifact:s3://etc"}
 
 
 def test_progress_event_msg():
-  assert progress_event_msg(0.5) == {"type": "progress", "fraction": 0.5}
+    assert progress_event_msg(0.5) == {"type": "progress", "fraction": 0.5}
 
 
 def test_search_result_event_msg():
-  assert search_result_event_msg([1, 2, 3]) == {"type": "result", "matches": [1, 2, 3]}
+    assert search_result_event_msg([1, 2, 3]) == {"type": "result", "matches": [1, 2, 3]}


### PR DESCRIPTION
Cache functionality changes:
- More accurate error results
- Each artifact error result is now returned individually instead of one global error causing whole request to fail
- Added support for streaming errors in real-time
- Added support for cache invalidation via `?invalidate=true` query parameter where results are cacheable
- Timeline search result now includes individual errors instead one global failure with error message for each task