### PR TITLE
Make sure aiohttp web response body is a binary

### DIFF
--- a/services/data/db_utils.py
+++ b/services/data/db_utils.py
@@ -14,17 +14,17 @@ def aiopg_exception_handling(exception):
     body = {"err_msg": err_msg}
     if isinstance(exception, psycopg2.IntegrityError):
         if "duplicate key" in err_msg:
-            return DBResponse(response_code=409, body=json.dumps(body))
+            return DBResponse(response_code=409, body=body)
         elif "foreign key" in err_msg:
-            return DBResponse(response_code=404, body=json.dumps(body))
+            return DBResponse(response_code=404, body=body)
         else:
-            return DBResponse(response_code=500, body=json.dumps(body))
+            return DBResponse(response_code=500, body=body)
     elif isinstance(exception, psycopg2.errors.UniqueViolation):
-        return DBResponse(response_code=409, body=json.dumps(body))
+        return DBResponse(response_code=409, body=body)
     elif isinstance(exception, IndexError):
         return DBResponse(response_code=404, body={})
     else:
-        return DBResponse(response_code=500, body=json.dumps(body))
+        return DBResponse(response_code=500, body=body)
 
 
 def get_db_ts_epoch_str():

--- a/services/metadata_service/api/admin.py
+++ b/services/metadata_service/api/admin.py
@@ -137,7 +137,7 @@ class AuthApi(object):
                 "SessionToken"
             ]
 
-            return web.Response(status=200, body=json.dumps(credentials))
+            return web.Response(status=200, body=json.dumps(credentials).encode('utf8'))
         except Exception as ex:
             body = {"err_msg": str(ex), "traceback": get_traceback_str()}
-            return web.Response(status=500, body=json.dumps(body))
+            return web.Response(status=500, body=json.dumps(body).encode('utf8'))

--- a/services/metadata_service/api/artifact.py
+++ b/services/metadata_service/api/artifact.py
@@ -142,7 +142,7 @@ class ArtificatsApi(object):
         filtered_body = filter_artifacts_by_attempt_id_for_tasks(
             artifacts.body)
         return web.Response(
-            status=artifacts.response_code, body=json.dumps(filtered_body)
+            status=artifacts.response_code, body=json.dumps(filtered_body).encode('utf8')
         )
 
     async def get_artifacts_by_step(self, request):
@@ -186,7 +186,7 @@ class ArtificatsApi(object):
         filtered_body = filter_artifacts_by_attempt_id_for_tasks(
             artifacts.body)
         return web.Response(
-            status=artifacts.response_code, body=json.dumps(filtered_body)
+            status=artifacts.response_code, body=json.dumps(filtered_body).encode('utf8')
         )
 
     async def get_artifacts_by_run(self, request):
@@ -221,7 +221,7 @@ class ArtificatsApi(object):
         filtered_body = filter_artifacts_by_attempt_id_for_tasks(
             artifacts.body)
         return web.Response(
-            status=artifacts.response_code, body=json.dumps(filtered_body)
+            status=artifacts.response_code, body=json.dumps(filtered_body).encode('utf8')
         )
 
     async def create_artifacts(self, request):
@@ -315,7 +315,7 @@ class ArtificatsApi(object):
                                                              step_name, task_id)
         except Exception:
             return web.Response(status=400, body=json.dumps(
-                {"message": "need to register run_id and task_id first"}))
+                {"message": "need to register run_id and task_id first"}).encode('utf8'))
 
         # todo change to bulk insert
         for artifact in body:
@@ -343,4 +343,4 @@ class ArtificatsApi(object):
 
         result = {"artifacts_created": count}
 
-        return web.Response(body=json.dumps(result))
+        return web.Response(body=json.dumps(result).encode('utf8'))

--- a/services/metadata_service/api/metadata.py
+++ b/services/metadata_service/api/metadata.py
@@ -179,7 +179,7 @@ class MetadataApi(object):
                                                              step_name, task_id)
         except Exception:
             return web.Response(status=400, body=json.dumps(
-                {"message": "need to register run_id and task_id first"}))
+                {"message": "need to register run_id and task_id first"}).encode('utf8'))
 
         for datum in body:
             values = {
@@ -202,4 +202,4 @@ class MetadataApi(object):
 
         result = {"metadata_created": count}
 
-        return web.Response(body=json.dumps(result))
+        return web.Response(body=json.dumps(result).encode('utf8'))

--- a/services/metadata_service/api/task.py
+++ b/services/metadata_service/api/task.py
@@ -179,7 +179,7 @@ class TaskApi(object):
 
         if task_name and task_name.isnumeric():
             return web.Response(status=400, body=json.dumps(
-                {"message": "provided task_name may not be a numeric"}))
+                {"message": "provided task_name may not be a numeric"}).encode('utf8'))
 
         run_number, run_id = await self._db.get_run_ids(flow_id, run_number)
 

--- a/services/metadata_service/api/utils.py
+++ b/services/metadata_service/api/utils.py
@@ -21,7 +21,7 @@ def format_response(func):
     async def wrapper(*args, **kwargs):
         db_response = await func(*args, **kwargs)
         return web.Response(status=db_response.response_code,
-                            body=json.dumps(db_response.body),
+                            body=json.dumps(db_response.body).encode('utf8'),
                             headers=MultiDict(
                                 {METADATA_SERVICE_HEADER: METADATA_SERVICE_VERSION}))
 
@@ -30,7 +30,7 @@ def format_response(func):
 
 def web_response(status: int, body):
     return web.Response(status=status,
-                        body=json.dumps(body),
+                        body=json.dumps(body).encode('utf8'),
                         headers=MultiDict(
                             {"Content-Type": "application/json",
                              METADATA_SERVICE_HEADER: METADATA_SERVICE_VERSION}))

--- a/services/migration_service/api/admin.py
+++ b/services/migration_service/api/admin.py
@@ -105,12 +105,12 @@ class AdminApi(object):
                 "db_schema_versions": ApiUtils.list_migrations(),
                 "unapplied_migrations": unapplied_migrations
             }
-            return web.Response(body=json.dumps(body),
+            return web.Response(body=json.dumps(body).encode('utf8'),
                                 headers=MultiDict({"Content-Type": "application/json"}))
 
         except Exception as e:
             body = {
                 "detail": repr(e)
             }
-            return web.Response(status=500, body=json.dumps(body),
+            return web.Response(status=500, body=json.dumps(body).encode('utf8'),
                                 headers=MultiDict({"Content-Type": "application/json"}))


### PR DESCRIPTION
If you look at [aiohttp docs](https://docs.aiohttp.org/en/stable/web_reference.html#response), body is supposed to be a binary, not string. It mostly works if you pass a string, however some auxiliary things break -- I've ran into some issues because of this while trying to use `aiohttp-devel`. 

