### PR TITLE
chore: cache cleanup and configuration

### DIFF
--- a/services/ui_backend_service/data/cache/get_artifacts_action.py
+++ b/services/ui_backend_service/data/cache/get_artifacts_action.py
@@ -9,10 +9,8 @@ from .utils import (CacheS3AccessDenied, CacheS3CredentialsMissing,
                     CacheS3Exception, CacheS3NotFound,
                     CacheS3URLException, batchiter, decode,
                     error_event_msg, get_s3_obj, get_s3_size,
-                    artifact_cache_id, artifact_location_from_key)
-
-MAX_SIZE = 4096
-S3_BATCH_SIZE = 512
+                    artifact_cache_id, artifact_location_from_key,
+                    MAX_S3_SIZE)
 
 
 class GetArtifacts(CacheAction):
@@ -127,37 +125,36 @@ class GetArtifacts(CacheAction):
         # Fetch the S3 locations data
         s3_locations = [loc for loc in locations_to_fetch if loc.startswith('s3://')]
         s3 = boto3.client('s3')
-        for locations in batchiter(s3_locations, S3_BATCH_SIZE):
-            for location in locations:
-                artifact_key = artifact_cache_id(location)
-                try:
-                    obj_size = get_s3_size(s3, location)
-                    if obj_size < MAX_SIZE:
-                        temp_obj = get_s3_obj(s3, location)
-                        # TODO: Figure out a way to store the artifact content without decoding?
-                        # presumed that cache_data/tmp/ does not persist as long as the cached items themselves,
-                        # so we can not rely on the file existing if we only return a filepath as a cached response
-                        content = decode(temp_obj.name)
-                        results[artifact_key] = json.dumps([True, content])
-                    else:
-                        results[artifact_key] = json.dumps([False, 'artifact-too-large', obj_size])
+        for location in s3_locations:
+            artifact_key = artifact_cache_id(location)
+            try:
+                obj_size = get_s3_size(s3, location)
+                if obj_size < MAX_SIZE:
+                    temp_obj = get_s3_obj(s3, location)
+                    # TODO: Figure out a way to store the artifact content without decoding?
+                    # presumed that cache_data/tmp/ does not persist as long as the cached items themselves,
+                    # so we can not rely on the file existing if we only return a filepath as a cached response
+                    content = decode(temp_obj.name)
+                    results[artifact_key] = json.dumps([True, content])
+                else:
+                    results[artifact_key] = json.dumps([False, 'artifact-too-large', obj_size])
 
-                except TypeError:
-                    # In case the artifact was of a type that can not be json serialized,
-                    # we try casting it to a string first.
-                    results[artifact_key] = json.dumps([True, str(content)])
-                except CacheS3AccessDenied as ex:
-                    results[artifact_key] = json.dumps([False, 's3-access-denied', location])
-                except CacheS3NotFound:
-                    results[artifact_key] = json.dumps([False, 's3-not-found', location])
-                except CacheS3URLException:
-                    results[artifact_key] = json.dumps([False, 's3-bad-url', location])
-                except CacheS3CredentialsMissing:
-                    results[artifact_key] = json.dumps([False, 's3-missing-credentials', location])
-                except CacheS3Exception:
-                    results[artifact_key] = json.dumps([False, 's3-generic-error', get_traceback_str()])
-                except Exception:
-                    results[artifact_key] = json.dumps([False, 'artifact-handle-failed', get_traceback_str()])
+            except TypeError:
+                # In case the artifact was of a type that can not be json serialized,
+                # we try casting it to a string first.
+                results[artifact_key] = json.dumps([True, str(content)])
+            except CacheS3AccessDenied as ex:
+                results[artifact_key] = json.dumps([False, 's3-access-denied', location])
+            except CacheS3NotFound:
+                results[artifact_key] = json.dumps([False, 's3-not-found', location])
+            except CacheS3URLException:
+                results[artifact_key] = json.dumps([False, 's3-bad-url', location])
+            except CacheS3CredentialsMissing:
+                results[artifact_key] = json.dumps([False, 's3-missing-credentials', location])
+            except CacheS3Exception:
+                results[artifact_key] = json.dumps([False, 's3-generic-error', get_traceback_str()])
+            except Exception:
+                results[artifact_key] = json.dumps([False, 'artifact-handle-failed', get_traceback_str()])
 
         # Skip the inaccessible locations
         other_locations = [loc for loc in locations_to_fetch if not loc.startswith('s3://')]

--- a/services/ui_backend_service/data/cache/get_artifacts_action.py
+++ b/services/ui_backend_service/data/cache/get_artifacts_action.py
@@ -129,7 +129,7 @@ class GetArtifacts(CacheAction):
             artifact_key = artifact_cache_id(location)
             try:
                 obj_size = get_s3_size(s3, location)
-                if obj_size < MAX_SIZE:
+                if obj_size < MAX_S3_SIZE:
                     temp_obj = get_s3_obj(s3, location)
                     # TODO: Figure out a way to store the artifact content without decoding?
                     # presumed that cache_data/tmp/ does not persist as long as the cached items themselves,

--- a/services/ui_backend_service/data/cache/search_artifacts_action.py
+++ b/services/ui_backend_service/data/cache/search_artifacts_action.py
@@ -8,7 +8,7 @@ from .utils import (CacheS3AccessDenied, CacheS3CredentialsMissing,
                     CacheS3NotFound, CacheS3Exception,
                     CacheS3URLException,
                     batchiter, decode, error_event_msg, progress_event_msg,
-                    get_s3_size, get_s3_obj)
+                    get_s3_size, get_s3_obj, artifact_cache_id)
 from ..refiner.refinery import unpack_processed_value
 
 MAX_SIZE = 4096
@@ -197,8 +197,3 @@ def lookup_id(locations, searchterm):
     "construct a unique id to be used with stream_key and result_key"
     _string = "-".join(list(frozenset(sorted(locations)))) + searchterm
     return hashlib.sha1(_string.encode('utf-8')).hexdigest()
-
-
-def artifact_cache_id(location):
-    "construct a unique cache key for artifact location"
-    return 'search:artifactdata:%s' % location

--- a/services/ui_backend_service/data/cache/search_artifacts_action.py
+++ b/services/ui_backend_service/data/cache/search_artifacts_action.py
@@ -8,11 +8,8 @@ from .utils import (CacheS3AccessDenied, CacheS3CredentialsMissing,
                     CacheS3NotFound, CacheS3Exception,
                     CacheS3URLException,
                     batchiter, decode, error_event_msg, progress_event_msg,
-                    get_s3_size, get_s3_obj, artifact_cache_id)
+                    get_s3_size, get_s3_obj, artifact_cache_id, MAX_S3_SIZE)
 from ..refiner.refinery import unpack_processed_value
-
-MAX_SIZE = 4096
-S3_BATCH_SIZE = 512
 
 
 class SearchArtifacts(CacheAction):
@@ -119,45 +116,44 @@ class SearchArtifacts(CacheAction):
         # Fetch the S3 locations data
         s3_locations = [loc for loc in locations_to_fetch if loc.startswith("s3://")]
         s3 = boto3.client("s3")
-        for locations in batchiter(s3_locations, S3_BATCH_SIZE):
-            for idx, location in enumerate(locations):
-                artifact_key = artifact_cache_id(location)
-                stream_progress((idx + 1) / len(locations))
-                try:
-                    obj_size = get_s3_size(s3, location)
-                    if obj_size < MAX_SIZE:
-                        temp_obj = get_s3_obj(s3, location)
-                        # TODO: Figure out a way to store the artifact content without decoding?
-                        # presumed that cache_data/tmp/ does not persist as long as the cached items themselves,
-                        # so we can not rely on the file existing if we only return a filepath as a cached response
-                        content = decode(temp_obj.name)
-                        results[artifact_key] = json.dumps([True, content])
-                    else:
-                        results[artifact_key] = json.dumps([False, 'artifact-too-large', obj_size])
-                except TypeError:
-                    # In case the artifact was of a type that can not be json serialized,
-                    # we try casting it to a string first.
-                    results[artifact_key] = json.dumps([True, str(content)])
-                except CacheS3AccessDenied as ex:
-                    stream_error(str(ex), "s3-access-denied")
-                    results[artifact_key] = json.dumps([False, 's3-access-denied', location])
-                except CacheS3NotFound as ex:
-                    stream_error(str(ex), "s3-not-found")
-                    results[artifact_key] = json.dumps([False, 's3-not-found', location])
-                except CacheS3URLException as ex:
-                    stream_error(str(ex), "s3-bad-url")
-                    results[artifact_key] = json.dumps([False, 's3-bad-url', location])
-                except CacheS3CredentialsMissing as ex:
-                    stream_error(str(ex), "s3-missing-credentials")
-                    results[artifact_key] = json.dumps([False, 's3-missing-credentials', location])
-                except CacheS3Exception as ex:
-                    stream_error(str(ex), "s3-generic-error", get_traceback_str())
-                    results[artifact_key] = json.dumps([False, 's3-generic-error', get_traceback_str()])
-                except Exception as ex:
-                    # Exceptions might be fixable with configuration changes or other measures,
-                    # therefore we do not want to write anything to the cache for these artifacts.
-                    stream_error(str(ex), "artifact-handle-failed", get_traceback_str())
-                    results[artifact_key] = json.dumps([False, 'artifact-handle-failed', get_traceback_str()])
+        for idx, location in enumerate(s3_locations):
+            artifact_key = artifact_cache_id(location)
+            stream_progress((idx + 1) / len(s3_locations))
+            try:
+                obj_size = get_s3_size(s3, location)
+                if obj_size < MAX_SIZE:
+                    temp_obj = get_s3_obj(s3, location)
+                    # TODO: Figure out a way to store the artifact content without decoding?
+                    # presumed that cache_data/tmp/ does not persist as long as the cached items themselves,
+                    # so we can not rely on the file existing if we only return a filepath as a cached response
+                    content = decode(temp_obj.name)
+                    results[artifact_key] = json.dumps([True, content])
+                else:
+                    results[artifact_key] = json.dumps([False, 'artifact-too-large', obj_size])
+            except TypeError:
+                # In case the artifact was of a type that can not be json serialized,
+                # we try casting it to a string first.
+                results[artifact_key] = json.dumps([True, str(content)])
+            except CacheS3AccessDenied as ex:
+                stream_error(str(ex), "s3-access-denied")
+                results[artifact_key] = json.dumps([False, 's3-access-denied', location])
+            except CacheS3NotFound as ex:
+                stream_error(str(ex), "s3-not-found")
+                results[artifact_key] = json.dumps([False, 's3-not-found', location])
+            except CacheS3URLException as ex:
+                stream_error(str(ex), "s3-bad-url")
+                results[artifact_key] = json.dumps([False, 's3-bad-url', location])
+            except CacheS3CredentialsMissing as ex:
+                stream_error(str(ex), "s3-missing-credentials")
+                results[artifact_key] = json.dumps([False, 's3-missing-credentials', location])
+            except CacheS3Exception as ex:
+                stream_error(str(ex), "s3-generic-error", get_traceback_str())
+                results[artifact_key] = json.dumps([False, 's3-generic-error', get_traceback_str()])
+            except Exception as ex:
+                # Exceptions might be fixable with configuration changes or other measures,
+                # therefore we do not want to write anything to the cache for these artifacts.
+                stream_error(str(ex), "artifact-handle-failed", get_traceback_str())
+                results[artifact_key] = json.dumps([False, 'artifact-handle-failed', get_traceback_str()])
         # Skip the inaccessible locations
         other_locations = [loc for loc in locations_to_fetch if not loc.startswith("s3://")]
         for loc in other_locations:

--- a/services/ui_backend_service/data/cache/search_artifacts_action.py
+++ b/services/ui_backend_service/data/cache/search_artifacts_action.py
@@ -121,7 +121,7 @@ class SearchArtifacts(CacheAction):
             stream_progress((idx + 1) / len(s3_locations))
             try:
                 obj_size = get_s3_size(s3, location)
-                if obj_size < MAX_SIZE:
+                if obj_size < MAX_S3_SIZE:
                     temp_obj = get_s3_obj(s3, location)
                     # TODO: Figure out a way to store the artifact content without decoding?
                     # presumed that cache_data/tmp/ does not persist as long as the cached items themselves,

--- a/services/ui_backend_service/data/cache/utils.py
+++ b/services/ui_backend_service/data/cache/utils.py
@@ -7,6 +7,7 @@ from urllib.parse import urlparse
 from botocore.exceptions import ClientError, NoCredentialsError
 from services.ui_backend_service.features import FEATURE_S3_DISABLE
 
+# Generic helpers
 
 def batchiter(it, batch_size):
     it = iter(it)
@@ -23,6 +24,19 @@ def decode(path):
     with GzipFile(path) as f:
         obj = pickle.load(f)
         return obj
+
+# Cache Action helpers
+
+
+def artifact_cache_id(location):
+    "construct a unique cache key for artifact location"
+    return 'search:artifactdata:%s' % location
+
+
+def artifact_location_from_key(x):
+    "extract location from the artifact cache key"
+    return x[len("search:artifactdata:"):]
+
 
 # Cache action stream output helpers
 

--- a/services/ui_backend_service/data/cache/utils.py
+++ b/services/ui_backend_service/data/cache/utils.py
@@ -1,3 +1,4 @@
+import os
 import pickle
 from gzip import GzipFile
 from itertools import islice
@@ -8,6 +9,7 @@ from botocore.exceptions import ClientError, NoCredentialsError
 from services.ui_backend_service.features import FEATURE_S3_DISABLE
 
 # Generic helpers
+
 
 def batchiter(it, batch_size):
     it = iter(it)
@@ -26,6 +28,11 @@ def decode(path):
         return obj
 
 # Cache Action helpers
+
+
+MAX_S3_SIZE = int(os.environ.get("MAX_PROCESSABLE_S3_ARTIFACT_SIZE_KB", 4)) * 1024
+
+# Cache Key helpers
 
 
 def artifact_cache_id(location):

--- a/services/ui_backend_service/docs/environment.md
+++ b/services/ui_backend_service/docs/environment.md
@@ -16,7 +16,7 @@ Configure amount of seconds realtime events are kept in queue (delivered to UI i
 
 - `WS_QUEUE_TTL_SECONDS` [defaults to 300 (5 minutes)]
 
-## Cache and data preload limits 
+## Cache and data limits 
 
 Configure amount of runs to prefetch during server startup (artifact cache):
 
@@ -32,6 +32,10 @@ Configure the maximum usable space by the cache:
 
 - `CACHE_ARTIFACT_STORAGE_LIMIT` [in bytes, defaults to 600000]
 - `CACHE_DAG_STORAGE_LIMIT` [in bytes, defaults to 100000]
+
+Configure the maximum size of files that should be processed by cache actions:
+
+- `MAX_PROCESSABLE_S3_ARTIFACT_SIZE_KB` [in kilobytes, defaults to 4]
 
 ## Feature flags
 

--- a/services/ui_backend_service/tests/unit_tests/cache_utils_test.py
+++ b/services/ui_backend_service/tests/unit_tests/cache_utils_test.py
@@ -1,7 +1,8 @@
 import pytest
 
 from services.ui_backend_service.data.cache.utils import (
-    error_event_msg, progress_event_msg, search_result_event_msg
+    error_event_msg, progress_event_msg, search_result_event_msg,
+    artifact_location_from_key, artifact_cache_id
 )
 
 pytestmark = [pytest.mark.unit_tests]
@@ -24,3 +25,18 @@ def test_progress_event_msg():
 
 def test_search_result_event_msg():
     assert search_result_event_msg([1, 2, 3]) == {"type": "result", "matches": [1, 2, 3]}
+
+
+def test_artifact_cache_key_and_location_from_key():
+    # first generate an artifact cache key with any location
+    _loc = "s3://test-s3-locations/artifact_location/for/cache/1"
+
+    key = artifact_cache_id(_loc)
+
+    assert _loc in key
+
+    # We need to be able to extract the location from a cache key, to form correctly keyed responses
+    _extracted_loc = artifact_location_from_key(key)
+
+    assert _extracted_loc == _loc
+

--- a/services/ui_backend_service/tests/unit_tests/get_artifacts_action_test.py
+++ b/services/ui_backend_service/tests/unit_tests/get_artifacts_action_test.py
@@ -1,6 +1,6 @@
 import pytest
 
-from services.ui_backend_service.data.cache.get_artifacts_action import lookup_id, artifact_cache_id, artifact_location_from_key
+from services.ui_backend_service.data.cache.get_artifacts_action import lookup_id
 
 pytestmark = [pytest.mark.unit_tests]
 
@@ -11,17 +11,3 @@ async def test_cache_key_independent_of_location_order():
     b = lookup_id(reversed(locs))
 
     assert a == b
-
-
-async def test_artifact_cache_key_and_location_from_key():
-    # first generate an artifact cache key with any location
-    _loc = "s3://test-s3-locations/artifact_location/for/cache/1"
-
-    key = artifact_cache_id(_loc)
-
-    assert _loc in key
-
-    # We need to be able to extract the location from a cache key, to form correctly keyed responses
-    _extracted_loc = artifact_location_from_key(key)
-
-    assert _extracted_loc == _loc


### PR DESCRIPTION
- moves shared helpers to cache utils, update unit tests accordingly
- removes batching of S3 gets inside cache actions, as the current implementation is completely sequential in the way s3 objects are fetched.
- make `MAX_SIZE` configurable via environment variables, as the default 4kb limit is quite arbitrary.
- update docs