### PR TITLE
feat[s3]: Customize S3 client endpoint url as well as SSL verify flag

### DIFF
--- a/services/ui_backend_service/api/log.py
+++ b/services/ui_backend_service/api/log.py
@@ -158,7 +158,11 @@ class LogApi(object):
         "Initializes an S3 client for this API handler"
         session = aiobotocore.get_session()
         conf = botocore.config.Config(max_pool_connections=S3_MAX_POOL_CONNECTIONS)
-        self.s3_client = await self.context_stack.enter_async_context(session.create_client('s3', config=conf))
+        self.s3_client = await self.context_stack.enter_async_context(
+            session.create_client(
+                's3', config=conf,
+                endpoint_url=os.environ.get("METAFLOW_S3_ENDPOINT_URL", None),
+                verify=os.environ.get("METAFLOW_S3_VERIFY_CERTIFICATE", None)))
 
     async def teardown_s3_client(self, app):
         "closes the async context for the S3 client"

--- a/services/ui_backend_service/data/cache/generate_dag_action.py
+++ b/services/ui_backend_service/data/cache/generate_dag_action.py
@@ -1,7 +1,6 @@
 import hashlib
 import json
 import os
-import boto3
 from tarfile import TarFile
 
 from .client import CacheAction
@@ -10,7 +9,7 @@ from services.utils import get_traceback_str
 from .custom_flowgraph import FlowGraph
 from .utils import (CacheS3AccessDenied, CacheS3CredentialsMissing,
                     CacheS3Exception, CacheS3NotFound,
-                    CacheS3URLException, get_s3_obj)
+                    CacheS3URLException, get_s3_obj, get_s3_client)
 
 
 class GenerateDag(CacheAction):
@@ -92,7 +91,7 @@ class GenerateDag(CacheAction):
             return stream_output({"type": "error", "message": err, "id": id, "traceback": traceback})
 
         # get codepackage from S3
-        s3 = boto3.client("s3")
+        s3 = get_s3_client()
         try:
             codetar = get_s3_obj(s3, location)
             results[result_key] = json.dumps(generate_dag(flow_name, codetar.name))

--- a/services/ui_backend_service/data/cache/get_artifacts_action.py
+++ b/services/ui_backend_service/data/cache/get_artifacts_action.py
@@ -1,4 +1,3 @@
-import boto3
 import hashlib
 import json
 
@@ -7,8 +6,8 @@ from services.utils import get_traceback_str
 
 from .utils import (CacheS3AccessDenied, CacheS3CredentialsMissing,
                     CacheS3Exception, CacheS3NotFound,
-                    CacheS3URLException, batchiter, decode,
-                    error_event_msg, get_s3_obj, get_s3_size,
+                    CacheS3URLException, decode, error_event_msg,
+                    get_s3_obj, get_s3_size, get_s3_client,
                     artifact_cache_id, artifact_location_from_key,
                     MAX_S3_SIZE)
 
@@ -124,7 +123,7 @@ class GetArtifacts(CacheAction):
 
         # Fetch the S3 locations data
         s3_locations = [loc for loc in locations_to_fetch if loc.startswith('s3://')]
-        s3 = boto3.client('s3')
+        s3 = get_s3_client()
         for location in s3_locations:
             artifact_key = artifact_cache_id(location)
             try:

--- a/services/ui_backend_service/data/cache/search_artifacts_action.py
+++ b/services/ui_backend_service/data/cache/search_artifacts_action.py
@@ -1,14 +1,14 @@
 import hashlib
 import json
-import boto3
 
 from .client import CacheAction
 from services.utils import get_traceback_str
 from .utils import (CacheS3AccessDenied, CacheS3CredentialsMissing,
                     CacheS3NotFound, CacheS3Exception,
                     CacheS3URLException,
-                    batchiter, decode, error_event_msg, progress_event_msg,
-                    get_s3_size, get_s3_obj, artifact_cache_id, MAX_S3_SIZE)
+                    decode, error_event_msg, progress_event_msg,
+                    get_s3_size, get_s3_obj, get_s3_client, artifact_cache_id,
+                    MAX_S3_SIZE)
 from ..refiner.refinery import unpack_processed_value
 
 
@@ -115,7 +115,7 @@ class SearchArtifacts(CacheAction):
 
         # Fetch the S3 locations data
         s3_locations = [loc for loc in locations_to_fetch if loc.startswith("s3://")]
-        s3 = boto3.client("s3")
+        s3 = get_s3_client()
         for idx, location in enumerate(s3_locations):
             artifact_key = artifact_cache_id(location)
             stream_progress((idx + 1) / len(s3_locations))

--- a/services/ui_backend_service/data/cache/utils.py
+++ b/services/ui_backend_service/data/cache/utils.py
@@ -5,6 +5,7 @@ from itertools import islice
 from tempfile import NamedTemporaryFile
 from urllib.parse import urlparse
 
+import boto3
 from botocore.exceptions import ClientError, NoCredentialsError
 from services.ui_backend_service.features import FEATURE_S3_DISABLE
 
@@ -80,6 +81,13 @@ def search_result_event_msg(results):
     }
 
 # S3 helpers
+
+
+def get_s3_client():
+    return boto3.client(
+        "s3",
+        endpoint_url=os.environ.get("METAFLOW_S3_ENDPOINT_URL", None),
+        verify=os.environ.get("METAFLOW_S3_VERIFY_CERTIFICATE", None))
 
 
 def get_s3_size(s3_client, location):


### PR DESCRIPTION
Two new environment variables for UI service:

- `METAFLOW_S3_ENDPOINT_URL`
- `METAFLOW_S3_VERIFY_CERTIFICATE`

This change is similar to Metaflow boto3 client init https://github.com/Netflix/metaflow/blob/dc42d670e6c3f7555f40290fce6ed46eb0c12b17/metaflow/datastore/util/s3util.py#L19