### PR TITLE
fix[cache]: Fix problem when unpacking more than 2 values from cache.

### DIFF
--- a/services/ui_backend_service/data/cache/get_artifacts_action.py
+++ b/services/ui_backend_service/data/cache/get_artifacts_action.py
@@ -10,6 +10,7 @@ from .utils import (CacheS3AccessDenied, CacheS3CredentialsMissing,
                     get_s3_obj, get_s3_size, get_s3_client,
                     artifact_cache_id, artifact_location_from_key,
                     MAX_S3_SIZE)
+from ..refiner.refinery import unpack_processed_value
 
 
 class GetArtifacts(CacheAction):
@@ -63,7 +64,7 @@ class GetArtifacts(CacheAction):
 
         collected = {}
         for key, val in artifact_keys:
-            success, value = json.loads(val)
+            success, value, _ = unpack_processed_value(json.loads(val))
 
             # Only include artifacts whose content could successfully be read in the cache response.
             if success:


### PR DESCRIPTION
`GetArtifacts` -action: Fix problem when unpacking more than 2 values from cache. This only affected error responses where it contained more than 2 values: `success,value,detail`.