### PR TITLE
fix: make sure artifact preload query uses index

### DIFF
--- a/services/ui_backend_service/api/notify.py
+++ b/services/ui_backend_service/api/notify.py
@@ -146,7 +146,7 @@ class ListenNotify(object):
                             self.event_emitter, "UPDATE", self.db.run_table_postgres,
                             data)
                         # Also trigger preload of artifacts after a run finishes.
-                        self.event_emitter.emit("preload-artifacts", data['run_number'])
+                        self.event_emitter.emit("preload-artifacts", data['flow_id'], data['run_number'])
                         # And remove possible heartbeat watchers for completed runs
                         self.event_emitter.emit("run-heartbeat", "complete", data)
 

--- a/services/ui_backend_service/data/db/tables/run.py
+++ b/services/ui_backend_service/data/db/tables/run.py
@@ -124,7 +124,7 @@ class AsyncRunTablePostgres(AsyncPostgresTable):
     ]
     _command = MetadataRunTable._command
 
-    async def get_recent_run_numbers(self):
+    async def get_recent_runs(self):
         _records, *_ = await self.find_records(
             conditions=["ts_epoch >= %s"],
             values=[int(round(time.time() * 1000)) - (int(METAFLOW_ARTIFACT_PREFETCH_RUNS_SINCE) * 1000)],
@@ -133,7 +133,7 @@ class AsyncRunTablePostgres(AsyncPostgresTable):
             expanded=True
         )
 
-        return [run['run_number'] for run in _records.body]
+        return _records.body
 
     async def get_expanded_run(self, run_key: str) -> DBResponse:
         """


### PR DESCRIPTION
- change how artifact locations are fetched for runs when preloading data, make sure the query uses an index on artifact table