### PR TITLE
feat: Add ability to inject head/body content when serving UI

### DIFF
--- a/services/ui_backend_service/README.md
+++ b/services/ui_backend_service/README.md
@@ -33,13 +33,13 @@ Optionally you can also overrider the host and port the service runs on:
 - `MF_UI_METADATA_PORT` [defaults to 8083]
 - `MF_UI_METADATA_HOST` [defaults to 0.0.0.0]
 
-
 Running the service without Docker (from project root):
 
 > ```sh
 > $ pip3 install -r services/ui_backend_service/requirements.txt
 > $ python3 -m services.ui_backend_service.ui_server
 > ```
+
 ### Hosting the Frontend UI
 
 This service provides the UI Backend. There are two options for hosting the UI Frontend assets from [Metaflow UI](https://github.com/Netflix/metaflow-ui)
@@ -50,7 +50,7 @@ For hosting the frontend assets for a production environment, refer to the docum
 
 If you require the UI for local development, refer to [metaflow-ui/docs/README.md](https://github.com/Netflix/metaflow-ui/blob/master/docs/README.md) on how to host the UI locally.
 
-#### Serve frontend assets through the backend instance 
+#### Serve frontend assets through the backend instance
 
 Enable built-in UI bundle serving (assumes assets are located inside `ui/` folder):
 
@@ -65,6 +65,20 @@ This also works as a Docker build argument to download and install latest or spe
 > ```sh
 > $ docker build --arg UI_ENABLED=1 UI_VERSION=v0.1.2 ...
 > ```
+
+Use following environment variables to inject content to Metaflow UI index.html:
+
+- `METAFLOW_HEAD` - Inject content to `head` element
+- `METAFLOW_BODY_BEFORE` - Inject content at the beginning of `body` element
+- `METAFLOW_BODY_AFTER` - Inject content at the end of `body` element
+
+Use case for these variables ranges from additional meta tags to analytics script injection.
+
+Example on how to add keyword meta tag to Metaflow UI:
+
+```
+METAFLOW_HEAD='<meta name="keywords" content="metaflow" />'
+```
 
 ## Documentation
 

--- a/services/ui_backend_service/frontend.py
+++ b/services/ui_backend_service/frontend.py
@@ -9,6 +9,10 @@ static_ui_path = os.path.join(dirname, "ui")
 
 METAFLOW_SERVICE = os.environ.get("METAFLOW_SERVICE", "/")
 
+METAFLOW_HEAD = os.environ.get("METAFLOW_HEAD", None)
+METAFLOW_BODY_BEFORE = os.environ.get("METAFLOW_BODY_BEFORE", None)
+METAFLOW_BODY_AFTER = os.environ.get("METAFLOW_BODY_AFTER", None)
+
 
 class Frontend(object):
     """
@@ -45,6 +49,19 @@ class Frontend(object):
                 content = f.read() \
                     .replace("</head>",
                              "<script>window.METAFLOW_SERVICE=\"{METAFLOW_SERVICE}\";</script></head>".format(METAFLOW_SERVICE=METAFLOW_SERVICE))
+
+                if METAFLOW_HEAD:
+                    content = content.replace("</head>", "{METAFLOW_HEAD}</head>"
+                                              .format(METAFLOW_HEAD=METAFLOW_HEAD))
+
+                if METAFLOW_BODY_BEFORE:
+                    content = content.replace("<body>", "<body>{METAFLOW_BODY_BEFORE}"
+                                              .format(METAFLOW_BODY_BEFORE=METAFLOW_BODY_BEFORE))
+
+                if METAFLOW_BODY_AFTER:
+                    content = content.replace("</body>", "{METAFLOW_BODY_AFTER}</body>"
+                                              .format(METAFLOW_BODY_AFTER=METAFLOW_BODY_AFTER))
+
                 return web.Response(text=content, content_type='text/html')
         except Exception as err:
             return web.Response(text=str(err), status=500, content_type='text/plain')


### PR DESCRIPTION
Adds ability to inject content to `index.html` when serving UI (with `UI_ENABLED=1` env variable).

Introduces following env variables:

- `METAFLOW_HEAD` - Inject content to `head` element
- `METAFLOW_BODY_BEFORE` - Inject content at the beginning of `body` element
- `METAFLOW_BODY_AFTER` - Inject content at the end of `body` element

Use case for these variables ranges from additional meta tags to analytics script injection.

Example on how to add keyword meta tag to Metaflow UI:

```
METAFLOW_HEAD='<meta name="keywords" content="metaflow" />'
```