### PR TITLE
Pinning Go Dep in docker file.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:latest
+FROM golang:1.16.3
 
 RUN go get -u github.com/pressly/goose/cmd/goose
 


### PR DESCRIPTION
Pinning the go docker dependency otherwise the image is not building; Ran into some issue with `go:latest` image so pinning the working image. 