### PR TITLE
fix: Switch pg_notify ping channel to notify

### DIFF
--- a/services/ui_backend_service/api/notify.py
+++ b/services/ui_backend_service/api/notify.py
@@ -64,7 +64,7 @@ class ListenNotify(object):
         async with conn.cursor() as cur:
             while not cur.closed:
                 try:
-                    await cur.execute("NOTIFY ping")
+                    await cur.execute("NOTIFY listen")
                 except Exception:
                     self.logger.debug("Exception NOTIFY ping.")
                 finally:


### PR DESCRIPTION
Related to PR https://github.com/Netflix/metaflow-service/pull/132

Prefer NOTIFY notify instead of ping to ensure messages are always consumed. This is experimental fix to try to overcome a bug on pg_notify while using logical replication.

Following messages were observed on PostgreSQL logs against logical replication (subscription) instance:

```
ERROR: too many notifications in the NOTIFY queue
STATEMENT: NOTIFY ping
WARNING: NOTIFY queue is 100% full
```