### PR TITLE
fix: streamline run statuses and remove fallbacks

### DIFF
--- a/services/ui_backend_service/data/db/tables/base.py
+++ b/services/ui_backend_service/data/db/tables/base.py
@@ -1,7 +1,7 @@
 import math
 import os
 from asyncio import iscoroutinefunction
-from typing import Callable, List
+from typing import Callable, List, Tuple
 
 import psycopg2
 import psycopg2.extras
@@ -61,7 +61,7 @@ class AsyncPostgresTable(MetadataAsyncPostgresTable):
                            postprocess: Callable[[DBResponse], DBResponse] = None,
                            invalidate_cache=False, benchmark: bool = False,
                            overwrite_select_from: str = None
-                           ) -> (DBResponse, DBPagination):
+                           ) -> Tuple[DBResponse, DBPagination]:
         # Grouping not enabled
         if groups is None or len(groups) == 0:
             sql_template = """
@@ -213,7 +213,7 @@ class AsyncPostgresTable(MetadataAsyncPostgresTable):
             return None
 
     async def execute_sql(self, select_sql: str, values=[], fetch_single=False,
-                          expanded=False, limit: int = 0, offset: int = 0, serialize: bool = True) -> (DBResponse, DBPagination):
+                          expanded=False, limit: int = 0, offset: int = 0, serialize: bool = True) -> Tuple[DBResponse, DBPagination]:
         try:
             with (
                 await self.db.pool.cursor(

--- a/services/ui_backend_service/data/db/tables/run.py
+++ b/services/ui_backend_service/data/db/tables/run.py
@@ -128,6 +128,7 @@ class AsyncRunTablePostgres(AsyncPostgresTable):
             WHEN end_attempt_ok IS NOT NULL
             THEN end_attempt_ok.ts_epoch
             WHEN {table_name}.last_heartbeat_ts IS NOT NULL
+                AND latest_failed_task IS NOT NULL
                 AND @(extract(epoch from now())-{table_name}.last_heartbeat_ts)>{heartbeat_threshold}
             THEN {table_name}.last_heartbeat_ts*1000
             ELSE NULL

--- a/services/ui_backend_service/data/db/tables/run.py
+++ b/services/ui_backend_service/data/db/tables/run.py
@@ -27,10 +27,6 @@ class AsyncRunTablePostgres(AsyncPostgresTable):
     keys = MetadataRunTable.keys
     primary_keys = MetadataRunTable.primary_keys
     trigger_keys = MetadataRunTable.trigger_keys
-    # check-heartbeat;
-    # if not, check end artifact;
-    # if not check any failed task;
-    # if not consider running
 
     joins = [
         """

--- a/services/ui_backend_service/data/db/tables/run.py
+++ b/services/ui_backend_service/data/db/tables/run.py
@@ -87,10 +87,8 @@ class AsyncRunTablePostgres(AsyncPostgresTable):
                 AND {table_name}.run_number = task.run_number
                 AND @(extract(epoch from now())-{table_name}.last_heartbeat_ts)>{heartbeat_threshold}
                 AND end_attempt_ok IS NULL
-                AND (
-                    (attempt_ok.is_ok IS FALSE) OR
-                    (attempt_ok.is_ok IS NULL AND @(extract(epoch from now())-task.last_heartbeat_ts)>{heartbeat_threshold})
-                )
+                AND attempt_ok.is_ok IS NOT TRUE
+                AND @(extract(epoch from now())-task.last_heartbeat_ts)>{heartbeat_threshold}
             GROUP BY task.flow_id, task.run_number, task.step_name, task.task_id, attempt_ok.ts_epoch
             ORDER BY attempt_ok.ts_epoch DESC
             LIMIT 1

--- a/services/ui_backend_service/data/db/tables/run.py
+++ b/services/ui_backend_service/data/db/tables/run.py
@@ -83,6 +83,7 @@ class AsyncRunTablePostgres(AsyncPostgresTable):
                 AND {table_name}.run_number = task.run_number
                 AND @(extract(epoch from now())-{table_name}.last_heartbeat_ts)>{heartbeat_threshold}
                 AND end_attempt_ok IS NULL
+                AND end_attempt is NULL
                 AND attempt_ok.is_ok IS NOT TRUE
                 AND @(extract(epoch from now())-task.last_heartbeat_ts)>{heartbeat_threshold}
             GROUP BY task.flow_id, task.run_number, task.step_name, task.task_id, attempt_ok.ts_epoch

--- a/services/ui_backend_service/tests/integration_tests/grouped_runs_test.py
+++ b/services/ui_backend_service/tests/integration_tests/grouped_runs_test.py
@@ -39,7 +39,7 @@ async def test_list_runs_group_by_flow_id(cli, db):
     await _test_list_resources(cli, db, "/runs?_group=flow_id&_group_limit=1", 200, [first_runs[0], second_runs[0]], approx_keys=["duration"])
 
     # _limit should limit number of groups, not number of rows.
-    await _test_list_resources(cli, db, "/runs?_group=flow_id&_group_limit=2&_limit=1", 200, first_runs[:2], approx_keys=["duration"])
+    await _test_list_resources(cli, db, "/runs?_group=flow_id&_group_limit=2&_limit=1&_order=%2Brun_number", 200, first_runs[:2], approx_keys=["duration"])
 
     # _order should order within groups.
     await _test_list_resources(cli, db, "/runs?_group=flow_id&_order=run_number", 200, [*first_runs[::-1][:10], *second_runs[::-1][:10]], approx_keys=["duration"])

--- a/services/ui_backend_service/tests/integration_tests/runs_test.py
+++ b/services/ui_backend_service/tests/integration_tests/runs_test.py
@@ -163,6 +163,14 @@ async def test_run_status_with_heartbeat(cli, db):
 
     # A run with no end task and an expired heartbeat should count as failed.
     _run_failed = (await add_run(db, flow_id=_flow.get("flow_id"), last_heartbeat_ts=1)).body
+    # even when a run has a heartbeat, it still requires a task that has failed via attempt_ok=false OR by an expired heartbeat.
+    _step = (await add_step(db, flow_id=_run_failed.get("flow_id"), step_name="end", run_number=_run_failed.get("run_number"), run_id=_run_failed.get("run_id"))).body
+    _task = (await add_task(db,
+                            flow_id=_step.get("flow_id"),
+                            step_name=_step.get("step_name"),
+                            run_number=_step.get("run_number"),
+                            run_id=_step.get("run_id"),
+                            last_heartbeat_ts=1)).body
     _run_failed["status"] = "failed"
     _run_failed["user"] = None
     _run_failed["run"] = _run_failed["run_number"]

--- a/services/ui_backend_service/tests/integration_tests/runs_test.py
+++ b/services/ui_backend_service/tests/integration_tests/runs_test.py
@@ -202,21 +202,7 @@ async def test_run_status_with_heartbeat(cli, db):
                             step_name=_step.get("step_name"),
                             run_number=_step.get("run_number"),
                             run_id=_step.get("run_id"))).body
-    # _artifact = (await add_artifact(
-    #     db,
-    #     flow_id=_run_complete.get("flow_id"),
-    #     run_number=_run_complete.get("run_number"),
-    #     step_name="end",
-    #     task_id=1,
-    #     artifact={
-    #         "name": "_task_ok",
-    #         "location": "location",
-    #         "ds_type": "ds_type",
-    #         "sha": "sha",
-    #         "type": "type",
-    #         "content_type": "content_type",
-    #         "attempt_id": 0
-    #     })).body
+
     _metadata = (await add_metadata(db,
                                     flow_id=_task.get("flow_id"),
                                     run_number=_task.get("run_number"),
@@ -239,8 +225,7 @@ async def test_run_status_with_heartbeat(cli, db):
     await _test_single_resource(cli, db, "/flows/{flow_id}/runs/{run_number}".format(**_run_complete), 200, _run_complete)
 
 
-async def Xtest_old_run_status_without_heartbeat(cli, db):
-    # Test does not make sense with current changes.
+async def test_old_run_status_without_heartbeat(cli, db):
     # Run is only complete if it records attempt_ok True metadata. _task_ok artifact is not part of the check anymore.
     await _test_single_resource(cli, db, "/flows/HelloFlow/runs/hello", 404, {})
 
@@ -251,17 +236,15 @@ async def Xtest_old_run_status_without_heartbeat(cli, db):
     _run_running["status"] = "running"
     _run_running["user"] = None
     _run_running["run"] = _run_running["run_number"]
-    _run_running["duration"] = int(round(time.time() * 1000)) - _run_running["ts_epoch"]
+    _run_running["duration"] = get_heartbeat_ts() * 1000 - _run_running["ts_epoch"]
 
     await _test_single_resource(cli, db, "/flows/{flow_id}/runs/{run_number}".format(**_run_running), 200, _run_running, approx_keys=["duration"])
 
-    # A run with an end task _task_ok artifact should count as completed.
-    _run_complete = (await add_run(db, flow_id=_flow.get("flow_id"))).body
-
+    # A run with an end task _task_ok artifact should not count as completed.
     _artifact = (await add_artifact(
         db,
-        flow_id=_run_complete.get("flow_id"),
-        run_number=_run_complete.get("run_number"),
+        flow_id=_run_running.get("flow_id"),
+        run_number=_run_running.get("run_number"),
         step_name="end",
         task_id=1,
         artifact={
@@ -274,13 +257,10 @@ async def Xtest_old_run_status_without_heartbeat(cli, db):
                             "attempt_id": 0
         })).body
 
-    _run_complete["status"] = "completed"
-    _run_complete["user"] = None
-    _run_complete["run"] = _run_complete["run_number"]
-    _run_complete["finished_at"] = _artifact["ts_epoch"]
-    _run_complete["duration"] = _run_complete["finished_at"] - _run_complete["ts_epoch"]
+    _run_running["finished_at"] = None
+    _run_running["duration"] = get_heartbeat_ts() * 1000 - _run_running["ts_epoch"]
 
-    await _test_single_resource(cli, db, "/flows/{flow_id}/runs/{run_number}".format(**_run_complete), 200, _run_complete)
+    await _test_single_resource(cli, db, "/flows/{flow_id}/runs/{run_number}".format(**_run_running), 200, _run_running, approx_keys=["duration"])
 
     # A run with no end task and a timestamp older than two weeks should count as failed.
     _run_failed = (await add_run(db, flow_id=_flow.get("flow_id"))).body

--- a/services/ui_backend_service/tests/integration_tests/status_runs_test.py
+++ b/services/ui_backend_service/tests/integration_tests/status_runs_test.py
@@ -174,60 +174,6 @@ async def test_run_status_running_with_heartbeat(cli, db):
     assert data["finished_at"] == None
 
 
-# Run should have "Failed" status when any of the following apply:
-#   1. A task has failed
-#   2. No heartbeat has been logged for the task in the last Y minutes for any task
-#
-# Sart time: created_at(ts_epoch) column value in the run table
-# End time: Latest end time for all tasks
-
-async def Xtest_run_status_failed_failed_task(cli, db):
-    # Test does not make sense with recent changes, as a run will always have a heartbeat now.
-    _flow = (await add_flow(db, flow_id="HelloFlow")).body
-    _run = (await add_run(db, flow_id=_flow.get("flow_id"))).body
-    _step = (await add_step(db, flow_id=_run.get("flow_id"), step_name="end", run_number=_run.get("run_number"), run_id=_run.get("run_id"))).body
-    _task = (await add_task(db,
-                            flow_id=_step.get("flow_id"),
-                            step_name=_step.get("step_name"),
-                            run_number=_step.get("run_number"),
-                            run_id=_step.get("run_id"))).body
-
-    _artifact = (await add_artifact(
-        db,
-        flow_id=_task.get("flow_id"),
-        run_number=_task.get("run_number"),
-        step_name="end",
-        task_id=_task.get("task_id"),
-        artifact={
-            "name": "_task_ok",
-            "location": "location",
-            "ds_type": "ds_type",
-            "sha": "sha",
-            "type": "type",
-            "content_type": "content_type",
-                            "attempt_id": 0
-        })).body
-
-    _metadata = (await add_metadata(db,
-                                    flow_id=_task.get("flow_id"),
-                                    run_number=_task.get("run_number"),
-                                    run_id=_task.get("run_id"),
-                                    step_name=_task.get("step_name"),
-                                    task_id=_task.get("task_id"),
-                                    task_name=_task.get("task_name"),
-                                    tags=["attempt_id:0"],
-                                    metadata={
-                                        "field_name": "attempt_ok",
-                                        "value": "False",
-                                        "type": "internal_attempt_status"})).body
-
-    _, data = await _test_single_resource(cli, db, "/flows/{flow_id}/runs/{run_number}".format(**_run), 200, None)
-
-    assert data["status"] == "failed"
-    assert data["ts_epoch"] == _run["ts_epoch"]
-    assert data["finished_at"] == _artifact["ts_epoch"]
-
-
 async def test_run_status_failed_with_heartbeat_expired(cli, db):
     _flow = (await add_flow(db, flow_id="HelloFlow")).body
 
@@ -258,6 +204,13 @@ async def test_run_status_failed_with_heartbeat_expired(cli, db):
     assert data["last_heartbeat_ts"] == 1
     assert data["duration"] == _run["last_heartbeat_ts"] * 1000 - _run["ts_epoch"]
     assert data["finished_at"] == _run["last_heartbeat_ts"] * 1000
+
+# Run should have "Failed" status when any of the following apply:
+#   1. A task has failed
+#   2. No heartbeat has been logged for the task in the last Y minutes for any task
+#
+# Sart time: created_at(ts_epoch) column value in the run table
+# End time: Latest end time for all tasks
 
 
 async def test_run_status_failed_with_retrying_task(cli, db):

--- a/services/ui_backend_service/tests/integration_tests/status_runs_test.py
+++ b/services/ui_backend_service/tests/integration_tests/status_runs_test.py
@@ -258,3 +258,96 @@ async def test_run_status_failed_with_heartbeat_expired(cli, db):
     assert data["last_heartbeat_ts"] == 1
     assert data["duration"] == _run["last_heartbeat_ts"] * 1000 - _run["ts_epoch"]
     assert data["finished_at"] == _run["last_heartbeat_ts"] * 1000
+
+
+async def test_run_status_failed_with_retrying_task(cli, db):
+    _flow = (await add_flow(db, flow_id="HelloFlow")).body
+
+    _expired_heartbeat = get_heartbeat_ts() - 610
+
+    _run = (await add_run(db, flow_id=_flow.get("flow_id"), last_heartbeat_ts=_expired_heartbeat)).body
+    # even when a run has a heartbeat, it still requires a task that has failed via attempt_ok=false OR by an expired heartbeat.
+    _step = (await add_step(db, flow_id=_run.get("flow_id"), step_name="any_step", run_number=_run.get("run_number"), run_id=_run.get("run_id"))).body
+    _task = (await add_task(db,
+                            flow_id=_step.get("flow_id"),
+                            step_name=_step.get("step_name"),
+                            run_number=_step.get("run_number"),
+                            run_id=_step.get("run_id"),
+                            last_heartbeat_ts=get_heartbeat_ts())).body
+
+    # task does not count as failed yet, so expired run heartbeat should not fail the run either.
+    _, data = await _test_single_resource(cli, db, "/flows/{flow_id}/runs/{run_number}".format(**_run), 200)
+
+    assert data["status"] == "running"
+    # assert data["last_heartbeat_ts"] == _heartbeat
+    # assert data["duration"] == _run["last_heartbeat_ts"] * 1000 - _run["ts_epoch"]
+    # assert data["finished_at"] == _run["last_heartbeat_ts"] * 1000
+
+    await db.task_table_postgres.update_row(
+        filter_dict={
+            "flow_id": _task.get("flow_id"),
+            "run_number": _task.get("run_number"),
+            "step_name": _task.get("step_name"),
+            "task_id": _task.get("task_id")
+        },
+        update_dict={
+            "last_heartbeat_ts": _expired_heartbeat
+        }
+    )
+
+    # Task counts as failed now, run should also be failed
+    _, data = await _test_single_resource(cli, db, "/flows/{flow_id}/runs/{run_number}".format(**_run), 200)
+
+    assert data["status"] == "failed"
+
+    await db.task_table_postgres.update_row(
+        filter_dict={
+            "flow_id": _task.get("flow_id"),
+            "run_number": _task.get("run_number"),
+            "step_name": _task.get("step_name"),
+            "task_id": _task.get("task_id")
+        },
+        update_dict={
+            "last_heartbeat_ts": get_heartbeat_ts()
+        }
+    )
+
+    # Task counts as running again, run should also count as running.
+    _, data = await _test_single_resource(cli, db, "/flows/{flow_id}/runs/{run_number}".format(**_run), 200)
+
+    assert data["status"] == "running"
+
+    _metadata = (await add_metadata(db,
+                                    flow_id=_task.get("flow_id"),
+                                    run_number=_task.get("run_number"),
+                                    run_id=_task.get("run_id"),
+                                    step_name=_task.get("step_name"),
+                                    task_id=_task.get("task_id"),
+                                    task_name=_task.get("task_name"),
+                                    tags=["attempt_id:0"],
+                                    metadata={
+                                        "field_name": "attempt_ok",
+                                        "value": "False",
+                                        "type": "internal_attempt_status"})).body
+
+    # Task counts as failed again, run should count as failed once task heartbeat expires
+    # (no successive attempt of the task is updating the heartbeat).
+    _, data = await _test_single_resource(cli, db, "/flows/{flow_id}/runs/{run_number}".format(**_run), 200)
+
+    assert data["status"] == "running"
+
+    await db.task_table_postgres.update_row(
+        filter_dict={
+            "flow_id": _task.get("flow_id"),
+            "run_number": _task.get("run_number"),
+            "step_name": _task.get("step_name"),
+            "task_id": _task.get("task_id")
+        },
+        update_dict={
+            "last_heartbeat_ts": _expired_heartbeat
+        }
+    )
+
+    _, data = await _test_single_resource(cli, db, "/flows/{flow_id}/runs/{run_number}".format(**_run), 200)
+
+    assert data["status"] == "failed"

--- a/services/ui_backend_service/tests/integration_tests/status_runs_test.py
+++ b/services/ui_backend_service/tests/integration_tests/status_runs_test.py
@@ -43,6 +43,7 @@ async def test_run_status_completed(cli, db):
                             run_number=_step.get("run_number"),
                             run_id=_step.get("run_id"))).body
 
+    # Should not affect the status at all anymore
     _artifact = (await add_artifact(
         db,
         flow_id=_task.get("flow_id"),
@@ -61,9 +62,9 @@ async def test_run_status_completed(cli, db):
 
     _, data = await _test_single_resource(cli, db, "/flows/{flow_id}/runs/{run_number}".format(**_run), 200, None)
 
-    assert data["status"] == "completed"
+    assert data["status"] == "running"
     assert data["ts_epoch"] == _run["ts_epoch"]
-    assert data["finished_at"] == _artifact["ts_epoch"]
+    assert data["finished_at"] == None
 
     _metadata = (await add_metadata(db,
                                     flow_id=_task.get("flow_id"),
@@ -82,7 +83,8 @@ async def test_run_status_completed(cli, db):
 
     assert data["status"] == "completed"
     assert data["ts_epoch"] == _run["ts_epoch"]
-    assert data["finished_at"] == _artifact["ts_epoch"]
+    assert data["finished_at"] == _metadata["ts_epoch"]
+    assert data["duration"] == _metadata["ts_epoch"] - _run["ts_epoch"]
 
 
 # Run should have "Running" status when all of the following apply:
@@ -179,7 +181,8 @@ async def test_run_status_running_with_heartbeat(cli, db):
 # Sart time: created_at(ts_epoch) column value in the run table
 # End time: Latest end time for all tasks
 
-async def test_run_status_failed_failed_task(cli, db):
+async def Xtest_run_status_failed_failed_task(cli, db):
+    # Test does not make sense with recent changes, as a run will always have a heartbeat now.
     _flow = (await add_flow(db, flow_id="HelloFlow")).body
     _run = (await add_run(db, flow_id=_flow.get("flow_id"))).body
     _step = (await add_step(db, flow_id=_run.get("flow_id"), step_name="end", run_number=_run.get("run_number"), run_id=_run.get("run_id"))).body


### PR DESCRIPTION
- remove unnecessary fallback to end step _task_ok artifact for run status inference
- rely solely on run heartbeat and attempt/attempt_ok metadata entries for status, duration and finished_at timestamp
- update integration tests to reflect changes
- Also solves incorrect status for runs during end-step retries.