### PR TITLE
feat: log improvements

### DIFF
--- a/services/ui_backend_service/api/log.py
+++ b/services/ui_backend_service/api/log.py
@@ -574,9 +574,11 @@ def paginate_log_lines(request, lines):
 
     lines = order_log_lines(request, lines)
 
+    page_count = max(len(lines) // limit, 1)
+
     response = DBResponse(200, lines[offset:][:limit])
     pagination = DBPagination(limit, offset, len(response.body), page)
-    return format_response_list(request, response, pagination, page)
+    return format_response_list(request, response, pagination, page, page_count)
 
 
 def order_log_lines(request, lines):
@@ -587,6 +589,7 @@ def order_log_lines(request, lines):
         return lines[::-1]
     else:
         return lines
+
 
 def file_download_response(filename, body):
     return web.Response(

--- a/services/ui_backend_service/api/log.py
+++ b/services/ui_backend_service/api/log.py
@@ -452,7 +452,7 @@ async def read_and_output(cache_client, path):
         await res.wait()  # wait until results are ready
 
     lines = []
-    for row, line in enumerate(res.get().split("\n"), start=1):
+    for row, line in enumerate(res.get().split("\n")):
         lines.append({
             'row': row,
             'line': line.strip(),
@@ -480,7 +480,7 @@ async def read_and_output_mflog(cache_client, paths):
             logs.append(chunk)
 
     lines = []
-    for row, line in enumerate(mflog_merge_logs([logchunk for logchunk in logs]), start=1):
+    for row, line in enumerate(mflog_merge_logs([logchunk for logchunk in logs])):
         lines.append({
             'row': row,
             'line': to_unicode(line.msg)})

--- a/services/ui_backend_service/api/log.py
+++ b/services/ui_backend_service/api/log.py
@@ -1,19 +1,14 @@
 
 import os
 import json
-import aiobotocore
-import contextlib
-import botocore
 import heapq
 import io
 import re
 from collections import namedtuple
 from datetime import datetime
-from urllib.parse import urlparse
 from typing import List, Dict, Optional, Tuple
 
 from services.data.db_utils import DBResponse, translate_run_key, translate_task_key, DBPagination, DBResponse
-from ..data.s3 import wrap_s3_errors
 from services.utils import handle_exceptions, web_response
 from .utils import format_response_list
 
@@ -123,7 +118,7 @@ def mflog_merge_logs(logs):
 
 
 class LogApi(object):
-    def __init__(self, app, db):
+    def __init__(self, app, db, cache=None):
         self.db = db
         app.router.add_route(
             "GET",
@@ -148,25 +143,8 @@ class LogApi(object):
         self.metadata_table = self.db.metadata_table_postgres
         self.task_table = self.db.task_table_postgres
 
-        # Shared S3 session config for LOG fetching
-        self.context_stack = contextlib.AsyncExitStack()
-        self.s3_client = None
-        app.on_startup.append(self.init_s3_client)
-        app.on_cleanup.append(self.teardown_s3_client)
-
-    async def init_s3_client(self, app):
-        "Initializes an S3 client for this API handler"
-        session = aiobotocore.get_session()
-        conf = botocore.config.Config(max_pool_connections=S3_MAX_POOL_CONNECTIONS)
-        self.s3_client = await self.context_stack.enter_async_context(
-            session.create_client(
-                's3', config=conf,
-                endpoint_url=os.environ.get("METAFLOW_S3_ENDPOINT_URL", None),
-                verify=os.environ.get("METAFLOW_S3_VERIFY_CERTIFICATE", None)))
-
-    async def teardown_s3_client(self, app):
-        "closes the async context for the S3 client"
-        await self.context_stack.aclose()
+        # Cache to hold already fetched logs
+        self.cache = getattr(cache, "log_cache", None)
 
     @handle_exceptions
     async def get_task_log_stdout(self, request):
@@ -340,19 +318,19 @@ class LogApi(object):
                 flow_id, task['run_id'], step_name, task['task_name'],
                 attempt_id, logtype)
             if to_fetch:
-                lines = await read_and_output_mflog(self.s3_client, to_fetch)
+                lines = await read_and_output_mflog(self.cache, to_fetch)
                 # paginate response
                 code, body = paginate_log_lines(request, lines)
                 return web_response(code, body)
         else:
-            bucket, path, _ = \
+            path, _ = \
                 await get_metadata_log_assume_path(
                     self.metadata_table.find_records,
                     flow_id, run_number, step_name, task_id,
                     attempt_id, logtype)
 
-            if bucket and path:
-                lines = await read_and_output(self.s3_client, bucket, path)
+            if path:
+                lines = await read_and_output(self.cache, path)
                 # paginate response
                 code, body = paginate_log_lines(request, lines)
                 return web_response(code, body)
@@ -382,18 +360,18 @@ class LogApi(object):
                 flow_id, task['run_id'], step_name, task['task_name'],
                 attempt_id, logtype)
             if to_fetch:
-                lines = await read_and_output_mflog(self.s3_client, to_fetch)
+                lines = await read_and_output_mflog(self.cache, to_fetch)
                 logstring = "\n".join(line['line'] for line in lines)
                 return file_download_response(log_filename, logstring)
         else:
-            bucket, path, _ = \
+            path, _ = \
                 await get_metadata_log_assume_path(
                     self.metadata_table.find_records,
                     flow_id, run_number, step_name, task_id,
                     attempt_id, logtype)
 
-            if bucket and path:
-                lines = await read_and_output(self.s3_client, bucket, path)
+            if path:
+                lines = await read_and_output(self.cache, path)
                 logstring = "\n".join(line['line'] for line in lines)
                 return file_download_response(log_filename, logstring)
         return web_response(404, {'data': []})
@@ -413,16 +391,13 @@ async def get_metadata_mflog_paths(flow_id, run_id, step_name, task_name, attemp
         for s in LOG_SOURCES]
     to_fetch = []
     for u in urls:
-        url = urlparse(u, allow_fragments=False)
-        if url.scheme == 's3':
-            bucket = url.netloc
-            path = url.path.lstrip('/')
-            to_fetch.append((bucket, path))
+        if u.startswith("s3://"):
+            to_fetch.append(u)
     return to_fetch
 
 
 async def get_metadata_log_assume_path(find_records, flow_name, run_number, step_name, task_id, attempt_id, field_name) -> Tuple[str, str, int]:
-    bucket, path, _ = \
+    path, _ = \
         await get_metadata_log(
             find_records,
             flow_name, run_number, step_name, task_id,
@@ -432,7 +407,7 @@ async def get_metadata_log_assume_path(find_records, flow_name, run_number, step
     # Manually construct assumed logfile S3 path based on first attempt
     if not path:
         if attempt_id and attempt_id is not 0 and attempt_id is not "0":
-            bucket, path, _ = \
+            path, _ = \
                 await get_metadata_log(
                     find_records,
                     flow_name, run_number, step_name, task_id,
@@ -442,7 +417,7 @@ async def get_metadata_log_assume_path(find_records, flow_name, run_number, step
                 suffix = "{}.log".format("stdout" if field_name == STDOUT else "stderr")
                 path = path.replace("0.{}".format(suffix), "{}.{}".format(attempt_id, suffix))
 
-    return bucket, path, attempt_id
+    return path, attempt_id
 
 
 async def get_metadata_log(find_records, flow_name, run_number, step_name, task_id, attempt_id, field_name) -> Tuple[str, str, int]:
@@ -476,58 +451,55 @@ async def get_metadata_log(find_records, flow_name, run_number, step_name, task_
             if result:
                 value = json.loads(result['value'])
                 if value['ds_type'] == 's3':
-                    url = urlparse(value['location'], allow_fragments=False)
-                    bucket = url.netloc
-                    path = url.path.lstrip('/')
+                    path = value['location']
                     attempt_id = value['attempt']
-                    return bucket, path, attempt_id
+                    return path, attempt_id
     except Exception:
         pass
-    return None, None, None
+    return None, None
 
 
-@wrap_s3_errors
-async def read_and_output(s3_client, bucket, path):
-    obj = await s3_client.get_object(Bucket=bucket, Key=path)
+async def read_and_output(cache_client, path):
+    res = await cache_client.cache.GetLogFile(path, invalidate_cache=True)
+
+    if res.has_pending_request():
+        async for event in res.stream():
+            if event["type"] == "error":
+                # raise error, there was an exception during fetching.
+                raise LogException(event["message"], event["id"], event["traceback"])
+        await res.wait()  # wait until results are ready
 
     lines = []
-    async with obj['Body'] as stream:
-        async for row, line in aenumerate(stream, start=1):
-            lines.append({
-                'row': row,
-                'line': line.strip(),
-            })
+    for row, line in enumerate(res.get().split("\n"), start=1):
+        lines.append({
+            'row': row,
+            'line': line.strip(),
+        })
     return lines
 
 
-async def read_and_output_ws(s3_client, bucket, path, ws):
-    obj = await s3_client.get_object(Bucket=bucket, Key=path)
+async def read_and_output_ws(cache_client, path, ws):
+    lines = await read_and_output(cache_client, path)
 
-    async with obj['Body'] as stream:
-        async for row, line in aenumerate(stream, start=1):
-            await ws.send_str(json.dumps({
-                'row': row,
-                'line': line.strip(),
-            }))
+    for line in lines:
+        await ws.send_str(json.dumps(line))
 
 
-@wrap_s3_errors
-async def read_and_output_mflog(s3_client, paths):
+async def read_and_output_mflog(cache_client, paths):
     logs = []
-    for bucket, path in paths:
-        try:
-            obj = await s3_client.get_object(Bucket=bucket, Key=path)
+    for path in paths:
+        res = await cache_client.cache.GetLogFile(path, invalidate_cache=True)
 
-            async with obj['Body'] as stream:
-                data = await stream.read()
-                logs.append(data)
-        except botocore.exceptions.ClientError as err:
-            if err.response['Error']['Code'] == 'NoSuchKey':
-                pass
-            else:
-                raise
+        if res.has_pending_request():
+            async for event in res.stream():
+                if event["type"] == "error":
+                    # raise error, there was an exception during fetching.
+                    raise LogException(event["message"], event["id"], event["traceback"])
+            await res.wait()  # wait until results are ready
+
+        logs.append(res.get())
+
     lines = []
-    # TODO: This could be an async iterator instead?
     for row, line in enumerate(mflog_merge_logs([blob for blob in logs])):
         lines.append({
             'row': row,
@@ -535,18 +507,10 @@ async def read_and_output_mflog(s3_client, paths):
     return lines
 
 
-async def read_and_output_mflog_ws(s3_client, paths, ws):
-    logs = []
-    for bucket, path in paths:
-        obj = await s3_client.get_object(Bucket=bucket, Key=path)
-
-        async with obj['Body'] as stream:
-            data = await stream.read()
-            logs.append(data)
-    for row, line in enumerate(mflog_merge_logs([blob for blob in logs])):
-        await ws.send_str(json.dumps({
-            'row': row,
-            'line': to_unicode(line.msg)}))
+async def read_and_output_mflog_ws(cache_client, paths, ws):
+    lines = await read_and_output_mflog(cache_client, paths)
+    for line in lines:
+        await ws.send_str(json.dumps(line))
 
 
 async def aenumerate(stream, start=0):
@@ -637,9 +601,10 @@ def _get_pathspec_from_request(request: MultiDict) -> Tuple[str, str, str, str, 
 
 
 class LogException(Exception):
-    def __init__(self, msg='Failed to read log', id='log-error'):
+    def __init__(self, msg='Failed to read log', id='log-error', traceback_str=None):
         self.message = msg
         self.id = id
+        self.traceback_str = traceback_str
 
     def __str__(self):
         return self.message

--- a/services/ui_backend_service/api/log.py
+++ b/services/ui_backend_service/api/log.py
@@ -572,10 +572,21 @@ def paginate_log_lines(request, lines):
     # Offset
     offset = limit * (page - 1)
 
-    response = DBResponse(200, lines[::-1][offset:][:limit])  # Read loglines in reverse order as latest ones are most important.
+    lines = order_log_lines(request, lines)
+
+    response = DBResponse(200, lines[offset:][:limit])
     pagination = DBPagination(limit, offset, len(response.body), page)
     return format_response_list(request, response, pagination, page)
 
+
+def order_log_lines(request, lines):
+    "orders log lines based on request parameters"
+
+    order = request.query.get("_order")
+    if order is not None and order.startswith("-row"):
+        return lines[::-1]
+    else:
+        return lines
 
 def file_download_response(filename, body):
     return web.Response(

--- a/services/ui_backend_service/api/log.py
+++ b/services/ui_backend_service/api/log.py
@@ -493,6 +493,9 @@ async def read_and_output_mflog(cache_client, paths):
         if res.has_pending_request():
             async for event in res.stream():
                 if event["type"] == "error":
+                    if event["id"] == "s3-not-found":
+                        # some of the mflog objects are not present at all times, this is expected
+                        continue
                     # raise error, there was an exception during fetching.
                     raise LogException(event["message"], event["id"], event["traceback"])
             await res.wait()  # wait until results are ready

--- a/services/ui_backend_service/api/utils.py
+++ b/services/ui_backend_service/api/utils.py
@@ -37,7 +37,7 @@ def format_response(request: web.BaseRequest, db_response: DBResponse) -> Tuple[
     return db_response.response_code, response_object
 
 
-def format_response_list(request: web.BaseRequest, db_response: DBResponse, pagination: DBPagination, page: int) -> (int, Dict):
+def format_response_list(request: web.BaseRequest, db_response: DBResponse, pagination: DBPagination, page: int, page_count: int = None) -> Tuple[int, Dict]:
     query = {}
     for key in request.query:
         query[key] = request.query.get(key)
@@ -56,13 +56,15 @@ def format_response_list(request: web.BaseRequest, db_response: DBResponse, pagi
             "self": "{}{}".format(baseurl, format_qs(query)),
             "first": "{}{}".format(baseurl, format_qs(query, {"_page": 1})),
             "prev": "{}{}".format(baseurl, format_qs(query, {"_page": prevPage})),
-            "next": "{}{}".format(baseurl, format_qs(query, {"_page": nextPage})) if nextPage else None
+            "next": "{}{}".format(baseurl, format_qs(query, {"_page": nextPage})) if nextPage else None,
+            "last": "{}{}".format(baseurl, format_qs(query, {"_page": page_count})) if page_count else None
         },
         "pages": {
             "self": page,
             "first": 1,
             "prev": prevPage,
-            "next": nextPage
+            "next": nextPage,
+            "last": page_count
         },
         "query": query,
     }

--- a/services/ui_backend_service/data/cache/client/cache_worker.py
+++ b/services/ui_backend_service/data/cache/client/cache_worker.py
@@ -53,6 +53,10 @@ def cli(action_spec, request_file=None):
 
         # write outputs to keys
         for key, val in res.items():
+            if key in ex_keys and ex_keys[key] == val:
+                # Reduce disk churn by not unnecessarily writing existing keys
+                # that have identical values to the newly produced ones.
+                continue
             blob = val if isinstance(val, bytes) else val.encode('utf-8')
             with open(req['keys'][key], 'wb') as f:
                 f.write(blob)

--- a/services/ui_backend_service/data/cache/get_log_file_action.py
+++ b/services/ui_backend_service/data/cache/get_log_file_action.py
@@ -1,0 +1,116 @@
+import hashlib
+import json
+
+from .client import CacheAction
+from services.utils import get_traceback_str
+
+from ..s3 import (
+    S3AccessDenied, S3CredentialsMissing,
+    S3Exception, S3NotFound,
+    S3URLException, get_s3_obj, get_s3_client, get_s3_size)
+from .utils import (error_event_msg, read_as_string)
+
+
+class GetLogFile(CacheAction):
+    """
+    Gets raw log file content from S3 url, caches both the content and the current file size,
+    when processing, compares file size from HEAD response of s3 file to the cached file size, and
+    performs re-fetch only if the sizes differ.
+
+    Parameters
+    ----------
+    s3_location : str
+        The S3 location of the log file
+
+    invalidate_cache: Boolean
+        Whether to invalidate the cache or not,
+        use this to force a re-check and possible refetch of the log file.
+
+    Returns
+    --------
+    str
+        example:
+        "log line 1\nlog line2\nlog line 3"
+    """
+
+    @classmethod
+    def format_request(cls, log_location, invalidate_cache=False):
+        msg = {
+            'log_location': log_location
+        }
+        log_key = log_cache_id(log_location)
+        stream_key = 'log:stream:%s' % lookup_id(log_location)
+
+        return msg,\
+            [log_key],\
+            stream_key,\
+            [stream_key],\
+            invalidate_cache
+
+    @classmethod
+    def response(cls, keys_objs):
+        '''
+        Return the cached log content
+        '''
+        return [
+            json.loads(val)["content"] for key, val in keys_objs.items()
+            if key.startswith('log:content')][0]
+
+    @classmethod
+    def stream_response(cls, it):
+        for msg in it:
+            yield msg
+
+    @classmethod
+    def execute(cls,
+                message=None,
+                keys=None,
+                existing_keys={},
+                stream_output=None,
+                invalidate_cache=False,
+                **kwargs):
+
+        results = {}
+        location = message['log_location']
+        log_key = log_cache_id(location)
+        previous_result = existing_keys.get(log_key, None)
+        previous_log_size = json.loads(previous_result).get("log_size", None) if previous_result else None
+
+        def stream_error(err, id, traceback=None):
+            return stream_output({"type": "error", "message": err, "id": id, "traceback": traceback})
+
+        # Fetch the S3 locations data
+        s3 = get_s3_client()
+        try:
+            # fetch HEAD of logfile and compare
+            current_size = get_s3_size(s3, location)
+            if previous_log_size and previous_log_size == current_size:
+                # if filesizes match, return existing results.
+                # NOTE: This might cause some amount of disk churn at the moment, as returning existing keys will still require a write to disk
+                # due to us being inside execute() at this point.
+                return existing_keys
+
+            # current size has increased since last check, update size and fetch new content
+            temp_obj = get_s3_obj(s3, location)
+            content = read_as_string(temp_obj.name)
+            results[log_key] = json.dumps({"log_size": current_size, "content": content})
+        except (S3AccessDenied, S3NotFound, S3URLException, S3CredentialsMissing) as ex:
+            stream_error(str(ex), ex.id)
+        except S3Exception as ex:
+            stream_error(get_traceback_str(), ex.id)
+        except Exception:
+            stream_error(get_traceback_str(), 'log-handle-failed')
+
+        return results
+
+# Utilities
+
+
+def log_cache_id(location):
+    "construct a unique cache key for log file location"
+    return 'log:content:%s' % location
+
+
+def lookup_id(location):
+    "construct a unique id to be used with stream_key and result_key"
+    return hashlib.sha1(location.encode('utf-8')).hexdigest()

--- a/services/ui_backend_service/data/cache/utils.py
+++ b/services/ui_backend_service/data/cache/utils.py
@@ -22,6 +22,12 @@ def decode(path):
         obj = pickle.load(f)
         return obj
 
+
+def read_as_string(path):
+    "reads file contents as a string"
+    with open(path, "r") as f:
+        return f.read()
+
 # Cache Action helpers
 
 

--- a/services/ui_backend_service/requirements.txt
+++ b/services/ui_backend_service/requirements.txt
@@ -2,7 +2,6 @@ aiohttp==3.6.2
 aiohttp-swagger==1.0.15
 botocore==1.19.52
 boto3==1.16.52
-aiobotocore==1.2.2
 pyee==8.0.1
 yarl==1.5.1
 throttler==1.2.0

--- a/services/ui_backend_service/tests/integration_tests/log_test.py
+++ b/services/ui_backend_service/tests/integration_tests/log_test.py
@@ -56,23 +56,21 @@ async def test_list_logs_without_assume(db):
                                               "value": '{"ds_type": "s3", "location": "s3://bucket/Flow/1/end/2/0.stdout.log", "attempt": 0}',
                                               "type": "log_path"})).body
 
-    bucket, path, attempt_id = \
+    path, attempt_id = \
         await get_metadata_log(
             db.metadata_table_postgres.find_records,
             _task.get("flow_id"), _task.get("run_number"), _task.get("step_name"), _task.get("task_id"),
             0, "log_location_stdout")
 
-    assert bucket == "bucket"
-    assert path == "Flow/1/end/2/0.stdout.log"
+    assert path == "s3://bucket/Flow/1/end/2/0.stdout.log"
     assert attempt_id == 0
 
-    bucket, path, attempt_id = \
+    path, attempt_id = \
         await get_metadata_log(
             db.metadata_table_postgres.find_records,
             _task.get("flow_id"), _task.get("run_number"), _task.get("step_name"), _task.get("task_id"),
             1, "log_location_stdout")
 
-    assert bucket == None
     assert path == None
     assert attempt_id == None
 
@@ -100,24 +98,22 @@ async def test_list_logs_assume_path(db):
                                               "value": '{"ds_type": "s3", "location": "s3://bucket/Flow/1/end/2/0.stdout.log", "attempt": 0}',
                                               "type": "log_path"})).body
 
-    bucket, path, attempt_id = \
+    path, attempt_id = \
         await get_metadata_log_assume_path(
             db.metadata_table_postgres.find_records,
             _task.get("flow_id"), _task.get("run_number"), _task.get("step_name"), _task.get("task_id"),
             0, "log_location_stdout")
 
-    assert bucket == "bucket"
-    assert path == "Flow/1/end/2/0.stdout.log"
+    assert path == "s3://bucket/Flow/1/end/2/0.stdout.log"
     assert attempt_id == 0
 
-    bucket, path, attempt_id = \
+    path, attempt_id = \
         await get_metadata_log_assume_path(
             db.metadata_table_postgres.find_records,
             _task.get("flow_id"), _task.get("run_number"), _task.get("step_name"), _task.get("task_id"),
             1, "log_location_stdout")
 
-    assert bucket == "bucket"
-    assert path == "Flow/1/end/2/1.stdout.log"
+    assert path == "s3://bucket/Flow/1/end/2/1.stdout.log"
     assert attempt_id == 1
 
 
@@ -226,7 +222,7 @@ async def test_log_paginated_response_with_regular_logs(cli, db):
         {"row": 5, "line": "log line 5"},
     ]
 
-    async def read_and_output(s3_client, bucket, path):
+    async def read_and_output(cache_client, path):
         return test_log
 
     with mock.patch("services.ui_backend_service.api.log.read_and_output", new=read_and_output):

--- a/services/ui_backend_service/tests/integration_tests/log_test.py
+++ b/services/ui_backend_service/tests/integration_tests/log_test.py
@@ -1,6 +1,7 @@
 from ...api.log import get_metadata_log, get_metadata_log_assume_path
 import pytest
 import os
+from unittest import mock
 from .utils import (
     init_app, init_db, clean_db,
     add_flow, add_run, add_step, add_task, add_metadata,
@@ -194,3 +195,45 @@ async def test_list_mflogs_assume_path_with_DS_ROOT(ds_root_env, cli, db):
     # Check that choice of resource primary key does not affect return.
     await _test_list_resources(cli, db, "/flows/{flow_id}/runs/{run_id}/steps/{step_name}/tasks/{task_name}/logs/out".format(**_task), 500, None)
     await _test_list_resources(cli, db, "/flows/{flow_id}/runs/{run_number}/steps/{step_name}/tasks/{task_id}/logs/out".format(**_task), 500, None)
+
+
+async def test_log_paginated_response_with_regular_logs(cli, db):
+    _flow = (await add_flow(db, flow_id="HelloFlow")).body
+    _run = (await add_run(db, flow_id=_flow.get("flow_id"))).body
+    _step = (await add_step(db, flow_id=_run.get("flow_id"), step_name="step", run_number=_run.get("run_number"), run_id=_run.get("run_id"))).body
+    _task = (await add_task(db,
+                            flow_id=_step.get("flow_id"),
+                            step_name=_step.get("step_name"),
+                            run_number=_step.get("run_number"),
+                            run_id=_step.get("run_id"))).body
+
+    (await add_metadata(db,
+                        flow_id=_task.get("flow_id"),
+                        run_number=_task.get("run_number"),
+                        run_id=_task.get("run_id"),
+                        step_name=_task.get("step_name"),
+                        task_id=_task.get("task_id"),
+                        task_name=_task.get("task_name"),
+                        metadata={
+                            "field_name": "log_location_stdout",
+                            "value": '{"ds_type": "s3", "location": "s3://bucket/Flow/1/end/2/0.stdout.log", "attempt": 0}',
+                            "type": "log_path"})).body
+    test_log = [
+        {"row": 1, "line": "log line 1"},
+        {"row": 2, "line": "log line 2"},
+        {"row": 3, "line": "log line 3"},
+        {"row": 4, "line": "log line 4"},
+        {"row": 5, "line": "log line 5"},
+    ]
+
+    async def read_and_output(s3_client, bucket, path):
+        return test_log
+
+    with mock.patch("services.ui_backend_service.api.log.read_and_output", new=read_and_output):
+        # default log order should be oldest to newest. should obey limit.
+        _, data = await _test_list_resources(cli, db, "/flows/{flow_id}/runs/{run_number}/steps/{step_name}/tasks/{task_id}/logs/out?_limit=3".format(**_task), 200, None)
+        assert data == test_log[:3]
+
+        # ordering by row should be possible in reverse. should obey limit.
+        _, data = await _test_list_resources(cli, db, "/flows/{flow_id}/runs/{run_number}/steps/{step_name}/tasks/{task_id}/logs/out?_order=-row&_limit=3".format(**_task), 200, None)
+        assert data == test_log[::-1][:3]

--- a/services/ui_backend_service/tests/unit_tests/log_test.py
+++ b/services/ui_backend_service/tests/unit_tests/log_test.py
@@ -1,7 +1,7 @@
 import pytest
 import collections
 
-from services.ui_backend_service.api.log import paginate_log_lines
+from services.ui_backend_service.api.log import paginate_log_lines, order_log_lines
 
 pytestmark = [pytest.mark.unit_tests]
 
@@ -22,8 +22,8 @@ async def test_log_lines_pagination(req):
 
     # 1000 lines should fit in default pagination
     assert len(body['data']) == 1000
-    # order should be reverse
-    assert body['data'][0] == "log line 1000"
+    # order should be oldest to newest
+    assert body['data'][0] == "log line 1"
 
 
 async def test_log_lines_pagination_oob_page(req):
@@ -42,4 +42,17 @@ async def test_log_lines_pagination_with_limit(req):
     _, body = paginate_log_lines(req, TEST_LOG)
 
     assert len(body['data']) == 5
-    assert body['data'] == list("log line {}".format(i) for i in range(991, 996))[::-1]
+    assert body['data'] == list("log line {}".format(i) for i in range(6, 11))
+
+async def test_log_lines_ordering(req):
+    req.query = {
+    }
+
+    lines = order_log_lines(req, TEST_LOG)
+    assert lines == TEST_LOG
+
+
+    req.query = {"_order": "-row"}
+
+    lines = order_log_lines(req, TEST_LOG)
+    assert lines == TEST_LOG[::-1]

--- a/services/ui_backend_service/tests/unit_tests/utils_test.py
+++ b/services/ui_backend_service/tests/unit_tests/utils_test.py
@@ -51,13 +51,15 @@ def test_format_response_list():
             "self": "http://test/runs?_limit=1&_page=1",
             "first": "http://test/runs?_limit=1&_page=1",
             "prev": "http://test/runs?_limit=1&_page=1",
-            "next": "http://test/runs?_limit=1&_page=2"
+            "next": "http://test/runs?_limit=1&_page=2",
+            "last": None
         },
         "pages": {
             "self": 1,
             "first": 1,
             "prev": 1,
-            "next": 2
+            "next": 2,
+            "last": None
         },
         "query": {
             "_limit": "1",
@@ -84,13 +86,15 @@ def test_format_response_list_next_page_null():
             "self": "http://test/runs?_limit=10&_page=2",
             "first": "http://test/runs?_limit=10&_page=1",
             "prev": "http://test/runs?_limit=10&_page=1",
-            "next": None
+            "next": None,
+            "last": None
         },
         "pages": {
             "self": 2,
             "first": 1,
             "prev": 1,
-            "next": None
+            "next": None,
+            "last": None
         },
         "query": {
             "_limit": "10",

--- a/services/ui_backend_service/ui_server.py
+++ b/services/ui_backend_service/ui_server.py
@@ -78,7 +78,7 @@ def app(loop=None, db_conf: DBConfiguration = None):
     ConfigApi(app)
     PluginsApi(app)
 
-    LogApi(app, async_db)
+    LogApi(app, async_db, cache_store)
     AdminApi(app)
 
     setup_swagger(app,


### PR DESCRIPTION
- adds total page count to log api responses
- reverses the log lines default order to: from oldest to newest
- adds support for `?_order=-row` query param for reversing log order if necessary
- update tests
- adds cache layer to log fetching in order to reduce latency caused by unnecessarily refetching logs from S3 datastore
- change cache workers to skip re-writing key values to disk in case existing values are identical to new ones.
- remove aiobotocore dependency