### PR TITLE
fix: use configurable table name in all run queries

### DIFF
--- a/services/ui_backend_service/api/run.py
+++ b/services/ui_backend_service/api/run.py
@@ -112,8 +112,9 @@ class RunApi(object):
 
             # Allow optimized order only when sorting by real columns only
             if optimized_order and not unoptimized_order:
-                overwrite_select_from = "(SELECT * FROM runs_v3 {order_by}) AS runs_v3".format(
-                    order_by="ORDER BY {}".format(", ".join(optimized_order))
+                overwrite_select_from = "(SELECT * FROM {table_name} {order_by}) AS {table_name}".format(
+                    order_by="ORDER BY {}".format(", ".join(optimized_order)),
+                    table_name=self._async_table.table_name
                 )
 
                 return await find_records(request, self._async_table,


### PR DESCRIPTION
Run query building had a remaining static table name. changes this to use the configurable table name instead.