### PR TITLE
feat: add ack responses to websocket subscriptions

### DIFF
--- a/services/ui_backend_service/api/ws.py
+++ b/services/ui_backend_service/api/ws.py
@@ -144,6 +144,12 @@ class Websocket(object):
                 self.loop.create_task(
                     await self._event_subscription(subscription, event['operation'], event['resources'], event['data'])
                 )
+        # subscribed successfully, send ACK
+        payload = {
+            'type': 'ACK', 'uuid': uuid,
+            'resource': resource, 'data': None
+        }
+        await ws.send_str(json.dumps(payload))
 
     async def unsubscribe_from(self, ws, uuid: str = None):
         if uuid:

--- a/services/ui_backend_service/docs/websockets.md
+++ b/services/ui_backend_service/docs/websockets.md
@@ -54,7 +54,7 @@ Subscribable resource endpoints include. All subscriptions also adhere to the co
 ```
 
 ### Received messages
-The web socket client can receive three types of messages for its subscription:
+The web socket client can receive four types of messages for its subscription:
 
 ```json
   {
@@ -66,6 +66,8 @@ The web socket client can receive three types of messages for its subscription:
 ```
 The type can be one of `INSERT`, `UPDATE` or `DELETE`, corresponding to similar database actions.
 The `data` property contains the complete object of the subscribed resource, as it would be received from a basic GET request.
+
+The type can also be `ACK`, which conveys that the subscription was successfully accepted and is considered active. The client can be certain to receive events related to the resource only after receiving a corresponding ACK-response. For ACK-responses, the `data` will be null, but `uuid` and `resource` will be the ones originally used for the web socket subscription. 
 
 # SEARCH API
 


### PR DESCRIPTION
Adds `ACK` responses to web socket resource subscriptions. Used for timing the sending of GET requests only after a WS subscription is active on the UI, so no messages get lost in-between.

The feature is meant to deal with a rare edge-case when running flows with tasks that complete extremely fast. In rare cases the user can navigate to the timeline view, and between the `GET` request and web socket subscription happening, some `completed` status broadcasts can be missed. 
Proposed change is to be deliberate in the order of operations, where the `GET` follows only a successful subscription to a resource.

***Breaking Change***
current UI does not handle `ACK` types at all and will break with this, only merge at the same time the corresponding UI changes go in.