### PR TITLE
chore: Dockerfile download metaflow-ui release artifact v.1.0.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,11 @@ ARG BUILD_COMMIT_HASH
 ENV BUILD_TIMESTAMP=$BUILD_TIMESTAMP
 ENV BUILD_COMMIT_HASH=$BUILD_COMMIT_HASH
 
+ARG UI_ENABLED="1"
+ARG UI_VERSION="v1.0.0"
+ENV UI_ENABLED=$UI_ENABLED
+ENV UI_VERSION=$UI_VERSION
+
 RUN go get -u github.com/pressly/goose/cmd/goose
 
 RUN apt-get update && apt-get -y install python3.7 && apt-get -y install python3-pip && apt-get -y install libpq-dev
@@ -25,6 +30,9 @@ ADD services/utils /root/services/utils
 ADD setup.py setup.cfg /root/
 WORKDIR /root
 RUN /opt/latest/bin/pip install .
+
+# Install Netflix/metaflow-ui release artifact
+RUN /root/services/ui_backend_service/download_ui.sh
 
 # Migration Service
 ADD services/migration_service /root/services/migration_service

--- a/Dockerfile.ui_service
+++ b/Dockerfile.ui_service
@@ -1,8 +1,7 @@
 FROM python:3.7
 
-ARG UI_ENABLED="0"
-ARG UI_VERSION="v0.1.2"
-
+ARG UI_ENABLED="1"
+ARG UI_VERSION="v1.0.0"
 ENV UI_ENABLED=$UI_ENABLED
 ENV UI_VERSION=$UI_VERSION
 
@@ -19,12 +18,14 @@ ENV CUSTOM_QUICKLINKS=$CUSTOM_QUICKLINKS
 ADD services/__init__.py /root/services/__init__.py
 ADD services/data /root/services/data
 ADD services/utils /root/services/utils
+ADD services/metadata_service /root/services/metadata_service
 ADD services/ui_backend_service /root/services/ui_backend_service
 ADD setup.py setup.cfg /root/
 
 WORKDIR /root
 
-RUN services/ui_backend_service/download_ui.sh
+# Install Netflix/metaflow-ui release artifact
+RUN /root/services/ui_backend_service/download_ui.sh
 
 RUN pip install --editable .
 

--- a/docker-compose.development.yml
+++ b/docker-compose.development.yml
@@ -5,7 +5,7 @@ services:
       context: .
       dockerfile: Dockerfile.ui_service
       args:
-        UI_ENABLED: 0
+        UI_ENABLED: 1
     ports:
       - "${MF_UI_METADATA_PORT:-8083}:${MF_UI_METADATA_PORT:-8083}"
     volumes:

--- a/services/ui_backend_service/README.md
+++ b/services/ui_backend_service/README.md
@@ -54,16 +54,16 @@ If you require the UI for local development, refer to [metaflow-ui/docs/README.m
 
 Enable built-in UI bundle serving (assumes assets are located inside `ui/` folder):
 
-- `UI_ENABLED` [defaults to 0]
+- `UI_ENABLED` [defaults to `1`]
 
 Use path prefix in case UI service is served under non-root path (`example.com/api/`):
 
-- `PATH_PREFIX=/api` [defaults to None]
+- `PATH_PREFIX=/api` [defaults to `None`]
 
 This also works as a Docker build argument to download and install latest or specific UI release:
 
 > ```sh
-> $ docker build --arg UI_ENABLED=1 UI_VERSION=v0.1.2 ...
+> $ docker build --arg UI_ENABLED=1 UI_VERSION=v1.0.0 ...
 > ```
 
 Use following environment variables to inject content to Metaflow UI index.html:

--- a/services/ui_backend_service/download_ui.sh
+++ b/services/ui_backend_service/download_ui.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
 FILENAME="metaflow-ui.zip"
@@ -9,10 +11,10 @@ UI_RELEASE_URL="https://github.com/Netflix/metaflow-ui/releases/download/${UI_VE
 
 if [ $UI_ENABLED = "1" ]
 then
-    echo "Download UI from $UI_RELEASE_URL and installing to $DEST"
+    echo "Download UI version ${UI_VERSION} from $UI_RELEASE_URL to $DEST"
     curl $UI_RELEASE_URL -o $FILENAME
     unzip -o $FILENAME -d $DEST
     rm $FILENAME
 else
-    echo "No UI enabled, skip download."
+    echo "UI not enabled, skip download."
 fi

--- a/services/ui_backend_service/ui_server.py
+++ b/services/ui_backend_service/ui_server.py
@@ -85,7 +85,7 @@ def app(loop=None, db_conf: DBConfiguration = None):
                   description=swagger_description,
                   definitions=swagger_definitions)
 
-    if os.environ.get("UI_ENABLED", 0) == "1":
+    if os.environ.get("UI_ENABLED", "1") == "1":
         # Serve UI bundle only if enabled
         # This has to be placed last due to catch-all route
         Frontend(app)


### PR DESCRIPTION
Pin Netflix/metaflow-ui version for both `Dockerfile` & `Dockerfile.ui_service` and use `download_ui.sh` to download and extract the release artifact.

**NOTE**: Do not merge until Netflix/metaflow-ui `v1.0.0` is released and repository is made public.