### PR TITLE
fix: add configurable threshold for run status inference

### DIFF
--- a/services/ui_backend_service/data/db/tables/base.py
+++ b/services/ui_backend_service/data/db/tables/base.py
@@ -13,7 +13,12 @@ from services.data.postgres_async_db import \
 
 # Heartbeat check interval. Add margin in case of client-server communication delays, before marking a heartbeat stale.
 HEARTBEAT_THRESHOLD = int(os.environ.get("HEARTBEAT_THRESHOLD", WAIT_TIME * 6))
-OLD_RUN_FAILURE_CUTOFF_TIME = int(os.environ.get("OLD_RUN_FAILURE_CUTOFF_TIME", 60 * 60 * 24 * 1000 * 6))  # default 6 days (in milliseconds)
+# Time before a run without heartbeat will be marked as failed, if it is decisively not running, or completed.
+# Default 6 days (in milliseconds)
+OLD_RUN_FAILURE_CUTOFF_TIME = int(os.environ.get("OLD_RUN_FAILURE_CUTOFF_TIME", 60 * 60 * 24 * 1000 * 6))
+# Time before a run with a heartbeat will be considered inactive (and thus failed).
+# Default to 6 days (in seconds)
+RUN_INACTIVE_CUTOFF_TIME = int(os.environ.get("RUN_INACTIVE_CUTOFF_TIME", 60 * 60 * 24 * 6))
 
 
 class AsyncPostgresTable(MetadataAsyncPostgresTable):

--- a/services/ui_backend_service/docs/environment.md
+++ b/services/ui_backend_service/docs/environment.md
@@ -69,7 +69,9 @@ The threshold parameters for heartbeat checks can also be configured when necess
 
 `HEARTBEAT_THRESHOLD` [controls at what point a heartbeat is considered expired. Default is `WAIT_TIME * 6`]
 
-`OLD_RUN_FAILURE_CUTOFF_TIME` [ for runs that do not have a heartbeat, controls at what point a running status run should be considered failed. Default is 2 weeks]
+`OLD_RUN_FAILURE_CUTOFF_TIME` [ for runs that do not have a heartbeat, controls at what point a running status run should be considered failed. Default is 6 days (in milliseconds)]
+
+`RUN_INACTIVE_CUTOFF_TIME` [ for runs that have a heartbeat, controls how long a run with a failed heartbeat should wait for possibly queued tasks to start and resume heartbeat updates. Default is 6 days (in seconds)]
 
 ## Baseurl configuration
 


### PR DESCRIPTION
adds a configurable threshold `RUN_INACTIVE_CUTOFF_TIME` for how long a run should stay as 'running' when it has no failed tasks, yet its heartbeat has expired.  This is to cover the case where tasks have finished, but new ones have not yet started due to scheduler delays.

existing `OLD_RUN_FAILURE_CUTOFF_TIME` does not cover this case, as it is meant for runs that lack a heartbeat completely.