### PR TITLE
chore: remove foreach_stack join from task query

### DIFF
--- a/services/ui_backend_service/data/db/models/task_row.py
+++ b/services/ui_backend_service/data/db/models/task_row.py
@@ -13,7 +13,6 @@ class TaskRow(BaseRow):
     user_name: str = None
     status: str = None
     task_ok: str = None
-    foreach_stack: int = None
     ts_epoch: int = 0
     started_at: int = None
     finished_at: int = None
@@ -33,7 +32,6 @@ class TaskRow(BaseRow):
         task_name=None,
         status=None,
         task_ok=None,
-        foreach_stack=None,
         ts_epoch=None,
         started_at=None,
         finished_at=None,
@@ -57,7 +55,6 @@ class TaskRow(BaseRow):
 
         self.status = status
         self.task_ok = task_ok
-        self.foreach_stack = foreach_stack
         self.ts_epoch = ts_epoch
         self.started_at = started_at
         self.finished_at = finished_at
@@ -79,7 +76,6 @@ class TaskRow(BaseRow):
                 "user_name": self.user_name,
                 "status": self.status,
                 "task_ok": self.task_ok,
-                "foreach_stack": self.foreach_stack,
                 "ts_epoch": self.ts_epoch,
                 "started_at": self.started_at,
                 "finished_at": self.finished_at,
@@ -98,7 +94,6 @@ class TaskRow(BaseRow):
                 "user_name": self.user_name,
                 "status": self.status,
                 "task_ok": self.task_ok,
-                "foreach_stack": self.foreach_stack,
                 "ts_epoch": self.ts_epoch,
                 "started_at": self.started_at,
                 "finished_at": self.finished_at,


### PR DESCRIPTION
Remove foreach_stack join from task query as unnecessary after the introduction of metaflow client into the cache actions.