### PR TITLE
Metaflow client: prefer run_id over run_number and task_name over task_id

### DIFF
--- a/services/ui_backend_service/api/artifactsearch.py
+++ b/services/ui_backend_service/api/artifactsearch.py
@@ -42,7 +42,14 @@ class ArtifactSearchApi(object):
             else:
                 operator, value = _parse_search_term(value)
                 # Search through the artifact contents using the CacheClient
-                pathspecs = ["{flow_id}/{run_number}/{step_name}/{task_id}/{name}/{attempt_id}".format(**art) for art in meta_artifacts]
+                # Prefer run_id over run_number and task_name over task_id
+                pathspecs = ["{flow_id}/{run_id}/{step_name}/{task_name}/{name}/{attempt_id}".format(
+                    flow_id=art['flow_id'],
+                    run_id=art.get('run_id') or art['run_number'],
+                    step_name=art['step_name'],
+                    task_name=art.get('task_name') or art['task_id'],
+                    name=art['name'],
+                    attempt_id=art['attempt_id']) for art in meta_artifacts]
                 res = await self._artifact_store.cache.SearchArtifacts(
                     pathspecs, value, operator,
                     invalidate_cache=invalidate_cache)
@@ -125,7 +132,14 @@ async def _search_dict_filter(artifacts, artifact_match_dict={}):
 
     results = []
     for artifact in artifacts:
-        pathspec = "{flow_id}/{run_number}/{step_name}/{task_id}/{name}/{attempt_id}".format(**artifact)
+        # Prefer run_id over run_number and task_name over task_id
+        pathspec = "{flow_id}/{run_id}/{step_name}/{task_name}/{name}/{attempt_id}".format(
+            flow_id=artifact['flow_id'],
+            run_id=artifact.get('run_id') or artifact['run_number'],
+            step_name=artifact['step_name'],
+            task_name=artifact.get('task_name') or artifact['task_id'],
+            name=artifact['name'],
+            attempt_id=artifact['attempt_id'])
         if pathspec in artifact_match_dict:
             match_data = artifact_match_dict[pathspec]
             if match_data['matches'] or not match_data['included']:

--- a/services/ui_backend_service/api/dag.py
+++ b/services/ui_backend_service/api/dag.py
@@ -65,11 +65,13 @@ class DagApi(object):
             status, body = format_response(request, db_response)
             return web_response(status, body)
 
+        # Prefer run_id over run_number
         flow_name = db_response.body['flow_id']
+        run_id = db_response.body.get('run_id') or db_response.body['run_number']
         invalidate_cache = query_param_enabled(request, "invalidate")
 
         dag = await self._dag_store.cache.GenerateDag(
-            flow_name, run_id_value, invalidate_cache=invalidate_cache)
+            flow_name, run_id, invalidate_cache=invalidate_cache)
 
         if dag.has_pending_request():
             async for event in dag.stream():

--- a/services/ui_backend_service/data/cache/get_log_file_action.py
+++ b/services/ui_backend_service/data/cache/get_log_file_action.py
@@ -241,9 +241,11 @@ def lookup_id(task: Dict, logtype: str, limit: int = 0, page: int = 1, reverse_o
 
 def pathspec_for_task(task: Dict):
     "pathspec for a task"
-    return "{flow_id}/{run_number}/{step_name}/{task_id}".format(
-        flow_id=task["flow_id"],
-        run_number=task["run_number"],
-        step_name=task["step_name"],
-        task_id=task["task_id"]
+    # Prefer run_id over run_number
+    # Prefer task_name over task_id
+    return "{flow_id}/{run_id}/{step_name}/{task_name}".format(
+        flow_id=task['flow_id'],
+        run_id=task.get('run_id') or task['run_number'],
+        step_name=task['step_name'],
+        task_name=task.get('task_name') or task['task_id']
     )

--- a/services/ui_backend_service/data/refiner/artifact_refiner.py
+++ b/services/ui_backend_service/data/refiner/artifact_refiner.py
@@ -20,7 +20,15 @@ class ArtifactRefiner(Refinery):
         return self.cache_store.cache.GetArtifacts
 
     def _record_to_action_input(self, record):
-        return "{flow_id}/{run_number}/{step_name}/{task_id}/{name}/{attempt_id}".format(**record)
+        # Prefer run_id over run_number
+        # Prefer task_name over task_id
+        return "{flow_id}/{run_id}/{step_name}/{task_name}/{name}/{attempt_id}".format(
+            flow_id=record['flow_id'],
+            run_id=record.get('run_id') or record['run_number'],
+            step_name=record['step_name'],
+            task_name=record.get('task_name') or record['task_id'],
+            name=record['name'],
+            attempt_id=record['attempt_id'])
 
     async def refine_record(self, record, values):
         record['content'] = str(values)

--- a/services/ui_backend_service/data/refiner/parameter_refiner.py
+++ b/services/ui_backend_service/data/refiner/parameter_refiner.py
@@ -10,7 +10,7 @@ class ParameterRefiner(Refinery):
     Parameters
     -----------
     cache : AsyncCacheClient
-        An instance of a cache that implements the GetArtifacts action.
+        An instance of a cache that implements the GetParameters action.
     """
 
     def __init__(self, cache):
@@ -30,7 +30,10 @@ class ParameterRefiner(Refinery):
         return _res.get() or {}  # cache get() might return None if no keys are produced.
 
     def _record_to_action_input(self, record):
-        return "{flow_id}/{run_number}".format(**record)
+        # Prefer run_id over run_number
+        return "{flow_id}/{run_id}".format(
+            flow_id=record['flow_id'],
+            run_id=record.get('run_id') or record['run_number'])
 
     async def refine_record(self, record, values):
         return {k: {'value': v} for k, v in values.items()}

--- a/services/ui_backend_service/data/refiner/task_refiner.py
+++ b/services/ui_backend_service/data/refiner/task_refiner.py
@@ -10,7 +10,7 @@ class TaskRefiner(Refinery):
     Parameters
     -----------
     cache : AsyncCacheClient
-        An instance of a cache that implements the GetArtifacts action.
+        An instance of a cache that implements the GetTask action.
     """
 
     def __init__(self, cache):
@@ -20,7 +20,14 @@ class TaskRefiner(Refinery):
         return self.cache_store.cache.GetTask
 
     def _record_to_action_input(self, record):
-        return "{flow_id}/{run_number}/{step_name}/{task_id}/{attempt_id}".format(**record)
+        # Prefer run_id over run_number
+        # Prefer task_name over task_id
+        return "{flow_id}/{run_id}/{step_name}/{task_name}/{attempt_id}".format(
+            flow_id=record['flow_id'],
+            run_id=record.get('run_id') or record['run_number'],
+            step_name=record['step_name'],
+            task_name=record.get('task_name') or record['task_id'],
+            attempt_id=record['attempt_id'])
 
     async def refine_record(self, record, values):
         if record['status'] == 'unknown' and values.get('_task_ok') is not None:


### PR DESCRIPTION
Metaflow client inside cache actions will now prefer `run_id` (str) over `run_number` (int) and `task_name` (str) over `task_id` (int). This is for reducing the implementation bleed of the UI service inside the client.