### PR TITLE
chore: use test db_conf guard for ui service integration tests as well

### DIFF
--- a/services/metadata_service/tests/integration_tests/utils.py
+++ b/services/metadata_service/tests/integration_tests/utils.py
@@ -5,7 +5,7 @@ import psycopg2
 import pytest
 from aiohttp import web
 from services.data.postgres_async_db import AsyncPostgresDB
-from services.utils import DBConfiguration
+from services.utils.tests import get_test_dbconf
 from services.metadata_service.api.admin import AuthApi
 from services.metadata_service.api.flow import FlowApi
 from services.metadata_service.api.run import RunApi
@@ -20,18 +20,6 @@ from services.migration_service.data.postgres_async_db import \
     AsyncPostgresDB as MigrationAsyncPostgresDB
 
 # Test fixture helpers begin
-
-
-def get_test_dbconf():
-    "Returns a DBConfiguration suitable for the test environment, or exits pytest completely upon failure"
-    db_conf = DBConfiguration()
-
-    if db_conf.dsn != "dbname=test user=test host=db_test port=5432 password=test":
-        pytest.exit("The test suite should only be run in a test environment. \n \
-            Configured database host is not suited for running tests. \n \
-            expected DSN to be: dbname=test user=test host=db_test port=5432 password=test")
-
-    return db_conf
 
 
 def init_app(loop, aiohttp_client, queue_ttl=30):

--- a/services/ui_backend_service/tests/integration_tests/utils.py
+++ b/services/ui_backend_service/tests/integration_tests/utils.py
@@ -9,7 +9,7 @@ import contextlib
 
 from services.ui_backend_service.data.db import AsyncPostgresDB
 from services.ui_backend_service.data.cache.store import CacheStore
-from services.utils import DBConfiguration
+from services.utils.tests import get_test_dbconf
 
 from services.ui_backend_service.api import (
     FlowApi, RunApi, StepApi, TaskApi,
@@ -43,7 +43,7 @@ def init_app(loop, aiohttp_client, queue_ttl=30):
 
     # init a db adapter explicitly to be used for the api requests.
     # Skip all creation processes, these are handled with migration service and init_db
-    db_conf = DBConfiguration(timeout=1)
+    db_conf = get_test_dbconf()
     db = AsyncPostgresDB(name='api')
     loop.run_until_complete(db._init(db_conf=db_conf, create_tables=False, create_triggers=False))
 
@@ -69,7 +69,7 @@ def init_app(loop, aiohttp_client, queue_ttl=30):
 
 
 async def init_db(cli):
-    db_conf = DBConfiguration(timeout=1)
+    db_conf = get_test_dbconf()
 
     # Make sure migration scripts are applied
     migration_db = MigrationAsyncPostgresDB.get_instance()

--- a/services/utils/tests/__init__.py
+++ b/services/utils/tests/__init__.py
@@ -1,0 +1,16 @@
+from services.utils import DBConfiguration
+import pytest
+
+
+def get_test_dbconf():
+    """
+    Returns a DBConfiguration suitable for the test environment, or exits pytest completely upon failure
+    """
+    db_conf = DBConfiguration(timeout=1)
+
+    if db_conf.dsn != "dbname=test user=test host=db_test port=5432 password=test":
+        pytest.exit("The test suite should only be run in a test environment. \n \
+            Configured database host is not suited for running tests. \n \
+            expected DSN to be: dbname=test user=test host=db_test port=5432 password=test")
+
+    return db_conf


### PR DESCRIPTION
move test_dbconf guard to be a shared test helper, use it in both metadata and ui_backend service integration tests.