### PR TITLE
UI service metadata allow GET requests only

### DIFF
--- a/services/metadata_service/server.py
+++ b/services/metadata_service/server.py
@@ -17,10 +17,10 @@ from services.data.postgres_async_db import AsyncPostgresDB
 from services.utils import DBConfiguration
 
 
-def app(loop=None, db_conf: DBConfiguration = None):
+def app(loop=None, db_conf: DBConfiguration = None, middlewares=None):
 
     loop = loop or asyncio.get_event_loop()
-    app = web.Application(loop=loop)
+    app = web.Application(loop=loop, middlewares=middlewares)
     async_db = AsyncPostgresDB()
     loop.run_until_complete(async_db._init(db_conf))
     FlowApi(app)

--- a/services/ui_backend_service/api/utils.py
+++ b/services/ui_backend_service/api/utils.py
@@ -475,3 +475,13 @@ class TTLQueue:
 
     async def values_since(self, since_epoch: int):
         return [value for value in await self.values() if value[0] >= since_epoch]
+
+
+@web.middleware
+async def allow_get_requests_only(request, handler):
+    """
+    Only allow GET request, otherwise raise 405 Method Not Allowed.
+    """
+    if request.method != 'GET':
+        raise web.HTTPMethodNotAllowed(method=request.method, allowed_methods=['GET'])
+    return await handler(request)

--- a/services/ui_backend_service/ui_server.py
+++ b/services/ui_backend_service/ui_server.py
@@ -15,7 +15,7 @@ from .api import (AdminApi, ArtifactSearchApi, ArtificatsApi, AutoCompleteApi, C
                   DagApi, FeaturesApi, FlowApi, ListenNotify, LogApi,
                   MetadataApi, RunApi, RunHeartbeatMonitor, StepApi, TagApi,
                   TaskApi, TaskHeartbeatMonitor, Websocket, PluginsApi)
-
+from .api.utils import allow_get_requests_only
 from .data.cache import CacheStore
 from .data.db import AsyncPostgresDB
 from .doc import swagger_definitions, swagger_description
@@ -98,7 +98,11 @@ def app(loop=None, db_conf: DBConfiguration = None):
 
     # Add Metadata Service as a sub application so that Metaflow Client
     # can use it as a service backend in case none provided via METAFLOW_SERVICE_URL
-    app.add_subapp("/metadata", metadata_service_app(loop=loop, db_conf=db_conf))
+    #
+    # Metadata service exposed through UI service is intended for read-only use only.
+    # 'allow_get_requests_only' middleware will only accept GET requests.
+    app.add_subapp("/metadata", metadata_service_app(
+        loop=loop, db_conf=db_conf, middlewares=[allow_get_requests_only]))
 
     setup_swagger(app,
                   description=swagger_description,


### PR DESCRIPTION
UI service exposes `/metadata` route as `aiohttp` subapp, which is used by Metaflow Client.

Since this is intended for read-only operations we should only allow `GET` requests.