### PR TITLE
Feat/expose timestamps for loglines

### DIFF
--- a/services/ui_backend_service/data/cache/get_log_file_action.py
+++ b/services/ui_backend_service/data/cache/get_log_file_action.py
@@ -187,7 +187,7 @@ def get_log_content(task: Task, logtype: str):
         ]
     else:
         return [
-            (int(datetime.timestamp()), line)
+            (int(datetime.timestamp() * 1000), line)
             for datetime, line in task.loglines(stream)
         ]
 

--- a/services/ui_backend_service/data/cache/get_log_file_action.py
+++ b/services/ui_backend_service/data/cache/get_log_file_action.py
@@ -178,6 +178,10 @@ def get_log_size(task: Task, logtype: str):
 
 @wrap_metaflow_s3_errors
 def get_log_content(task: Task, logtype: str):
+    # NOTE: this re-implements some of the client logic from _load_log(self, stream)
+    # for backwards compatibility of different log types.
+    # Necessary due to the client not exposing a stdout/stderr property that would
+    # contain the optional timestamps.
     stream = 'stderr' if logtype == STDERR else 'stdout'
     log_location = task.metadata_dict.get('log_location_%s' % stream)
     if log_location:

--- a/services/ui_backend_service/doc.py
+++ b/services/ui_backend_service/doc.py
@@ -661,6 +661,7 @@ swagger_definitions = {
         "type": "object",
         "properties": {
             **modelprop("row", "int", "Row number", 0),
+            **modelprop("timestamp", "int", "Epoch timestamp of the log line entry", 1591788834035),
             **modelprop("line", "string", "Log line content", "logged text")
         },
         "required": ["row", "line"]

--- a/services/ui_backend_service/tests/unit_tests/get_log_file_action_test.py
+++ b/services/ui_backend_service/tests/unit_tests/get_log_file_action_test.py
@@ -4,7 +4,8 @@ from services.ui_backend_service.data.cache.get_log_file_action import paginated
 
 pytestmark = [pytest.mark.unit_tests]
 
-TEST_LOG = "\n".join(list("log line {}".format(i) for i in range(1, 1001)))
+TEST_LOG = list((None, "log line {}".format(i)) for i in range(1, 1001))
+TEST_MFLOG = list((i, "log line {}".format(i)) for i in range(1, 1001))
 
 
 async def test_paginated_result():
@@ -14,7 +15,7 @@ async def test_paginated_result():
     assert len(body['content']) == 1000
     assert body["pages"] == 1
     # order should be oldest to newest
-    assert body['content'][0] == {"row": 0, "line": "log line 1"}
+    assert body['content'][0] == {"row": 0, "line": "log line 1", "timestamp": None}
 
 
 async def test_paginated_result_oob_page():
@@ -56,14 +57,14 @@ async def test_paginated_result_ordering():
         limit=0, reverse_order=False,
         output_raw=False
     )
-    assert [obj["line"] for obj in body["content"]] == TEST_LOG.split("\n")
+    assert [obj["line"] for obj in body["content"]] == [line for _, line in TEST_LOG]
 
     body = paginated_result(
         content=TEST_LOG, page=1,
         limit=0, reverse_order=True,
         output_raw=False
     )
-    assert [obj["line"] for obj in body["content"]] == TEST_LOG.split("\n")[::-1]
+    assert [obj["line"] for obj in body["content"]] == [line for _, line in TEST_LOG[::-1]]
 
 
 async def test_paginated_result_raw_output():
@@ -74,7 +75,7 @@ async def test_paginated_result_raw_output():
     )
     assert body["pages"] == 1
     # should return full log despite pagination limit when requesting raw.
-    assert body["content"] == TEST_LOG
+    assert body["content"] == "\n".join(line for _, line in TEST_LOG)
 
 
 async def test_log_cache_id_uniqueness():


### PR DESCRIPTION
Returns timestamps for log lines as part of the API response when they are available. Frontend can choose to display, or ignore them.

Slight concern that different logstyle access' implementation details are leaking from the metaflow cli into the cache action, but this has to be done in order to access (timestamp, logline) tuple stream from MFLOGs, and at the same time support old style logs as well.