### PR TITLE
Metaflow UI production stack deployment links.

### DIFF
--- a/services/ui_backend_service/README.md
+++ b/services/ui_backend_service/README.md
@@ -7,6 +7,10 @@ For more information, see [Metaflow's website](http://docs.metaflow.org)
 
 Refer to the project root for running the project [README.md](../../README.md)
 
+### Metaflow UI deployment
+
+For a complete Metaflow UI production stack deployment (frontend + service + database) please refer to [Cloudformation templates](https://github.com/Netflix/metaflow-tools/tree/master/aws/cloudformation) and [Admin docs](https://admin-docs.metaflow.org/). This is the preferred way to deploy Metaflow UI.
+
 ### Running UI Service using the official Docker image
 
 UI service provides backend instance that serves static frontend assets from [Netflix/metaflow-ui](https://github.com/Netflix/metaflow-ui) repository.


### PR DESCRIPTION
Added missing links for Cloudformation templates and upcoming Admin docs regarding complete Metaflow UI production stack deployment.