### PR TITLE
fix: pin test Dockerfile golang dependency

### DIFF
--- a/Dockerfile.service.test
+++ b/Dockerfile.service.test
@@ -1,4 +1,4 @@
-FROM golang:latest AS goose
+FROM golang:1.16.3 AS goose
 RUN go get -u github.com/pressly/goose/cmd/goose
 
 FROM python:3.7


### PR DESCRIPTION
golang:latest has issues with the goose installation for whatever reason. Pinning the version fixes this and the docker image build successfully.

Change is more in line with the other Dockerfiles also having the version pinned.