### PR TITLE
chore: unpin metaflow version from ui_backend_service

### DIFF
--- a/services/data/postgres_async_db.py
+++ b/services/data/postgres_async_db.py
@@ -910,7 +910,7 @@ class AsyncArtifactTablePostgres(AsyncPostgresTable):
         # artifacts. That is, if artifact "foo" was set in attempt N, that
         # doesn't mean it was set in attempt N+1, and vice versa.
         #
-        # To get the artifact value for the "latest" attempt, we first find 
+        # To get the artifact value for the "latest" attempt, we first find
         # the latest attempt_id by querying the artifacts table for the
         # artifact that always exists for every attempt (the artifact called
         # 'name', containing the flow name), then use that attempt_id to get

--- a/services/ui_backend_service/requirements.txt
+++ b/services/ui_backend_service/requirements.txt
@@ -4,5 +4,5 @@ pyee==8.0.1
 throttler==1.2.0
 psycopg2
 aiopg
-metaflow==2.4.2
+metaflow
 pygit2==1.6.1

--- a/services/ui_backend_service/requirements.txt
+++ b/services/ui_backend_service/requirements.txt
@@ -4,5 +4,5 @@ pyee==8.0.1
 throttler==1.2.0
 psycopg2
 aiopg
-metaflow
+metaflow>=2.4.2
 pygit2==1.6.1


### PR DESCRIPTION
Unpin metaflow client version from ui_service requirements, as the service should always work with latest client version.

Keep a lower bound to guard against installing unsupported versions though.