### PR TITLE
fix: websocket disconnect and broadcast issues

### DIFF
--- a/services/data/postgres_async_db.py
+++ b/services/data/postgres_async_db.py
@@ -910,7 +910,7 @@ class AsyncArtifactTablePostgres(AsyncPostgresTable):
         # artifacts. That is, if artifact "foo" was set in attempt N, that
         # doesn't mean it was set in attempt N+1, and vice versa.
         #
-        # To get the artifact value for the "latest" attempt, we first find 
+        # To get the artifact value for the "latest" attempt, we first find
         # the latest attempt_id by querying the artifacts table for the
         # artifact that always exists for every attempt (the artifact called
         # 'name', containing the flow name), then use that attempt_id to get

--- a/services/ui_backend_service/api/ws.py
+++ b/services/ui_backend_service/api/ws.py
@@ -147,7 +147,7 @@ class Websocket(object):
             event_queue = await self.queue.values_since(since)
             for _, event in event_queue:
                 self.loop.create_task(
-                    await self._event_subscription(subscription, event['operation'], event['resources'], event['data'])
+                    self._event_subscription(subscription, event['operation'], event['resources'], event['data'])
                 )
 
     async def unsubscribe_from(self, ws, uuid: str = None):

--- a/services/ui_backend_service/api/ws.py
+++ b/services/ui_backend_service/api/ws.py
@@ -106,10 +106,16 @@ class Websocket(object):
                 'data': _data
             })
             for subscription in self.subscriptions:
-                if not subscription.disconnected_ts:
-                    await self._event_subscription(subscription, operation, resources, _data)
-                elif subscription.disconnected_ts and time.time() - subscription.disconnected_ts > WS_QUEUE_TTL_SECONDS:
+                try:
+                    if subscription.disconnected_ts and time.time() - subscription.disconnected_ts > WS_QUEUE_TTL_SECONDS:
+                        await self.unsubscribe_from(subscription.ws, subscription.uuid)
+                    else:
+                        await self._event_subscription(subscription, operation, resources, _data)
+                except ConnectionResetError:
+                    self.logger.info("Trying to broadcast to a stale subscription. Unsubscribing")
                     await self.unsubscribe_from(subscription.ws, subscription.uuid)
+                except Exception:
+                    self.logger.exception("Broadcasting to subscription failed")
 
     async def _event_subscription(self, subscription: WSSubscription, operation: str, resources: List[str], data: Dict):
         for resource in resources:
@@ -128,7 +134,6 @@ class Websocket(object):
     async def subscribe_to(self, ws, uuid: str, resource: str, since: int):
         # Always unsubscribe existing duplicate identifiers
         await self.unsubscribe_from(ws, uuid)
-
         # Create new subscription
         _resource, query, filter_fn = resource_conditions(resource)
         subscription = WSSubscription(

--- a/services/ui_backend_service/api/ws.py
+++ b/services/ui_backend_service/api/ws.py
@@ -112,7 +112,7 @@ class Websocket(object):
                     else:
                         await self._event_subscription(subscription, operation, resources, _data)
                 except ConnectionResetError:
-                    self.logger.info("Trying to broadcast to a stale subscription. Unsubscribing")
+                    self.logger.debug("Trying to broadcast to a stale subscription. Unsubscribing")
                     await self.unsubscribe_from(subscription.ws, subscription.uuid)
                 except Exception:
                     self.logger.exception("Broadcasting to subscription failed")


### PR DESCRIPTION
fixes issues related to web socket holding on to stale connections in subscriptions, and the resource broadcast method not having any handling for possible exceptions thrown by trying to write to a closing transport.

exhibited as an issue where UI was not receiving realtime updates, but only in cases where there was a *preceding* 'closing' subscription when broadcasting resource updates.

also fixes an issue with passing 'since' to websocket subscription not being handled correctly. create_task was incorrectly being passed an awaited coroutine