### PR TITLE
fix: handle missing mflog timestamps

### DIFF
--- a/services/ui_backend_service/data/cache/get_log_file_action.py
+++ b/services/ui_backend_service/data/cache/get_log_file_action.py
@@ -191,7 +191,7 @@ def get_log_content(task: Task, logtype: str):
         ]
     else:
         return [
-            (int(datetime.timestamp() * 1000), line)
+            (_datetime_to_epoch(datetime), line)
             for datetime, line in task.loglines(stream)
         ]
 
@@ -267,3 +267,12 @@ def pathspec_for_task(task: Dict):
         step_name=task['step_name'],
         task_name=task.get('task_name') or task['task_id']
     )
+
+
+def _datetime_to_epoch(datetime) -> Optional[int]:
+    """convert datetime safely into an epoch in milliseconds"""
+    try:
+        return int(datetime.timestamp() * 1000)
+    except Exception:
+        # consider timestamp to be none if handling failed
+        return None

--- a/services/ui_backend_service/tests/unit_tests/get_log_file_action_test.py
+++ b/services/ui_backend_service/tests/unit_tests/get_log_file_action_test.py
@@ -1,6 +1,7 @@
 import pytest
+import datetime
 
-from services.ui_backend_service.data.cache.get_log_file_action import paginated_result, log_cache_id, lookup_id
+from services.ui_backend_service.data.cache.get_log_file_action import paginated_result, log_cache_id, lookup_id, _datetime_to_epoch
 
 pytestmark = [pytest.mark.unit_tests]
 
@@ -161,3 +162,12 @@ async def test_lookup_id_uniqueness():
 
     assert lookup_id(first_task, "stdout", 1, 1, False, False) != \
         lookup_id(first_task, "stdout", 1, 1, False, True)
+
+datetime_expectations = [
+    (None, None),
+    ("123", None),
+    (datetime.datetime(2021,10,27, 0, 0, tzinfo=datetime.timezone.utc), 1635292800000)
+]
+@pytest.mark.parametrize("datetime, output", datetime_expectations)
+async def test_datetime_to_epoch(datetime, output):
+    assert _datetime_to_epoch(datetime) == output


### PR DESCRIPTION
MFLOG type logs can have missing timestamps, where the tuple from the metaflow client does not always return a datetime object as part of the logline. Fix log cache action to handle this safely