### PR TITLE
chore: add cache helpers and refactor value storage

### DIFF
--- a/services/ui_backend_service/data/__init__.py
+++ b/services/ui_backend_service/data/__init__.py
@@ -1,0 +1,27 @@
+from typing import Tuple, Optional
+
+
+# Shared helpers
+
+
+def unpack_processed_value(value) -> Tuple[bool, Optional[str], Optional[str], Optional[str]]:
+    '''
+    Unpack cached value returning tuple of: success, value, detail, stacktrace
+
+    Defaults to None in case values are not defined.
+
+    Success example:
+        True, 'foo', None
+
+    Failure examples:
+        False, 'failure-id', 'error-details', None
+        False, 'failure-id-without-details', None, None
+        False, None, None, None
+        False, 'CustomError', 'Custom failure description', 'stacktrace of error'
+
+    Returns
+    -------
+    tuple : (bool, optional(str), optional(str), optional(str))
+        success, value, description, stacktrace
+    '''
+    return (list(value) + [None] * 4)[:4]

--- a/services/ui_backend_service/data/cache/get_artifacts_action.py
+++ b/services/ui_backend_service/data/cache/get_artifacts_action.py
@@ -1,7 +1,7 @@
 from typing import List, Callable
 
 from .get_data_action import GetData
-from .utils import unpack_pathspec_with_attempt_id, MAX_S3_SIZE
+from .utils import unpack_pathspec_with_attempt_id, cacheable_artifact_value
 
 from metaflow import DataArtifact
 
@@ -47,7 +47,4 @@ class GetArtifacts(GetData):
         pathspec_without_attempt, attempt_id = unpack_pathspec_with_attempt_id(pathspec)
 
         artifact = DataArtifact(pathspec_without_attempt, attempt=attempt_id)
-        if artifact.size < MAX_S3_SIZE:
-            return [True, DataArtifact(pathspec_without_attempt, attempt=attempt_id).data]
-        else:
-            return [False, 'artifact-too-large', "{}: {} bytes".format(artifact.pathspec, artifact.size)]
+        return cacheable_artifact_value(artifact)

--- a/services/ui_backend_service/data/cache/get_artifacts_action.py
+++ b/services/ui_backend_service/data/cache/get_artifacts_action.py
@@ -1,7 +1,7 @@
 from typing import List, Callable
 
 from .get_data_action import GetData
-from .utils import unpack_pathspec_with_attempt_id, cacheable_artifact_value
+from .utils import unpack_pathspec_with_attempt_id, artifact_value
 
 from metaflow import DataArtifact
 
@@ -47,4 +47,4 @@ class GetArtifacts(GetData):
         pathspec_without_attempt, attempt_id = unpack_pathspec_with_attempt_id(pathspec)
 
         artifact = DataArtifact(pathspec_without_attempt, attempt=attempt_id)
-        return cacheable_artifact_value(artifact)
+        return artifact_value(artifact)

--- a/services/ui_backend_service/data/cache/get_data_action.py
+++ b/services/ui_backend_service/data/cache/get_data_action.py
@@ -2,7 +2,7 @@ import json
 import hashlib
 
 from .client import CacheAction
-from services.utils import get_traceback_str
+from .utils import cacheable_exception_value
 
 from metaflow import namespace
 
@@ -119,7 +119,7 @@ class GetData(CacheAction):
                     continue
                 results[target_key] = json.dumps(result)
             except Exception as ex:
-                results[target_key] = json.dumps([False, ex.__class__.__name__, str(ex), get_traceback_str()])
+                results[target_key] = cacheable_exception_value(ex)
 
         return results
 

--- a/services/ui_backend_service/data/cache/search_artifacts_action.py
+++ b/services/ui_backend_service/data/cache/search_artifacts_action.py
@@ -6,7 +6,7 @@ from .utils import (cacheable_artifact_value, cacheable_exception_value,
                     progress_event_msg,
                     artifact_cache_id, unpack_pathspec_with_attempt_id,
                     streamed_errors)
-from ..refiner.refinery import unpack_processed_value, format_error_body
+from services.ui_backend_service.data import unpack_processed_value
 from services.ui_backend_service.api.utils import operators_to_filters
 
 
@@ -148,11 +148,11 @@ class SearchArtifacts(CacheAction):
             search_results[format_loc(key)] = {
                 "included": load_success,
                 "matches": matches,
-                "error": None if load_success else format_error_body(
-                    id=value or "artifact-handle-failed",
-                    detail=detail or "Unknown error during artifact processing",
-                    traceback=trace
-                )
+                "error": None if load_success else {
+                    "id": value or "artifact-handle-failed",
+                    "detail": detail or "Unknown error during artifact processing",
+                    "traceback": trace
+                }
             }
 
         results[result_key] = json.dumps(search_results)

--- a/services/ui_backend_service/data/cache/search_artifacts_action.py
+++ b/services/ui_backend_service/data/cache/search_artifacts_action.py
@@ -2,10 +2,10 @@ import hashlib
 import json
 
 from .client import CacheAction
-from services.utils import get_traceback_str
-from .utils import (error_event_msg, progress_event_msg,
+from .utils import (cacheable_artifact_value, cacheable_exception_value,
+                    progress_event_msg,
                     artifact_cache_id, unpack_pathspec_with_attempt_id,
-                    streamed_errors, MAX_S3_SIZE)
+                    streamed_errors)
 from ..refiner.refinery import unpack_processed_value, format_error_body
 from services.ui_backend_service.api.utils import operators_to_filters
 
@@ -122,13 +122,9 @@ class SearchArtifacts(CacheAction):
                     pathspec_without_attempt, attempt_id = unpack_pathspec_with_attempt_id(pathspec)
                     artifact_key = "search:artifactdata:{}".format(pathspec)
                     artifact = DataArtifact(pathspec_without_attempt, attempt=attempt_id)
-                    if artifact.size < MAX_S3_SIZE:
-                        results[artifact_key] = json.dumps([True, artifact.data])
-                    else:
-                        results[artifact_key] = json.dumps(
-                            [False, 'artifact-too-large', "{}: {} bytes".format(artifact.pathspec, artifact.size)])
+                    results[artifact_key] = cacheable_artifact_value(artifact)
                 except Exception as ex:
-                    results[artifact_key] = json.dumps([False, ex.__class__.__name__, str(ex), get_traceback_str()])
+                    results[artifact_key] = cacheable_exception_value(ex)
                     raise ex from None  # re-raise errors in order to stream it in context
 
         # Perform search on loaded artifacts.

--- a/services/ui_backend_service/data/cache/utils.py
+++ b/services/ui_backend_service/data/cache/utils.py
@@ -4,7 +4,7 @@ import json
 from gzip import GzipFile
 from itertools import islice
 from contextlib import contextmanager
-from typing import Callable
+from typing import Callable, Tuple
 
 from services.utils import get_traceback_str
 from metaflow import DataArtifact
@@ -56,11 +56,28 @@ def artifact_location_from_key(x):
     "extract location from the artifact cache key"
     return x[len("search:artifactdata:"):]
 
+
+def artifact_value(artifact: DataArtifact) -> Tuple[bool, object]:
+    """
+    Fetch the artifact value, return success along with value.
+    Success will be false only in case the artifact size exceeds MAX_S3_SIZE.
+
+    Returns
+    -------
+    tuple : (bool, object)
+        (success, artifact.data)
+    """
+    if artifact.size < MAX_S3_SIZE:
+        return (True, artifact.data)
+    else:
+        return (False, 'artifact-too-large', "{}: {} bytes".format(artifact.pathspec, artifact.size))
+
+
 def cacheable_artifact_value(artifact: DataArtifact) -> str:
     """
     Access a DataArtifacts .data property, returning it along a success state as a stringified json.
     A failure will be returned if the artifact size is greater than the allowed MAX_S3_SIZE.
-    
+
     Returns
     -------
     str
@@ -69,12 +86,8 @@ def cacheable_artifact_value(artifact: DataArtifact) -> str:
         failure:
         '[false, "artifact-too-large", "flow/run/step/task/artifact: 1234 bytes"]'
     """
-    if artifact.size < MAX_S3_SIZE:
-        return json.dumps([True, artifact.data])
-    else:
-        return json.dumps(
-            [False, 'artifact-too-large', "{}: {} bytes".format(artifact.pathspec, artifact.size)]
-        )
+    return json.dumps(artifact_value(artifact))
+
 
 def cacheable_exception_value(ex: Exception) -> str:
     """
@@ -91,6 +104,7 @@ def cacheable_exception_value(ex: Exception) -> str:
     return json.dumps([False, ex.__class__.__name__, str(ex), get_traceback_str()])
 
 # Cache action stream output helpers
+
 
 @contextmanager
 def streamed_errors(stream_output: Callable[[object], None], re_raise=True):

--- a/services/ui_backend_service/data/refiner/refinery.py
+++ b/services/ui_backend_service/data/refiner/refinery.py
@@ -1,6 +1,6 @@
-from typing import Any, Tuple, Optional
 from services.data.db_utils import DBResponse
 from services.ui_backend_service.features import FEATURE_REFINE_DISABLE
+from services.ui_backend_service.data import unpack_processed_value
 from services.utils import logging
 
 
@@ -113,29 +113,6 @@ class Refinery(object):
             body = await _process(response.body)
 
         return DBResponse(response_code=response.response_code, body=body)
-
-
-def unpack_processed_value(value) -> Tuple[bool, Optional[str], Optional[str], Optional[str]]:
-    '''
-    Unpack refined response returning tuple of: success, value, detail
-
-    Defaults to None in case values are not defined.
-
-    Success example:
-        True, 'foo', None
-
-    Failure examples:
-        False, 'failure-id', 'error-details', None
-        False, 'failure-id-without-details', None, None
-        False, None, None, None
-        False, 'CustomError', 'Custom failure description', 'stacktrace of error'
-
-    Returns
-    -------
-    tuple : (bool, optional(str), optional(str), optional(str))
-        Success|Failure, ExceptionClassName, Exception description, Stacktrace
-    '''
-    return (list(value) + [None] * 4)[:4]
 
 
 def format_error_body(id=None, detail=None, traceback=None):

--- a/services/ui_backend_service/tests/unit_tests/cache_utils_test.py
+++ b/services/ui_backend_service/tests/unit_tests/cache_utils_test.py
@@ -3,7 +3,7 @@ import pytest
 from services.ui_backend_service.data.cache.utils import (
     error_event_msg, progress_event_msg, search_result_event_msg,
     artifact_location_from_key, artifact_cache_id, unpack_pathspec_with_attempt_id,
-    streamed_errors
+    streamed_errors, cacheable_artifact_value, artifact_value
 )
 
 pytestmark = [pytest.mark.unit_tests]
@@ -88,3 +88,24 @@ def test_streamed_errors_exception_output():
             raise Exception("Should not be reraised")
     except Exception as ex:
         assert False #  Should not have re-raised exception
+    
+
+def test_cacheable_artifact_value():
+    artifact = TestArtifact("pathspec/to", 1, "test")
+    big_artifact = TestArtifact("pathspec/to", 123456789, "test")
+
+    assert cacheable_artifact_value(artifact) == '[true, "test"]'
+    assert cacheable_artifact_value(big_artifact) == '[false, "artifact-too-large", "pathspec/to: 123456789 bytes"]'
+
+def test_artifact_value():
+    artifact = TestArtifact("pathspec/to", 1, "test")
+    big_artifact = TestArtifact("pathspec/to", 123456789, "test")
+
+    assert artifact_value(artifact) == (True, "test")
+    assert artifact_value(big_artifact) == (False, "artifact-too-large", "pathspec/to: 123456789 bytes")
+
+class TestArtifact():
+    def __init__(self, pathspec, size, data):
+        self.pathspec = pathspec
+        self.size = size
+        self.data = data

--- a/services/ui_backend_service/tests/unit_tests/data_test.py
+++ b/services/ui_backend_service/tests/unit_tests/data_test.py
@@ -1,0 +1,16 @@
+import pytest
+
+from services.ui_backend_service.data import unpack_processed_value
+
+pytestmark = [pytest.mark.unit_tests]
+
+
+@pytest.mark.parametrize("value, expected", [
+    ([True, "test_value"], [True, 'test_value', None, None]),
+    ([False, "CustomException"], [False, 'CustomException', None, None]),
+    ([False, "CustomException", "error details"], [False, 'CustomException', "error details", None]),
+    ([False, "CustomException", "error details", "stacktrace"], [False, 'CustomException', "error details", "stacktrace"]),
+])
+def test_unpack_processed_value_padding(value, expected):
+    # test that the helper pads the output list with enough None items by default.
+    assert unpack_processed_value(value) == expected


### PR DESCRIPTION
add helpers for cache actions to unify the value storage for artifacts and non-recoverable exceptions

adds unit tests to cover helpers, and the previously introduced `streamed_errors` contextmanager

refactors value unpacking helper to a common module as it is shared among a few components.