### PR TITLE
fix: cache timing issue, returning none

### DIFF
--- a/services/ui_backend_service/api/log.py
+++ b/services/ui_backend_service/api/log.py
@@ -256,6 +256,11 @@ async def read_and_output(cache_client, task, logtype, limit=0, page=1, reverse_
 
     log_response = res.get()
 
+    if log_response is None:
+        # This should not happen under normal circumstances.
+        raise LogException("Cache returned None for log content and raised no errors. \
+            The cache server might be experiencing issues.")
+
     return log_response["content"], log_response["pages"]
 
 

--- a/services/ui_backend_service/data/cache/client/cache_client.py
+++ b/services/ui_backend_service/data/cache/client/cache_client.py
@@ -102,6 +102,10 @@ class CacheFuture(object):
                     stream = obj
                     break
 
+            if stream is None:
+                # in case waiting for file timed out and stream remained none.
+                return
+
             tail = ''
             while True:
                 buf = stream.readline()

--- a/services/ui_backend_service/data/cache/client/cache_client.py
+++ b/services/ui_backend_service/data/cache/client/cache_client.py
@@ -2,6 +2,7 @@ import os
 import json
 import sys
 import hashlib
+import time
 
 from .cache_store import object_path, stream_path, is_safely_readable
 from .cache_action import Check
@@ -69,10 +70,13 @@ class CacheFuture(object):
     def stream(self, timeout=FOREVER):
 
         def _wait_paths(paths):
-            # wait until one of the paths is readable
+            # wait until one of the paths is readable.
+            # NOTE: for terminated workers, have a curfew of 20seconds before giving up on
+            # waiting for a stream file to appear.
+            started = time.time()
             while True:
                 # Make sure we still have pending cache worker request
-                if not self.has_pending_request():
+                if not self.has_pending_request() and time.time() - started > 20:
                     return
 
                 for path in paths:
@@ -100,9 +104,6 @@ class CacheFuture(object):
 
             tail = ''
             while True:
-                if not self.has_pending_request():
-                    break
-
                 buf = stream.readline()
                 if buf == '':
                     yield None
@@ -122,6 +123,13 @@ class CacheFuture(object):
                         yield msg
                 else:
                     tail += buf
+
+                if not self.has_pending_request():
+                    # NOTE: break only after reading the stream file in order to stream messages
+                    # even for cache workers that would otherwise exit
+                    # (and remove their pending request) before wait_iter has a chance
+                    # to access the file.
+                    break
 
         if self.stream_key:
             # the stream has three layers:


### PR DESCRIPTION
*Issue*
Under certain circumstances the cache futures .get() can be accessed even though an async with block is used for capturing streamed errors. This can happen for example with cache actions that throw an exception quickly, removing themselves from pending requests immediately afterwards. More often than not the `wait_iter` did not have time to find the file on disk and read its contents before `has_pending_request()` starts returning false again, completely breaking out of stream iteration.

*Change*
introduces a fixed curfew for when a stream file should appear on disk, and trying to access this despite no pending request existing anymore. Also introduces a guard for log routes against possible `None` being returned  despite the fixes, due to other underlying issues with the cache (for example if the cache server experiences an issue).