### PR TITLE
fix: catch unsupported DAG language case correctly

### DIFF
--- a/services/ui_backend_service/data/cache/generate_dag_action.py
+++ b/services/ui_backend_service/data/cache/generate_dag_action.py
@@ -87,17 +87,17 @@ class GenerateDag(CacheAction):
 
         with streamed_errors(stream_output):
             run = Run("{}/{}".format(flow_id, run_number))
-            results[result_key] = json.dumps(generate_dag(flow_id, run.code.flowspec))
+            results[result_key] = json.dumps(generate_dag(run))
 
         return results
 
 # Utilities
 
 
-def generate_dag(flow_id, source):
+def generate_dag(run: Run):
     try:
         # Initialize a FlowGraph object
-        graph = FlowGraph(source=source, name=flow_id)
+        graph = FlowGraph(source=run.code.flowspec, name=run.parent.id)
         # Build the DAG based on the DAGNodes given by the FlowGraph for the found FlowSpec class.
         dag = {}
         for node in graph:


### PR DESCRIPTION
code package access (which fails for R flows due to KeyError) was left outside the try/except block that raises a custom error for unsupported flow language. Refactor `generate_dag` to take in a Run instance, and perform code package accessing inside it to correctly except the error.