### PR TITLE
Add CORS flag as an env variable

### DIFF
--- a/services/metadata_service/api/admin.py
+++ b/services/metadata_service/api/admin.py
@@ -9,10 +9,11 @@ from aiohttp import web
 from botocore.client import Config
 from services.data.postgres_async_db import AsyncPostgresDB
 from services.utils import (
-    get_traceback_str
+    get_traceback_str,
+    web_response
 )
 from services.metadata_service.api.utils import METADATA_SERVICE_VERSION, \
-    METADATA_SERVICE_HEADER, web_response
+    METADATA_SERVICE_HEADER
 
 
 class AuthApi(object):

--- a/services/metadata_service/api/artifact.py
+++ b/services/metadata_service/api/artifact.py
@@ -2,9 +2,7 @@ from aiohttp import web
 from services.data.postgres_async_db import AsyncPostgresDB
 from services.data.db_utils import filter_artifacts_for_latest_attempt, \
     filter_artifacts_by_attempt_id_for_tasks
-from services.utils import read_body
-from services.metadata_service.api.utils import format_response, \
-    handle_exceptions
+from services.utils import read_body, format_response, handle_exceptions
 import json
 
 

--- a/services/metadata_service/api/flow.py
+++ b/services/metadata_service/api/flow.py
@@ -1,8 +1,6 @@
 from services.data import FlowRow
 from services.data.postgres_async_db import AsyncPostgresDB
-from services.utils import read_body
-from services.metadata_service.api.utils import format_response, \
-    handle_exceptions
+from services.utils import read_body, format_response, handle_exceptions
 import asyncio
 
 

--- a/services/metadata_service/api/metadata.py
+++ b/services/metadata_service/api/metadata.py
@@ -1,8 +1,6 @@
 from aiohttp import web
 import json
-from services.utils import read_body
-from services.metadata_service.api.utils import format_response, \
-    handle_exceptions
+from services.utils import read_body, format_response, handle_exceptions
 import asyncio
 from services.data.postgres_async_db import AsyncPostgresDB
 

--- a/services/metadata_service/api/run.py
+++ b/services/metadata_service/api/run.py
@@ -1,8 +1,6 @@
 import asyncio
 from services.data.models import RunRow
-from services.utils import has_heartbeat_capable_version_tag, read_body
-from services.metadata_service.api.utils import format_response, \
-    handle_exceptions
+from services.utils import has_heartbeat_capable_version_tag, read_body, format_response, handle_exceptions
 from services.data.postgres_async_db import AsyncPostgresDB
 
 

--- a/services/metadata_service/api/step.py
+++ b/services/metadata_service/api/step.py
@@ -1,7 +1,5 @@
 from services.data import StepRow
-from services.utils import read_body
-from services.metadata_service.api.utils import format_response, \
-    handle_exceptions
+from services.utils import read_body, handle_exceptions, format_response
 from services.data.postgres_async_db import AsyncPostgresDB
 
 

--- a/services/metadata_service/api/task.py
+++ b/services/metadata_service/api/task.py
@@ -1,8 +1,6 @@
 from services.data import TaskRow
 from services.data.postgres_async_db import AsyncPostgresDB
-from services.utils import has_heartbeat_capable_version_tag, read_body
-from services.metadata_service.api.utils import format_response, \
-    handle_exceptions
+from services.utils import has_heartbeat_capable_version_tag, read_body, handle_exceptions, format_response
 import json
 from aiohttp import web
 import asyncio

--- a/services/metadata_service/api/utils.py
+++ b/services/metadata_service/api/utils.py
@@ -14,29 +14,6 @@ METADATA_SERVICE_HEADER = 'METADATA_SERVICE_VERSION'
 
 ServiceResponse = collections.namedtuple("ServiceResponse", "response_code body")
 
-
-def format_response(func):
-    """handle formatting"""
-
-    @wraps(func)
-    async def wrapper(*args, **kwargs):
-        db_response = await func(*args, **kwargs)
-        return web.Response(status=db_response.response_code,
-                            body=json.dumps(db_response.body),
-                            headers=MultiDict(
-                                {METADATA_SERVICE_HEADER: METADATA_SERVICE_VERSION}))
-
-    return wrapper
-
-
-def web_response(status: int, body):
-    return web.Response(status=status,
-                        body=json.dumps(body),
-                        headers=MultiDict(
-                            {"Content-Type": "application/json",
-                             METADATA_SERVICE_HEADER: METADATA_SERVICE_VERSION}))
-
-
 def http_500(msg, traceback_str=get_traceback_str()):
     # NOTE: worth considering if we want to expose tracebacks in the future in the api messages.
     body = {

--- a/services/metadata_service/tests/unit_tests/api_util_test.py
+++ b/services/metadata_service/tests/unit_tests/api_util_test.py
@@ -1,5 +1,5 @@
 import json
-from services.metadata_service.api.utils import handle_exceptions, format_response
+from services.utils import handle_exceptions, format_response
 
 async def test_handle_exceptions():
 

--- a/services/ui_backend_service/api/admin.py
+++ b/services/ui_backend_service/api/admin.py
@@ -6,7 +6,7 @@ from aiohttp import web
 from multidict import MultiDict
 from services.utils import (METADATA_SERVICE_HEADER, METADATA_SERVICE_VERSION,
                             SERVICE_BUILD_TIMESTAMP, SERVICE_COMMIT_HASH,
-                            web_response)
+                            web_response, text_response)
 
 from .utils import get_json_from_env
 
@@ -54,7 +54,7 @@ class AdminApi(object):
             "405":
                 description: invalid HTTP Method
         """
-        return web.Response(text=str(UI_SERVICE_VERSION))
+        return text_response(status=200, text=str(UI_SERVICE_VERSION))
 
     async def ping(self, request):
         """

--- a/services/ui_backend_service/api/autocomplete.py
+++ b/services/ui_backend_service/api/autocomplete.py
@@ -1,6 +1,6 @@
-from services.utils import handle_exceptions, logging
+from services.utils import handle_exceptions, logging, web_response
 from services.data.db_utils import DBResponse, DBPagination, translate_run_key
-from .utils import format_response_list, web_response, custom_conditions_query, pagination_query, operators_to_filters
+from .utils import format_response_list, custom_conditions_query, pagination_query, operators_to_filters
 import sys
 import asyncio
 

--- a/services/ui_backend_service/api/run.py
+++ b/services/ui_backend_service/api/run.py
@@ -1,7 +1,7 @@
 from ..data.refiner.parameter_refiner import GetParametersFailed
 from services.data.db_utils import DBResponse, translate_run_key
-from services.utils import handle_exceptions
-from .utils import find_records, web_response, format_response,\
+from services.utils import handle_exceptions, web_response, format_response
+from .utils import find_records, \
     builtin_conditions_query, pagination_query, query_param_enabled
 
 


### PR DESCRIPTION
This PR fixes two things:
* Setting CORS header to `*` is useful for development but arguably not recommended for production. Previously it was set on some responses but not others. This PR fixes the inconsistency and introduces an env variable `ACCESS_CONTROL_ALLOW_ORIGIN` that can controls what the header is set to.
* When I made the change I realized that there are two copies of functions `web_response()` and `format_response()` in the code so I deleted one and made sure all code that calls those refers to the ones that are left.