### PR TITLE
Fixing how `traceback_str` is set in `http_500` function

### DIFF
--- a/services/metadata_service/api/utils.py
+++ b/services/metadata_service/api/utils.py
@@ -37,8 +37,10 @@ def web_response(status: int, body):
                              METADATA_SERVICE_HEADER: METADATA_SERVICE_VERSION}))
 
 
-def http_500(msg, traceback_str=get_traceback_str()):
+def http_500(msg, traceback_str=None):
     # NOTE: worth considering if we want to expose tracebacks in the future in the api messages.
+    if traceback_str is None:
+        traceback_str = get_traceback_str()
     body = {
         'traceback': traceback_str,
         'detail': msg,


### PR DESCRIPTION
The calling function doesn't pass the `traceback_str` argument to the `http_500` function in  `services.metadata_service.api.utils`; This makes the `traceback_str` to be what is set during import. 

This will PR resolves this by dynamically getting the traceback when it is not added in the function. ( as it is in `services.metadata_service.api.utils.handle_exception`