### PR TITLE
Gracefully handling db failure for `/artifacts` API

### DIFF
--- a/services/data/db_utils.py
+++ b/services/data/db_utils.py
@@ -67,11 +67,28 @@ def get_latest_attempt_id_for_tasks(artifacts):
 
 
 def filter_artifacts_for_latest_attempt(artifacts):
+    """
+    filters artifacts of latest task attempt. 
+    Args:
+        artifacts (List[ArtifactRow]): a dictionary form of `ArtifactRow`
+
+    Returns:
+        `list` of filtered artifacts for the latest attempt
+    """
     attempt_ids = get_latest_attempt_id_for_tasks(artifacts)
     return filter_artifacts_by_attempt_id_for_tasks(artifacts, attempt_ids)
 
 
 def filter_artifacts_by_attempt_id_for_tasks(artifacts, attempt_for_tasks):
+    """
+    filters artifacts based on the attempt_ids. 
+    Args:
+        artifacts (List[ArtifactRow]): a dictionary form of `ArtifactRow`
+        attempt_for_tasks ([dict]): dictionary of {task_id:attempt_id}
+
+    Returns:
+        `list` of artifacts filtered based on `attempt_id`
+    """
     result = []
     for artifact in artifacts:
         if artifact['attempt_id'] == attempt_for_tasks[artifact['task_id']]:

--- a/services/data/db_utils.py
+++ b/services/data/db_utils.py
@@ -1,8 +1,11 @@
+from typing import List
 import psycopg2
 import collections
 import datetime
 import time
 import json
+
+from .models import ArtifactRow
 
 DBResponse = collections.namedtuple("DBResponse", "response_code body")
 
@@ -66,29 +69,12 @@ def get_latest_attempt_id_for_tasks(artifacts):
     return attempt_ids
 
 
-def filter_artifacts_for_latest_attempt(artifacts):
-    """
-    filters artifacts of latest task attempt. 
-    Args:
-        artifacts (List[ArtifactRow]): a dictionary form of `ArtifactRow`
-
-    Returns:
-        `list` of filtered artifacts for the latest attempt
-    """
+def filter_artifacts_for_latest_attempt(artifacts:List[ArtifactRow]) -> List[ArtifactRow]:
     attempt_ids = get_latest_attempt_id_for_tasks(artifacts)
     return filter_artifacts_by_attempt_id_for_tasks(artifacts, attempt_ids)
 
 
-def filter_artifacts_by_attempt_id_for_tasks(artifacts, attempt_for_tasks):
-    """
-    filters artifacts based on the attempt_ids. 
-    Args:
-        artifacts (List[ArtifactRow]): a dictionary form of `ArtifactRow`
-        attempt_for_tasks ([dict]): dictionary of {task_id:attempt_id}
-
-    Returns:
-        `list` of artifacts filtered based on `attempt_id`
-    """
+def filter_artifacts_by_attempt_id_for_tasks(artifacts:List[ArtifactRow], attempt_for_tasks:dict) -> List[ArtifactRow]:
     result = []
     for artifact in artifacts:
         if artifact['attempt_id'] == attempt_for_tasks[artifact['task_id']]:

--- a/services/metadata_service/api/artifact.py
+++ b/services/metadata_service/api/artifact.py
@@ -166,7 +166,6 @@ class ArtificatsApi(object):
             flow_name, run_number, step_name, task_id, artifact_name, attempt_id
         )
 
-    @format_response
     async def get_artifacts_by_task(self, request):
         """
         ---
@@ -221,7 +220,6 @@ class ArtificatsApi(object):
             status=500,body=json.dumps(http_500(artifacts.body))
           )
 
-    @format_response  
     async def get_artifacts_by_task_attempt(self, request):
         """
         ---
@@ -287,7 +285,6 @@ class ArtificatsApi(object):
             status=500,body=json.dumps(http_500(artifacts.body))
           )
 
-    @format_response
     async def get_artifacts_by_step(self, request):
         """
         ---

--- a/services/metadata_service/api/artifact.py
+++ b/services/metadata_service/api/artifact.py
@@ -217,7 +217,7 @@ class ArtificatsApi(object):
           )
         else:
           return web.Response(
-            status=500,body=json.dumps(http_500(artifacts.body))
+            status=artifacts.response_code,body=json.dumps(http_500(artifacts.body))
           )
 
     async def get_artifacts_by_task_attempt(self, request):
@@ -282,7 +282,7 @@ class ArtificatsApi(object):
           )
         else:
           return web.Response(
-            status=500,body=json.dumps(http_500(artifacts.body))
+            status=artifacts.response_code,body=json.dumps(http_500(artifacts.body))
           )
 
     async def get_artifacts_by_step(self, request):
@@ -330,7 +330,7 @@ class ArtificatsApi(object):
           )
         else:
           return web.Response(
-            status=500,body=json.dumps(http_500(artifacts.body))
+            status=artifacts.response_code,body=json.dumps(http_500(artifacts.body))
           )
 
     async def get_artifacts_by_run(self, request):
@@ -370,7 +370,7 @@ class ArtificatsApi(object):
           )
         else:
           return web.Response(
-            status=500,body=json.dumps(http_500(artifacts.body))
+            status=artifacts.response_code,body=json.dumps(http_500(artifacts.body))
           )
 
     async def create_artifacts(self, request):


### PR DESCRIPTION
## Context 

Users of metaflow after upgrading the service were getting `500` Errors when they try to access Data for task related to some flow; They managed to access metadata though. Slack Thread with more context : https://outerboundsco.slack.com/archives/C02116BBNTU/p1636723735291800

The Debug logs from the MD service looked like the following :
```
2021-12-10 08:13:18.782,ERROR:aiohttp.server:Error handling request
2021-12-10 08:13:18.782,Traceback (most recent call last):
2021-12-10 08:13:18.782,"  File ""/opt/latest/lib/python3.7/site-packages/aiohttp/web_protocol.py"", line 435, in _handle_request"
2021-12-10 08:13:18.782,    resp = await request_handler(request)
2021-12-10 08:13:18.782,"  File ""/opt/latest/lib/python3.7/site-packages/aiohttp/web_app.py"", line 504, in _handle"
2021-12-10 08:13:18.782,    resp = await handler(request)
2021-12-10 08:13:18.782,"  File ""/opt/latest/lib/python3.7/site-packages/services/metadata_service/api/artifact.py"", line 214, in get_artifacts_by_task"
2021-12-10 08:13:18.782,    artifacts.body)
2021-12-10 08:13:18.782,"  File ""/opt/latest/lib/python3.7/site-packages/services/data/db_utils.py"", line 70, in filter_artifacts_for_latest_attempt"
2021-12-10 08:13:18.782,    attempt_ids = get_latest_attempt_id_for_tasks(artifacts)
2021-12-10 08:13:18.782,"  File ""/opt/latest/lib/python3.7/site-packages/services/data/db_utils.py"", line 65, in get_latest_attempt_id_for_tasks"
2021-12-10 08:13:18.782,"    artifact['attempt_id'], attempt_ids.get(artifact['task_id'], 0))"
2021-12-10 08:13:18.782,TypeError: string indices must be integers
2021-12-10 08:13:18.782,"INFO:aiohttp.access:10.202.1.122 [10/Dec/2021:08:12:18 +0000] ""GET /flows/MRPFlow/runs/sfn-asdfasdfasfasdfadsfasdfdas/steps/some_step/tasks/asdfasfasdfasfsafasfasdgfasdgasf/artifacts HTTP/1.1"" 500 244 ""-"" ""python-requests/2.25.1"""
```

## What Is the Root Cause
We are not handing the exception from the database cleanly over [here](https://github.com/Netflix/metaflow-service/blob/65e19aef268e9e707522ee0695fd4ebaee42aa69/services/metadata_service/api/artifact.py#L209); In that line `artifacts` is a `DBResponse` object which consists of a status code. IN this [line](https://github.com/Netflix/metaflow-service/blob/65e19aef268e9e707522ee0695fd4ebaee42aa69/services/metadata_service/api/artifact.py#L209) we don't validate the response code of the DB's response and directly pass the `artifacts` to `filter_artifacts_for_latest_attempt`. This is where the service is failing. 

Based on the logs shared, we are getting a log like the following `2021-12-10 08:12:10.755,ERROR:AsyncPostgresDB:global:Exception occured `; This is emitted by [aiopg_exception_handling](https://github.com/Netflix/metaflow-service/blob/65e19aef268e9e707522ee0695fd4ebaee42aa69/services/data/db_utils.py#L13) function. Ideally, we should be checking the status_code and then making the call to `filter_artifacts_for_latest_attempt`

This PR tries to gracefully Handle such errors thrown by the Database. 
