### PR TITLE
fix: pin problematic test dependency

### DIFF
--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,4 +1,4 @@
 tox
 pytest
 pytest-cov
-pytest-aiohttp
+pytest-aiohttp==0.3.0


### PR DESCRIPTION
temporarily pin pytest-aiohttp to v0.3.0 due to unexpected issues with latest versions.