### PR TITLE
chore: pin dependencies and use new pytest aiohttp fixtures

### DIFF
--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,4 +1,4 @@
 tox
 pytest
 pytest-cov
-pytest-aiohttp==0.3.0
+pytest-aiohttp

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,4 +1,4 @@
 tox
 pytest
 pytest-cov
-pytest-aiohttp
+pytest-aiohttp >= 1.0.3, < 2

--- a/services/metadata_service/requirements.txt
+++ b/services/metadata_service/requirements.txt
@@ -1,5 +1,5 @@
-aiohttp
-aiohttp-swagger
+aiohttp >= 3.8.1, < 4
+aiohttp-swagger >= 1.0.13, < 2
 psycopg2
 boto3
 aiopg

--- a/services/metadata_service/tests/integration_tests/artifact_test.py
+++ b/services/metadata_service/tests/integration_tests/artifact_test.py
@@ -1,28 +1,14 @@
 from .utils import (
-    init_app, init_db, clean_db,
+    cli, db,
     assert_api_get_response, assert_api_post_response, compare_partial,
     add_flow, add_run, add_step,
     add_task, add_artifact
 )
 import pytest
-import json
+
 pytestmark = [pytest.mark.integration_tests]
 
-# Fixtures begin
 
-
-@pytest.fixture
-def cli(loop, aiohttp_client):
-    return init_app(loop, aiohttp_client)
-
-
-@pytest.fixture
-async def db(cli):
-    async_db = await init_db(cli)
-    yield async_db
-    await clean_db(async_db)
-
-# Fixtures end
 
 # Shared Artifact test data
 ARTIFACT_A = {

--- a/services/metadata_service/tests/integration_tests/flow_test.py
+++ b/services/metadata_service/tests/integration_tests/flow_test.py
@@ -1,27 +1,11 @@
 from .utils import (
-    init_app, init_db, clean_db,
+    cli, db,
     assert_api_get_response, assert_api_post_response, compare_partial,
     add_flow
 )
 import pytest
-import json
+
 pytestmark = [pytest.mark.integration_tests]
-
-# Fixtures begin
-
-
-@pytest.fixture
-def cli(loop, aiohttp_client):
-    return init_app(loop, aiohttp_client)
-
-
-@pytest.fixture
-async def db(cli):
-    async_db = await init_db(cli)
-    yield async_db
-    await clean_db(async_db)
-
-# Fixtures end
 
 
 async def test_flows_post(cli, db):

--- a/services/metadata_service/tests/integration_tests/metadata_test.py
+++ b/services/metadata_service/tests/integration_tests/metadata_test.py
@@ -1,28 +1,13 @@
 from .utils import (
-    init_app, init_db, clean_db,
+    cli, db,
     assert_api_get_response, assert_api_post_response, compare_partial,
     add_flow, add_run, add_step,
     add_task, add_metadata
 )
 import pytest
-import json
+
 pytestmark = [pytest.mark.integration_tests]
 
-# Fixtures begin
-
-
-@pytest.fixture
-def cli(loop, aiohttp_client):
-    return init_app(loop, aiohttp_client)
-
-
-@pytest.fixture
-async def db(cli):
-    async_db = await init_db(cli)
-    yield async_db
-    await clean_db(async_db)
-
-# Fixtures end
 
 # Shared metadata test data
 METADATA_A = {

--- a/services/metadata_service/tests/integration_tests/run_test.py
+++ b/services/metadata_service/tests/integration_tests/run_test.py
@@ -1,27 +1,12 @@
 from .utils import (
-    init_app, init_db, clean_db,
+    cli, db,
     assert_api_get_response, assert_api_post_response, compare_partial,
     add_flow, add_run
 )
 import pytest
-import json
+
 pytestmark = [pytest.mark.integration_tests]
 
-# Fixtures begin
-
-
-@pytest.fixture
-def cli(loop, aiohttp_client):
-    return init_app(loop, aiohttp_client)
-
-
-@pytest.fixture
-async def db(cli):
-    async_db = await init_db(cli)
-    yield async_db
-    await clean_db(async_db)
-
-# Fixtures end
 
 
 async def test_run_post(cli, db):

--- a/services/metadata_service/tests/integration_tests/step_test.py
+++ b/services/metadata_service/tests/integration_tests/step_test.py
@@ -1,27 +1,11 @@
 from .utils import (
-    init_app, init_db, clean_db,
+    cli, db,
     assert_api_get_response, assert_api_post_response, compare_partial,
     add_flow, add_run, add_step
 )
 import pytest
-import json
+
 pytestmark = [pytest.mark.integration_tests]
-
-# Fixtures begin
-
-
-@pytest.fixture
-def cli(loop, aiohttp_client):
-    return init_app(loop, aiohttp_client)
-
-
-@pytest.fixture
-async def db(cli):
-    async_db = await init_db(cli)
-    yield async_db
-    await clean_db(async_db)
-
-# Fixtures end
 
 
 async def test_step_post(cli, db):
@@ -45,7 +29,7 @@ async def test_step_post(cli, db):
     _found = (await db.step_table_postgres.get_step(_step["flow_id"], _step["run_number"], _step["step_name"])).body
 
     compare_partial(_found, {"step_name": "test_step", **payload})
-    
+
     # Duplicate step names should not be accepted for a run
     await assert_api_post_response(
         cli,

--- a/services/metadata_service/tests/integration_tests/task_test.py
+++ b/services/metadata_service/tests/integration_tests/task_test.py
@@ -1,27 +1,11 @@
 from .utils import (
-    init_app, init_db, clean_db,
+    cli, db,
     assert_api_get_response, assert_api_post_response, compare_partial,
     add_flow, add_run, add_step, add_task
 )
 import pytest
-import json
+
 pytestmark = [pytest.mark.integration_tests]
-
-# Fixtures begin
-
-
-@pytest.fixture
-def cli(loop, aiohttp_client):
-    return init_app(loop, aiohttp_client)
-
-
-@pytest.fixture
-async def db(cli):
-    async_db = await init_db(cli)
-    yield async_db
-    await clean_db(async_db)
-
-# Fixtures end
 
 
 async def test_task_post(cli, db):
@@ -114,6 +98,7 @@ async def test_task_post_has_initial_heartbeat_with_supported_version(cli, db):
     # Run heartbeat should have been updated as well
     _found = (await db.run_table_postgres.get_run(_run["flow_id"], _run["run_number"])).body
     assert _found['last_heartbeat_ts'] is not None
+
 
 async def test_task_heartbeat_post(cli, db):
     # create flow, run and step to add tasks for.

--- a/services/migration_service/requirements.txt
+++ b/services/migration_service/requirements.txt
@@ -1,4 +1,4 @@
-aiohttp
-aiohttp-swagger
+aiohttp >= 3.8.1, < 4
+aiohttp-swagger >= 1.0.13, < 2
 psycopg2
 aiopg

--- a/services/ui_backend_service/requirements.txt
+++ b/services/ui_backend_service/requirements.txt
@@ -1,5 +1,5 @@
-aiohttp
-aiohttp-swagger
+aiohttp >= 3.8.1, < 4
+aiohttp-swagger >= 1.0.13, < 2
 pyee==8.0.1
 throttler==1.2.0
 psycopg2

--- a/services/ui_backend_service/tests/integration_tests/admin_test.py
+++ b/services/ui_backend_service/tests/integration_tests/admin_test.py
@@ -3,23 +3,11 @@ import json
 import os
 import time
 from .utils import (
-    init_app, init_db, clean_db
+    cli, db
 )
 pytestmark = [pytest.mark.integration_tests]
 
 # Fixtures begin
-
-
-@pytest.fixture
-def cli(loop, aiohttp_client):
-    return init_app(loop, aiohttp_client)
-
-
-@pytest.fixture
-async def db(cli):
-    async_db = await init_db(cli)
-    yield async_db
-    await clean_db(async_db)
 
 
 @pytest.fixture

--- a/services/ui_backend_service/tests/integration_tests/artifact_test.py
+++ b/services/ui_backend_service/tests/integration_tests/artifact_test.py
@@ -1,26 +1,10 @@
 import pytest
 from .utils import (
-    init_app, init_db, clean_db,
+    cli, db,
     add_flow, add_run, add_step, add_task, add_artifact,
-    _test_list_resources, _test_single_resource
+    _test_list_resources
 )
 pytestmark = [pytest.mark.integration_tests]
-
-# Fixtures begin
-
-
-@pytest.fixture
-def cli(loop, aiohttp_client):
-    return init_app(loop, aiohttp_client)
-
-
-@pytest.fixture
-async def db(cli):
-    async_db = await init_db(cli)
-    yield async_db
-    await clean_db(async_db)
-
-# Fixtures end
 
 
 async def test_list_artifact(cli, db):
@@ -38,36 +22,36 @@ async def test_list_artifact(cli, db):
     await _test_list_resources(cli, db, "/flows/{flow_id}/runs/{run_number}/steps/{step_name}/tasks/{task_id}/artifacts".format(**_task), 200, [])
 
     _first = (await add_artifact(db,
-                                    flow_id=_task.get("flow_id"),
-                                    run_number=_task.get("run_number"),
-                                    run_id=_task.get("run_id"),
-                                    step_name=_task.get("step_name"),
-                                    task_id=_task.get("task_id"),
-                                    task_name=_task.get("task_name"),
-                                    artifact={
-                                        "name": "name",
-                                        "location": "location",
-                                        "ds_type": "ds_type",
-                                        "sha": "sha",
-                                        "type": "type",
-                                        "content_type": "content_type",
-                                        "attempt_id": 0})).body
+                                 flow_id=_task.get("flow_id"),
+                                 run_number=_task.get("run_number"),
+                                 run_id=_task.get("run_id"),
+                                 step_name=_task.get("step_name"),
+                                 task_id=_task.get("task_id"),
+                                 task_name=_task.get("task_name"),
+                                 artifact={
+                                     "name": "name",
+                                     "location": "location",
+                                     "ds_type": "ds_type",
+                                     "sha": "sha",
+                                     "type": "type",
+                                     "content_type": "content_type",
+                                     "attempt_id": 0})).body
 
     _second = (await add_artifact(db,
-                                    flow_id=_task.get("flow_id"),
-                                    run_number=_task.get("run_number"),
-                                    run_id=_task.get("run_id"),
-                                    step_name=_task.get("step_name"),
-                                    task_id=_task.get("task_id"),
-                                    task_name=_task.get("task_name"),
-                                    artifact={
-                                        "name": "name",
-                                        "location": "location",
-                                        "ds_type": "ds_type",
-                                        "sha": "sha",
-                                        "type": "type",
-                                        "content_type": "content_type",
-                                        "attempt_id": 1})).body
+                                  flow_id=_task.get("flow_id"),
+                                  run_number=_task.get("run_number"),
+                                  run_id=_task.get("run_id"),
+                                  step_name=_task.get("step_name"),
+                                  task_id=_task.get("task_id"),
+                                  task_name=_task.get("task_name"),
+                                  artifact={
+                                      "name": "name",
+                                      "location": "location",
+                                      "ds_type": "ds_type",
+                                      "sha": "sha",
+                                      "type": "type",
+                                      "content_type": "content_type",
+                                      "attempt_id": 1})).body
 
     await _test_list_resources(cli, db, "/flows/{flow_id}/runs/{run_number}/artifacts".format(**_task), 200, [_first, _second])
     await _test_list_resources(cli, db, "/flows/{flow_id}/runs/{run_number}/steps/{step_name}/artifacts".format(**_task), 200, [_first, _second])

--- a/services/ui_backend_service/tests/integration_tests/autocomplete_test.py
+++ b/services/ui_backend_service/tests/integration_tests/autocomplete_test.py
@@ -1,26 +1,9 @@
 import pytest
 from .utils import (
-    init_app, init_db, add_flow, clean_db, _test_list_resources,
+    cli, db, add_flow, _test_list_resources,
     add_run, add_step, add_task, add_artifact
 )
 pytestmark = [pytest.mark.integration_tests]
-
-# Fixtures begin
-
-
-@pytest.fixture
-def cli(loop, aiohttp_client):
-    return init_app(loop, aiohttp_client)
-
-
-@pytest.fixture
-async def db(cli):
-    async_db = await init_db(cli)
-    yield async_db
-    await clean_db(async_db)
-
-
-# Fixtures end
 
 
 async def test_flows_autocomplete(cli, db):
@@ -36,7 +19,6 @@ async def test_flows_autocomplete(cli, db):
 
     # no-match
     await _test_list_resources(cli, db, '/flows/autocomplete?flow_id:co=test', 200, [])
-
 
 
 async def test_runs_autocomplete(cli, db):
@@ -63,7 +45,7 @@ async def test_steps_autocomplete(cli, db):
     await add_step(db, flow_id=_run.get("flow_id"), step_name="step3", run_number=_run.get("run_number"), run_id=_run.get("run_id"))
 
     await _test_list_resources(cli, db, '/flows/{flowid}/runs/{runid}/steps/autocomplete'.format(flowid=_step.get('flow_id'), runid=_step.get('run_number')), 200, ["another_step", "regular_step", "step3"])
-    
+
     # Partial match
     await _test_list_resources(cli, db, '/flows/{flowid}/runs/{runid}/steps/autocomplete?step_name:co=lar'.format(flowid=_step.get('flow_id'), runid=_step.get('run_number')), 200, ["regular_step"])
 
@@ -80,7 +62,7 @@ async def test_tags_autocomplete(cli, db):
     await cli.server.app.AutoCompleteApi.update_cached_tags()
     # Note that runtime:dev tags gets assigned automatically
     await _test_list_resources(cli, db, '/tags/autocomplete', 200, ['runtime:dev', 'tag:something'])
-    
+
     # Partial match
     await _test_list_resources(cli, db, '/tags/autocomplete?tag:co=thing', 200, ['tag:something'])
 

--- a/services/ui_backend_service/tests/integration_tests/features_test.py
+++ b/services/ui_backend_service/tests/integration_tests/features_test.py
@@ -1,17 +1,8 @@
 import pytest
 from .utils import (
-    init_app, set_env
+    init_app, set_env, cli
 )
 pytestmark = [pytest.mark.integration_tests]
-
-# Fixtures begin
-
-
-@pytest.fixture
-def cli(loop, aiohttp_client):
-    return init_app(loop, aiohttp_client)
-
-# Fixtures end
 
 
 async def get_features(cli):

--- a/services/ui_backend_service/tests/integration_tests/flows_test.py
+++ b/services/ui_backend_service/tests/integration_tests/flows_test.py
@@ -1,26 +1,10 @@
 import pytest
 from .utils import (
-    init_app, init_db, clean_db,
+    cli, db,
     add_flow,
     _test_list_resources, _test_single_resource
 )
 pytestmark = [pytest.mark.integration_tests]
-
-# Fixtures begin
-
-
-@pytest.fixture
-def cli(loop, aiohttp_client):
-    return init_app(loop, aiohttp_client)
-
-
-@pytest.fixture
-async def db(cli):
-    async_db = await init_db(cli)
-    yield async_db
-    await clean_db(async_db)
-
-# Fixtures end
 
 
 async def test_list_flows(cli, db):

--- a/services/ui_backend_service/tests/integration_tests/grouped_runs_test.py
+++ b/services/ui_backend_service/tests/integration_tests/grouped_runs_test.py
@@ -1,28 +1,12 @@
 import pytest
 import time
 from .utils import (
-    init_app, init_db, clean_db,
+    cli, db,
     add_flow, add_run, add_artifact,
     add_step, add_task, add_metadata,
     _test_list_resources, _test_single_resource, get_heartbeat_ts
 )
 pytestmark = [pytest.mark.integration_tests]
-
-# Fixtures begin
-
-
-@pytest.fixture
-def cli(loop, aiohttp_client):
-    return init_app(loop, aiohttp_client)
-
-
-@pytest.fixture
-async def db(cli):
-    async_db = await init_db(cli)
-    yield async_db
-    await clean_db(async_db)
-
-# Fixtures end
 
 
 async def test_list_runs_group_by_flow_id(cli, db):

--- a/services/ui_backend_service/tests/integration_tests/log_test.py
+++ b/services/ui_backend_service/tests/integration_tests/log_test.py
@@ -1,28 +1,11 @@
 import pytest
 from unittest import mock
 from .utils import (
-    add_metadata, init_app, init_db, clean_db,
+    add_metadata, cli, db,
     add_flow, add_run, add_step, add_task,
     _test_list_resources
 )
 pytestmark = [pytest.mark.integration_tests]
-
-
-# Fixtures begin
-
-
-@pytest.fixture
-def cli(loop, aiohttp_client):
-    return init_app(loop, aiohttp_client)
-
-
-@pytest.fixture
-async def db(cli):
-    async_db = await init_db(cli)
-    yield async_db
-    await clean_db(async_db)
-
-# Fixtures end
 
 
 async def test_log_default_response(cli, db):

--- a/services/ui_backend_service/tests/integration_tests/metadata_test.py
+++ b/services/ui_backend_service/tests/integration_tests/metadata_test.py
@@ -1,26 +1,10 @@
 import pytest
 from .utils import (
-    init_app, init_db, clean_db,
+    cli, db,
     add_flow, add_run, add_step, add_task, add_metadata,
-    _test_list_resources, _test_single_resource
+    _test_list_resources
 )
 pytestmark = [pytest.mark.integration_tests]
-
-# Fixtures begin
-
-
-@pytest.fixture
-def cli(loop, aiohttp_client):
-    return init_app(loop, aiohttp_client)
-
-
-@pytest.fixture
-async def db(cli):
-    async_db = await init_db(cli)
-    yield async_db
-    await clean_db(async_db)
-
-# Fixtures end
 
 
 async def test_list_metadata(cli, db):

--- a/services/ui_backend_service/tests/integration_tests/notify_test.py
+++ b/services/ui_backend_service/tests/integration_tests/notify_test.py
@@ -1,6 +1,6 @@
 import pytest
 from .utils import (
-    init_app, init_db, clean_db,
+    cli, init_db, clean_db,
     add_flow, add_run, add_step, add_task, add_artifact, add_metadata,
     TIMEOUT_FUTURE
 )
@@ -12,11 +12,6 @@ from services.ui_backend_service.api.notify import ListenNotify
 pytestmark = [pytest.mark.integration_tests]
 
 # Fixtures begin
-
-
-@pytest.fixture
-def cli(loop, aiohttp_client):
-    return init_app(loop, aiohttp_client)
 
 
 @pytest.fixture

--- a/services/ui_backend_service/tests/integration_tests/plugins_test.py
+++ b/services/ui_backend_service/tests/integration_tests/plugins_test.py
@@ -4,7 +4,7 @@ import json
 import os
 import contextlib
 from .utils import (
-    init_app, init_db, clean_db
+    cli, db
 )
 from ...plugins import init_plugins, list_plugins, _reset_plugins, Plugin
 from aiohttp import web
@@ -14,18 +14,6 @@ import pygit2
 pytestmark = [pytest.mark.integration_tests]
 
 # Fixtures begin
-
-
-@pytest.fixture
-def cli(loop, aiohttp_client):
-    return init_app(loop, aiohttp_client)
-
-
-@pytest.fixture
-async def db(cli):
-    async_db = await init_db(cli)
-    yield async_db
-    await clean_db(async_db)
 
 
 @pytest.fixture

--- a/services/ui_backend_service/tests/integration_tests/runs_test.py
+++ b/services/ui_backend_service/tests/integration_tests/runs_test.py
@@ -1,28 +1,12 @@
 import pytest
 import time
 from .utils import (
-    init_app, init_db, clean_db,
+    cli, db,
     add_flow, add_run, add_artifact,
     add_step, add_task, add_metadata,
     _test_list_resources, _test_single_resource, get_heartbeat_ts
 )
 pytestmark = [pytest.mark.integration_tests]
-
-# Fixtures begin
-
-
-@pytest.fixture
-def cli(loop, aiohttp_client):
-    return init_app(loop, aiohttp_client)
-
-
-@pytest.fixture
-async def db(cli):
-    async_db = await init_db(cli)
-    yield async_db
-    await clean_db(async_db)
-
-# Fixtures end
 
 
 async def test_list_runs(cli, db):

--- a/services/ui_backend_service/tests/integration_tests/status_attempts_test.py
+++ b/services/ui_backend_service/tests/integration_tests/status_attempts_test.py
@@ -1,29 +1,12 @@
 import pytest
 from unittest import mock
 from .utils import (
-    init_app, init_db, clean_db,
+    cli, db,
     add_flow, add_run, add_artifact,
     add_step, add_task, add_metadata,
-    _test_list_resources, _test_single_resource
+    _test_single_resource
 )
 pytestmark = [pytest.mark.integration_tests]
-
-# Fixtures begin
-
-
-@pytest.fixture
-def cli(loop, aiohttp_client):
-    return init_app(loop, aiohttp_client)
-
-
-@pytest.fixture
-async def db(cli):
-    async_db = await init_db(cli)
-    yield async_db
-    await clean_db(async_db)
-
-
-# Fixtures end
 
 # NOTE: For Attempts which don’t have attempt_ok in metadata, utilize the value of attempt specific task_ok in s3
 

--- a/services/ui_backend_service/tests/integration_tests/status_runs_test.py
+++ b/services/ui_backend_service/tests/integration_tests/status_runs_test.py
@@ -1,27 +1,11 @@
 import pytest
 from .utils import (
-    init_app, init_db, clean_db,
+    cli, db,
     add_flow, add_run, add_artifact,
     add_step, add_task, add_metadata,
-    _test_list_resources, _test_single_resource, get_heartbeat_ts
+    _test_single_resource, get_heartbeat_ts
 )
 pytestmark = [pytest.mark.integration_tests]
-
-# Fixtures begin
-
-
-@pytest.fixture
-def cli(loop, aiohttp_client):
-    return init_app(loop, aiohttp_client)
-
-
-@pytest.fixture
-async def db(cli):
-    async_db = await init_db(cli)
-    yield async_db
-    await clean_db(async_db)
-
-# Fixtures end
 
 # NOTE: For Runs which don’t have heartbeat enabled, for heartbeat checks fall back on using the timestamp of the latest metadata entry for the task as a proxy and set x and Y to 2 weeks.
 # NOTE: For Runs which don’t have attempt_ok in metadata, utilize the value of attempt specific task_ok in s3 (IMPORTANT: For the time being this won't affect Run context)

--- a/services/ui_backend_service/tests/integration_tests/status_tasks_test.py
+++ b/services/ui_backend_service/tests/integration_tests/status_tasks_test.py
@@ -1,29 +1,13 @@
 import pytest
 from unittest import mock
 from .utils import (
-    init_app, init_db, clean_db,
+    cli, db,
     add_flow, add_run, add_artifact,
     add_step, add_task, add_metadata,
-    _test_list_resources, _test_single_resource
+    _test_single_resource
 )
 pytestmark = [pytest.mark.integration_tests]
 
-# Fixtures begin
-
-
-@pytest.fixture
-def cli(loop, aiohttp_client):
-    return init_app(loop, aiohttp_client)
-
-
-@pytest.fixture
-async def db(cli):
-    async_db = await init_db(cli)
-    yield async_db
-    await clean_db(async_db)
-
-
-# Fixtures end
 
 # NOTE: For Tasks which don’t have heartbeat enabled, for heartbeat checks fall back on using the timestamp of the latest metadata entry for the task as a proxy and set x and Y to 2 weeks.
 # NOTE: For Tasks which don’t have attempt_ok in metadata, utilize the value of attempt specific task_ok in s3

--- a/services/ui_backend_service/tests/integration_tests/steps_test.py
+++ b/services/ui_backend_service/tests/integration_tests/steps_test.py
@@ -1,27 +1,11 @@
 import pytest
 from .utils import (
-    init_app, init_db, clean_db,
+    cli, db,
     add_flow, add_run, add_step, add_task,
     add_artifact, get_heartbeat_ts,
     _test_list_resources, _test_single_resource
 )
 pytestmark = [pytest.mark.integration_tests]
-
-# Fixtures begin
-
-
-@pytest.fixture
-def cli(loop, aiohttp_client):
-    return init_app(loop, aiohttp_client)
-
-
-@pytest.fixture
-async def db(cli):
-    async_db = await init_db(cli)
-    yield async_db
-    await clean_db(async_db)
-
-# Fixtures end
 
 
 async def test_list_steps(cli, db):

--- a/services/ui_backend_service/tests/integration_tests/tasks_test.py
+++ b/services/ui_backend_service/tests/integration_tests/tasks_test.py
@@ -1,27 +1,11 @@
 import pytest
 import time
 from .utils import (
-    init_app, init_db, clean_db,
+    cli, db,
     add_flow, add_run, add_step, add_task, add_artifact,
     _test_list_resources, _test_single_resource, add_metadata, get_heartbeat_ts
 )
 pytestmark = [pytest.mark.integration_tests]
-
-# Fixtures begin
-
-
-@pytest.fixture
-def cli(loop, aiohttp_client):
-    return init_app(loop, aiohttp_client)
-
-
-@pytest.fixture
-async def db(cli):
-    async_db = await init_db(cli)
-    yield async_db
-    await clean_db(async_db)
-
-# Fixtures end
 
 
 async def test_list_tasks(cli, db):
@@ -393,6 +377,7 @@ async def test_task_attempt_statuses_with_attempt_ok_failed(cli, db):
 # NOTE: for a more accurate finished_at timestamp, use the greatest timestamp out of task_ok / attempt_ok / attempt-done
 # as this is the latest write_timestamp for the task
 
+
 async def test_task_attempt_status_completed(cli, db):
     _task = await create_task(db)
     _task['duration'] = None
@@ -481,7 +466,6 @@ async def test_task_attempt_status_failed_with_existing_subsequent_attempt(cli, 
     _first_attempt['duration'] = _first_attempt['finished_at'] - _first_attempt['started_at']
 
     await _test_list_resources(cli, db, "/flows/{flow_id}/runs/{run_number}/steps/{step_name}/tasks/{task_id}/attempts".format(**_task), 200, [_second_attempt, _first_attempt])
-
 
 
 # Resource Helpers / factories

--- a/services/ui_backend_service/tests/integration_tests/utils.py
+++ b/services/ui_backend_service/tests/integration_tests/utils.py
@@ -1,7 +1,7 @@
 from services.ui_backend_service.api.plugins import PluginsApi
 from aiohttp import web
 from pyee import AsyncIOEventEmitter
-from pytest import approx
+import pytest
 import os
 import json
 import datetime
@@ -32,7 +32,7 @@ TIMEOUT_FUTURE = 0.2
 # Test fixture helpers begin
 
 
-def init_app(loop, aiohttp_client, queue_ttl=30):
+async def init_app(aiohttp_client, queue_ttl=30):
     app = web.Application()
     app.event_emitter = AsyncIOEventEmitter()
 
@@ -45,7 +45,7 @@ def init_app(loop, aiohttp_client, queue_ttl=30):
     # Skip all creation processes, these are handled with migration service and init_db
     db_conf = get_test_dbconf()
     db = AsyncPostgresDB(name='api')
-    loop.run_until_complete(db._init(db_conf=db_conf, create_tables=False, create_triggers=False))
+    await db._init(db_conf=db_conf, create_tables=False, create_triggers=False)
 
     cache_store = CacheStore(db=db, event_emitter=app.event_emitter)
 
@@ -65,7 +65,7 @@ def init_app(loop, aiohttp_client, queue_ttl=30):
 
     AdminApi(app, cache_store)
 
-    return loop.run_until_complete(aiohttp_client(app))
+    return await aiohttp_client(app)
 
 
 async def init_db(cli):
@@ -97,6 +97,18 @@ async def clean_db(db: AsyncPostgresDB):
     ]
     for table in tables:
         await table.execute_sql(select_sql="DELETE FROM {}".format(table.table_name))
+
+
+@pytest.fixture
+async def cli(aiohttp_client):
+    return await init_app(aiohttp_client)
+
+
+@pytest.fixture
+async def db(cli):
+    async_db = await init_db(cli)
+    yield async_db
+    await clean_db(async_db)
 
 # Test fixture helpers end
 
@@ -301,7 +313,7 @@ def _test_dict_approx(actual, expected, approx_keys, threshold=1000):
     # TODO: If possible, a less error prone solution would be to somehow mock/freeze the now() on a per-test basis.
     for k, v in actual.items():
         if k in approx_keys:
-            assert v == approx(expected[k], rel=threshold)
+            assert v == pytest.approx(expected[k], rel=threshold)
         else:
             assert v == expected[k]
 

--- a/services/ui_backend_service/tests/integration_tests/ws_test.py
+++ b/services/ui_backend_service/tests/integration_tests/ws_test.py
@@ -3,7 +3,7 @@ import time
 import asyncio
 import math
 from .utils import (
-    init_app, init_db, clean_db,
+    cli, init_app, init_db, clean_db,
     add_flow,
     TIMEOUT_FUTURE
 )
@@ -15,14 +15,9 @@ pytestmark = [pytest.mark.integration_tests]
 
 
 @pytest.fixture
-def cli(loop, aiohttp_client):
-    return init_app(loop, aiohttp_client)
-
-
-@pytest.fixture
-def cli_short_ttl(loop, aiohttp_client):
+async def cli_short_ttl(aiohttp_client):
     # Use 0.5 second TTL for Websocket queue
-    return init_app(loop, aiohttp_client, queue_ttl=0.5)
+    return await init_app(aiohttp_client, queue_ttl=0.5)
 
 
 @pytest.fixture


### PR DESCRIPTION
Pins some of the major versions of dependencies

- aiohttp
- aiohttp-swagger
- pytest-aiohttp

Also includes a major clean up to integration tests of all services as `pytest-aiohttp` introduced automatic async fixtures, removing the need to manually interact with the loop when setting up the app for testing.