### PR TITLE
chore: omit subapp swaggerdocs from ui_backend.

### DIFF
--- a/services/metadata_service/server.py
+++ b/services/metadata_service/server.py
@@ -2,7 +2,7 @@ import asyncio
 import os
 
 from aiohttp import web
-from aiohttp_swagger import *
+from aiohttp_swagger import setup_swagger
 
 from .api.run import RunApi
 from .api.flow import FlowApi

--- a/services/migration_service/api/utils.py
+++ b/services/migration_service/api/utils.py
@@ -1,5 +1,4 @@
 from subprocess import Popen, PIPE
-import shlex
 from ..data.postgres_async_db import PostgresUtils
 from . import version_dict, latest, \
     make_goose_migration_template, make_goose_template

--- a/services/migration_service/migration_server.py
+++ b/services/migration_service/migration_server.py
@@ -2,9 +2,7 @@ import asyncio
 import os
 
 from aiohttp import web
-from aiohttp_swagger import *
-
-from subprocess import Popen, PIPE
+from aiohttp_swagger import setup_swagger
 
 from .api.admin import AdminApi
 

--- a/services/ui_backend_service/ui_server.py
+++ b/services/ui_backend_service/ui_server.py
@@ -4,7 +4,7 @@ import signal
 import concurrent
 
 from aiohttp import web
-from aiohttp_swagger import *
+from aiohttp_swagger import setup_swagger
 from pyee import AsyncIOEventEmitter
 from services.utils import DBConfiguration, logging
 
@@ -96,6 +96,9 @@ def app(loop=None, db_conf: DBConfiguration = None):
     LogApi(app, async_db, cache_store)
     AdminApi(app, cache_store)
 
+    setup_swagger(app,
+                  description=swagger_description,
+                  definitions=swagger_definitions)
     # Add Metadata Service as a sub application so that Metaflow Client
     # can use it as a service backend in case none provided via METAFLOW_SERVICE_URL
     #
@@ -103,10 +106,6 @@ def app(loop=None, db_conf: DBConfiguration = None):
     # 'allow_get_requests_only' middleware will only accept GET requests.
     app.add_subapp("/metadata", metadata_service_app(
         loop=loop, db_conf=db_conf, middlewares=[allow_get_requests_only]))
-
-    setup_swagger(app,
-                  description=swagger_description,
-                  definitions=swagger_definitions)
 
     if os.environ.get("UI_ENABLED", "1") == "1":
         # Serve UI bundle only if enabled


### PR DESCRIPTION
Omit subapp metadata service swagger docs from ui backend service, as this is included for "internal" use only, and does not need to be documented as part of the public api.

Also clean up wildcard and unused imports from the three services.