### PR TITLE
fix: Unnecessarily eager dag preload

### DIFF
--- a/services/ui_backend_service/api/notify.py
+++ b/services/ui_backend_service/api/notify.py
@@ -179,6 +179,12 @@ class ListenNotify(object):
                         data["field_name"] in ["code-package-url", "code-package"]:
                     self.event_emitter.emit("preload-dag", data['flow_id'], data['run_number'])
 
+                if operation == "INSERT" and \
+                        table.table_name == self.db.artifact_table_postgres.table_name and \
+                        data["step_name"] == "_parameters" and \
+                        data["name"] == "_graph_info":
+                    self.event_emitter.emit("preload-dag", data['flow_id'], data['run_number'])
+
         except Exception:
             self.logger.exception("Exception occurred")
 

--- a/services/ui_backend_service/data/cache/store.py
+++ b/services/ui_backend_service/data/cache/store.py
@@ -7,6 +7,7 @@ from services.data.db_utils import DBResponse
 
 from .client import CacheAsyncClient
 from pyee import AsyncIOEventEmitter
+from services.ui_backend_service.data.db.utils import get_run_dag_data
 from services.ui_backend_service.features import (FEATURE_CACHE_ENABLE,
                                                   FEATURE_PREFETCH_ENABLE)
 from services.utils import logging
@@ -313,10 +314,7 @@ class DAGCacheStore(object):
         """
         logger.debug("  - Preload DAG for {}/{}".format(flow_name, run_number))
         # Check first if a DAG can be generated for the run.
-        db_response = await self.db.artifact_table_postgres.get_run_graph_info_artifact(flow_name, run_number)
-        if not db_response.response_code == 200:
-            # Try to look for codepackage if graph artifact is missing
-            db_response = await self.db.metadata_table_postgres.get_run_codepackage_metadata(flow_name, run_number)
+        db_response = await get_run_dag_data(self.db, flow_name, run_number)
 
         if not db_response.response_code == 200:
             return  # No reason to trigger the cache action when a DAG can not be generated.

--- a/services/ui_backend_service/data/cache/store.py
+++ b/services/ui_backend_service/data/cache/store.py
@@ -3,6 +3,8 @@ import os
 import shutil
 from typing import Dict, List, Optional
 
+from services.data.db_utils import DBResponse
+
 from .client import CacheAsyncClient
 from pyee import AsyncIOEventEmitter
 from services.ui_backend_service.features import (FEATURE_CACHE_ENABLE,
@@ -310,8 +312,19 @@ class DAGCacheStore(object):
             Run number
         """
         logger.debug("  - Preload DAG for {}/{}".format(flow_name, run_number))
+        # Check first if a DAG can be generated for the run.
+        db_response = await self.db.artifact_table_postgres.get_run_graph_info_artifact(flow_name, run_number)
+        if not db_response.response_code == 200:
+            # Try to look for codepackage if graph artifact is missing
+            db_response = await self.db.metadata_table_postgres.get_run_codepackage_metadata(flow_name, run_number)
 
-        res = await self.cache.GenerateDag(flow_name, run_number)
+        if not db_response.response_code == 200:
+            return  # No reason to trigger the cache action when a DAG can not be generated.
+
+        # Prefer run_id over run_number
+        run_id = db_response.body.get('run_id') or db_response.body['run_number']
+
+        res = await self.cache.GenerateDag(flow_name, run_id)
         async for event in res.stream():
             if event["type"] == "error":
                 logger.error(event)

--- a/services/ui_backend_service/data/db/utils.py
+++ b/services/ui_backend_service/data/db/utils.py
@@ -1,0 +1,16 @@
+
+from services.data.db_utils import DBResponse
+from services.ui_backend_service.data.db.postgres_async_db import AsyncPostgresDB
+
+
+async def get_run_dag_data(db: AsyncPostgresDB, flow_name: str, run_number: str) -> DBResponse:
+    """
+    Fetches either a _graph_info artifact, or a code-package metadata entry if the artifact is missing.
+    Used to determine whether a run can display a DAG.
+    """
+    db_response = await db.artifact_table_postgres.get_run_graph_info_artifact(flow_name, run_number)
+    if not db_response.response_code == 200:
+        # Try to look for codepackage if graph artifact is missing
+        db_response = await db.metadata_table_postgres.get_run_codepackage_metadata(flow_name, run_number)
+
+    return db_response


### PR DESCRIPTION
Fixes unnecessarily eager DAG preloading that happens during service launch. Previous implementation was agnostic whether a run can have a DAG or not, and was calling the cache action regardless, resulting in some unnecessary errors in service log.

Also refactors some of the DAG existence checking logic to the db layer.