### PR TITLE
chore: fix deprecations

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,5 @@
 [pytest]
+asyncio_mode = auto
 markers =
     unit_tests: Unit tests (deselect with '-m "not unit_tests"')
     integration_tests: Integration tests (deselect with '-m "not integration_tests"')

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,4 @@
 [pytest]
-asyncio_mode = auto
 markers =
     unit_tests: Unit tests (deselect with '-m "not unit_tests"')
     integration_tests: Integration tests (deselect with '-m "not integration_tests"')

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,4 +1,5 @@
 tox
+pylint
 pytest
 pytest-cov
 pytest-aiohttp >= 1.0.3, < 2

--- a/services/ui_backend_service/api/notify.py
+++ b/services/ui_backend_service/api/notify.py
@@ -44,7 +44,7 @@ class ListenNotify(object):
                         self.ping(conn)
                     )
             except Exception as ex:
-                self.logger.warn(str(ex))
+                self.logger.warning(str(ex))
             finally:
                 await asyncio.sleep(1)
 

--- a/services/ui_backend_service/data/cache/client/cache_async_client.py
+++ b/services/ui_backend_service/data/cache/client/cache_async_client.py
@@ -81,7 +81,7 @@ class CacheAsyncClient(CacheClient):
                     self._proc.stdin.drain(),
                     timeout=WAIT_FREQUENCY)
         except asyncio.TimeoutError:
-            self.logger.warn("StreamWriter.drain timeout, request restart: {}".format(repr(self._proc.stdin)))
+            self.logger.warning("StreamWriter.drain timeout, request restart: {}".format(repr(self._proc.stdin)))
             # Drain timeout error indicates unrecoverable critical issue,
             # essentially the cache functionality remains broken after the first asyncio.TimeoutError.
             # Request restart from CacheStore so that normal operation can be resumed.

--- a/services/ui_backend_service/plugins/__init__.py
+++ b/services/ui_backend_service/plugins/__init__.py
@@ -43,7 +43,7 @@ def init_plugins():
                 else:
                     auth = global_auth
             else:
-                logger.warn("   [{}] Invalid plugin format, skipping".format(identifier))
+                logger.warning("   [{}] Invalid plugin format, skipping".format(identifier))
                 continue
 
             if paths and isinstance(paths, list):

--- a/services/ui_backend_service/tests/integration_tests/ws_test.py
+++ b/services/ui_backend_service/tests/integration_tests/ws_test.py
@@ -50,7 +50,7 @@ async def _unsubscribe(ws, uuid="123"):
         "uuid": uuid})
 
 
-async def test_subscription(cli, db, loop):
+async def test_subscription(cli, db):
     ws = await cli.ws_connect("/ws")
 
     await _subscribe(ws, "/flows")
@@ -64,7 +64,7 @@ async def test_subscription(cli, db, loop):
     await ws.close()
 
 
-async def test_subscription_queue(cli, db, loop):
+async def test_subscription_queue(cli, db):
     ws = await cli.ws_connect("/ws")
 
     now = int(math.floor(time.time()))
@@ -90,7 +90,7 @@ async def test_subscription_queue(cli, db, loop):
     await ws.close()
 
 
-async def test_subscription_queue_without_since(cli, db, loop):
+async def test_subscription_queue_without_since(cli, db):
     ws = await cli.ws_connect("/ws")
 
     # At this point we have not subscribed to any resources
@@ -117,7 +117,7 @@ async def test_subscription_queue_without_since(cli, db, loop):
     await ws.close()
 
 
-async def test_subscription_queue_ttl_expired(cli_short_ttl, db, loop):
+async def test_subscription_queue_ttl_expired(cli_short_ttl, db):
     ws = await cli_short_ttl.ws_connect("/ws")
 
     now = int(math.floor(time.time()))
@@ -149,7 +149,7 @@ async def test_subscription_queue_ttl_expired(cli_short_ttl, db, loop):
     await ws.close()
 
 
-async def test_no_subscription(cli, db, loop):
+async def test_no_subscription(cli, db):
     ws = await cli.ws_connect("/ws")
 
     (await add_flow(db, flow_id="HelloFlow")).body
@@ -164,7 +164,7 @@ async def test_no_subscription(cli, db, loop):
     await ws.close()
 
 
-async def test_unubscribe(cli, db, loop):
+async def test_unubscribe(cli, db):
     ws = await cli.ws_connect("/ws")
 
     await _subscribe(ws, "/flows")
@@ -189,7 +189,7 @@ async def test_unubscribe(cli, db, loop):
     await ws.close()
 
 
-async def test_subscription_filters(cli, db, loop):
+async def test_subscription_filters(cli, db):
     ws = await cli.ws_connect("/ws")
 
     await _subscribe(ws, "/flows?_tags=custom:tag")

--- a/services/ui_backend_service/tests/unit_tests/cache_utils_test.py
+++ b/services/ui_backend_service/tests/unit_tests/cache_utils_test.py
@@ -91,20 +91,22 @@ def test_streamed_errors_exception_output_no_re_raise():
     
 
 def test_cacheable_artifact_value():
-    artifact = TestArtifact("pathspec/to", 1, "test")
-    big_artifact = TestArtifact("pathspec/to", 123456789, "test")
+    artifact = MockArtifact("pathspec/to", 1, "test")
+    big_artifact = MockArtifact("pathspec/to", 123456789, "test")
 
     assert cacheable_artifact_value(artifact) == '[true, "test"]'
     assert cacheable_artifact_value(big_artifact) == '[false, "artifact-too-large", "pathspec/to: 123456789 bytes"]'
 
+
 def test_artifact_value():
-    artifact = TestArtifact("pathspec/to", 1, "test")
-    big_artifact = TestArtifact("pathspec/to", 123456789, "test")
+    artifact = MockArtifact("pathspec/to", 1, "test")
+    big_artifact = MockArtifact("pathspec/to", 123456789, "test")
 
     assert artifact_value(artifact) == (True, "test")
     assert artifact_value(big_artifact) == (False, "artifact-too-large", "pathspec/to: 123456789 bytes")
 
-class TestArtifact():
+
+class MockArtifact():
     def __init__(self, pathspec, size, data):
         self.pathspec = pathspec
         self.size = size

--- a/services/utils/__init__.py
+++ b/services/utils/__init__.py
@@ -10,7 +10,7 @@ from functools import wraps
 from typing import Dict
 import logging
 import psycopg2
-from distutils.version import LooseVersion
+from packaging.version import Version, parse
 
 version = pkg_resources.require("metadata_service")[0].version
 
@@ -146,12 +146,12 @@ def has_heartbeat_capable_version_tag(system_tags):
     """Check client version tag whether it is known to support heartbeats or not"""
     try:
         version_tags = [tag for tag in system_tags if tag.startswith('metaflow_version:')]
-        version = LooseVersion(version_tags[0][17:])
+        version = parse(version_tags[0][17:])
 
-        if version >= LooseVersion("1") and version < LooseVersion("2"):
-            return version >= LooseVersion("1.14.0")
+        if version >= Version("1") and version < Version("2"):
+            return version >= Version("1.14.0")
 
-        return version >= LooseVersion("2.2.12")
+        return version >= Version("2.2.12")
     except Exception:
         return False
 


### PR DESCRIPTION
fixes use of some deprecated features

- Removes use of deprecated `loop` fixture with aiohttp tests, as of pytest-aiohttp >= 1 this is not necessary.
- use `logger.warning`
- Use packaging.version instead of distutils. unit tests should already cover the expected behavior which previously depended on `LooseVersion`
- rename `TestArtifact` mock class so pytest does not erroneously consider it a test case (has had no effect besides a warning until now).

