### PR TITLE
chore: fix deprecated way of initialising aiohttp app in services

### DIFF
--- a/services/metadata_service/server.py
+++ b/services/metadata_service/server.py
@@ -35,10 +35,12 @@ def app(loop=None, db_conf: DBConfiguration = None, middlewares=None):
 def main():
     loop = asyncio.get_event_loop()
     the_app = app(loop, DBConfiguration())
-    handler = the_app.make_handler()
+    handler = web.AppRunner(the_app)
+    loop.run_until_complete(handler.setup())
+
     port = os.environ.get("MF_METADATA_PORT", 8080)
     host = str(os.environ.get("MF_METADATA_HOST", "0.0.0.0"))
-    f = loop.create_server(handler, host, port)
+    f = loop.create_server(handler.server, host, port)
 
     srv = loop.run_until_complete(f)
     print("serving on", srv.sockets[0].getsockname())

--- a/services/migration_service/migration_server.py
+++ b/services/migration_service/migration_server.py
@@ -23,10 +23,12 @@ def app(loop=None, db_conf: DBConfiguration = None):
 def main():
     loop = asyncio.get_event_loop()
     the_app = app(loop, db_conf)
-    handler = the_app.make_handler()
+    handler = web.AppRunner(the_app)
+    loop.run_until_complete(handler.setup())
+
     port = os.environ.get("MF_MIGRATION_PORT", 8082)
     host = str(os.environ.get("MF_METADATA_HOST", "0.0.0.0"))
-    f = loop.create_server(handler, host, port)
+    f = loop.create_server(handler.server, host, port)
 
     srv = loop.run_until_complete(f)
 


### PR DESCRIPTION
Use aiohttp AppRunner as the preferred way of setting up a service process as `make_handler()` is deprecated. Affected services are only the metadata and migration service, as ui_backend is already using newer way.

Not in any way critical, as the deprecated method is still part of the library as well. Consider merging at some point as cleanup.

Fixes #197 