### PR TITLE
Add missing click dependency

### DIFF
--- a/services/ui_backend_service/requirements.txt
+++ b/services/ui_backend_service/requirements.txt
@@ -6,3 +6,4 @@ psycopg2
 aiopg
 pygit2==1.6.1
 metaflow>=2.5.0
+click==8.0.3


### PR DESCRIPTION
It was always missing but it was a transitive dep through `metaflow` package. Now `metaflow` vendors in `click` so it no longer depends on it.