### PR TITLE
Remove table creation from python code

### DIFF
--- a/services/data/postgres_async_db.py
+++ b/services/data/postgres_async_db.py
@@ -68,7 +68,7 @@ class _AsyncPostgresDB(object):
         tables.append(self.metadata_table_postgres)
         self.tables = tables
 
-    async def _init(self, db_conf: DBConfiguration, create_triggers=DB_TRIGGER_CREATE, create_tables=True):
+    async def _init(self, db_conf: DBConfiguration, create_triggers=DB_TRIGGER_CREATE):
         # todo make poolsize min and max configurable as well as timeout
         # todo add retry and better error message
         retries = max_connection_retires
@@ -82,7 +82,7 @@ class _AsyncPostgresDB(object):
                     echo=AIOPG_ECHO)
 
                 for table in self.tables:
-                    await table._init(create_tables=create_tables, create_triggers=create_triggers)
+                    await table._init(create_triggers=create_triggers)
 
                 self.logger.info(
                     "Connection established.\n"
@@ -143,7 +143,6 @@ class AsyncPostgresTable(object):
     joins: List[str] = None
     select_columns: List[str] = keys
     join_columns: List[str] = None
-    _command = None
     _insert_command = None
     _filters = None
     _base_query = "SELECT {0} from"
@@ -151,13 +150,11 @@ class AsyncPostgresTable(object):
 
     def __init__(self, db: _AsyncPostgresDB = None):
         self.db = db
-        if self.table_name is None or self._command is None:
+        if self.table_name is None:
             raise NotImplementedError(
-                "need to specify table name and create command")
+                "need to specify table name")
 
-    async def _init(self, create_tables: bool, create_triggers: bool):
-        if create_tables:
-            await PostgresUtils.create_if_missing(self.db, self.table_name, self._command)
+    async def _init(self, create_triggers: bool):
         if create_triggers:
             self.db.logger.info(
                 "Setting up notify trigger for {table_name}\n   Keys: {keys}".format(
@@ -349,21 +346,6 @@ class AsyncPostgresTable(object):
 
 class PostgresUtils(object):
     @staticmethod
-    async def create_if_missing(db: _AsyncPostgresDB, table_name, command):
-        with (await db.pool.cursor()) as cur:
-            try:
-                await cur.execute(
-                    "select * from information_schema.tables where table_name=%s",
-                    (table_name,),
-                )
-                table_exist = bool(cur.rowcount)
-                if not table_exist:
-                    await cur.execute(command)
-            finally:
-                cur.close()
-    # todo add method to check schema version
-
-    @staticmethod
     async def create_trigger_if_missing(db: _AsyncPostgresDB, table_name, trigger_name, commands=[]):
         "executes the commands only if a trigger with the given name does not already exist on the table"
         with (await db.pool.cursor()) as cur:
@@ -459,17 +441,6 @@ class AsyncFlowTablePostgres(AsyncPostgresTable):
     primary_keys = ["flow_id"]
     trigger_keys = primary_keys
     select_columns = keys
-    _command = """
-    CREATE TABLE {0} (
-        flow_id VARCHAR(255) PRIMARY KEY,
-        user_name VARCHAR(255),
-        ts_epoch BIGINT NOT NULL,
-        tags JSONB,
-        system_tags JSONB
-    )
-    """.format(
-        table_name
-    )
     _row_type = FlowRow
 
     async def add_flow(self, flow: FlowRow):
@@ -501,23 +472,6 @@ class AsyncRunTablePostgres(AsyncPostgresTable):
     trigger_keys = primary_keys + ["last_heartbeat_ts"]
     select_columns = keys
     flow_table_name = AsyncFlowTablePostgres.table_name
-    _command = """
-    CREATE TABLE {0} (
-        flow_id VARCHAR(255) NOT NULL,
-        run_number SERIAL NOT NULL,
-        run_id VARCHAR(255),
-        user_name VARCHAR(255),
-        ts_epoch BIGINT NOT NULL,
-        tags JSONB,
-        system_tags JSONB,
-        last_heartbeat_ts BIGINT,
-        PRIMARY KEY(flow_id, run_number),
-        FOREIGN KEY(flow_id) REFERENCES {1} (flow_id),
-        UNIQUE (flow_id, run_id)
-    )
-    """.format(
-        table_name, flow_table_name
-    )
 
     async def add_run(self, run: RunRow, fill_heartbeat: bool = False):
         dict = {
@@ -568,23 +522,6 @@ class AsyncStepTablePostgres(AsyncPostgresTable):
     trigger_keys = primary_keys
     select_columns = keys
     run_table_name = AsyncRunTablePostgres.table_name
-    _command = """
-    CREATE TABLE {0} (
-        flow_id VARCHAR(255) NOT NULL,
-        run_number BIGINT NOT NULL,
-        run_id VARCHAR(255),
-        step_name VARCHAR(255) NOT NULL,
-        user_name VARCHAR(255),
-        ts_epoch BIGINT NOT NULL,
-        tags JSONB,
-        system_tags JSONB,
-        PRIMARY KEY(flow_id, run_number, step_name),
-        FOREIGN KEY(flow_id, run_number) REFERENCES {1} (flow_id, run_number),
-        UNIQUE(flow_id, run_id, step_name)
-    )
-    """.format(
-        table_name, run_table_name
-    )
 
     async def add_step(self, step_object: StepRow):
         dict = {
@@ -626,25 +563,6 @@ class AsyncTaskTablePostgres(AsyncPostgresTable):
     trigger_keys = primary_keys
     select_columns = keys
     step_table_name = AsyncStepTablePostgres.table_name
-    _command = """
-    CREATE TABLE {0} (
-        flow_id VARCHAR(255) NOT NULL,
-        run_number BIGINT NOT NULL,
-        run_id VARCHAR(255),
-        step_name VARCHAR(255) NOT NULL,
-        task_id BIGSERIAL PRIMARY KEY,
-        task_name VARCHAR(255),
-        user_name VARCHAR(255),
-        ts_epoch BIGINT NOT NULL,
-        tags JSONB,
-        system_tags JSONB,
-        last_heartbeat_ts BIGINT,
-        FOREIGN KEY(flow_id, run_number, step_name) REFERENCES {1} (flow_id, run_number, step_name),
-        UNIQUE (flow_id, run_number, step_name, task_name)
-    )
-    """.format(
-        table_name, step_table_name
-    )
 
     async def add_task(self, task: TaskRow, fill_heartbeat=False):
         # todo backfill run_number if missing?
@@ -718,25 +636,6 @@ class AsyncMetadataTablePostgres(AsyncPostgresTable):
     trigger_keys = ["flow_id", "run_number",
                     "step_name", "task_id", "field_name", "value"]
     select_columns = keys
-    _command = """
-    CREATE TABLE {0} (
-        flow_id VARCHAR(255),
-        run_number BIGINT NOT NULL,
-        run_id VARCHAR(255),
-        step_name VARCHAR(255) NOT NULL,
-        task_name VARCHAR(255),
-        task_id BIGINT NOT NULL,
-        id BIGSERIAL NOT NULL,
-        field_name VARCHAR(255) NOT NULL,
-        value TEXT NOT NULL,
-        type VARCHAR(255) NOT NULL,
-        user_name VARCHAR(255),
-        ts_epoch BIGINT NOT NULL,
-        tags JSONB,
-        system_tags JSONB,
-        PRIMARY KEY(id, flow_id, run_number, step_name, task_id, field_name)
-    )
-    """.format(table_name)
 
     async def add_metadata(
         self,
@@ -804,30 +703,6 @@ class AsyncArtifactTablePostgres(AsyncPostgresTable):
                     "step_name", "task_id", "attempt_id", "name"]
     trigger_keys = primary_keys
     select_columns = keys
-    _command = """
-    CREATE TABLE {0} (
-        flow_id VARCHAR(255) NOT NULL,
-        run_number BIGINT NOT NULL,
-        run_id VARCHAR(255),
-        step_name VARCHAR(255) NOT NULL,
-        task_id BIGINT NOT NULL,
-        task_name VARCHAR(255),
-        name VARCHAR(255) NOT NULL,
-        location VARCHAR(255) NOT NULL,
-        ds_type VARCHAR(255) NOT NULL,
-        sha VARCHAR(255),
-        type VARCHAR(255),
-        content_type VARCHAR(255),
-        user_name VARCHAR(255),
-        attempt_id SMALLINT NOT NULL,
-        ts_epoch BIGINT NOT NULL,
-        tags JSONB,
-        system_tags JSONB,
-        PRIMARY KEY(flow_id, run_number, step_name, task_id, attempt_id, name)
-    )
-    """.format(
-        table_name
-    )
 
     async def add_artifact(
         self,

--- a/services/ui_backend_service/data/db/tables/artifact.py
+++ b/services/ui_backend_service/data/db/tables/artifact.py
@@ -16,7 +16,6 @@ class AsyncArtifactTablePostgres(AsyncPostgresTable):
     primary_keys = MetadataArtifactTable.primary_keys
     trigger_keys = MetadataArtifactTable.trigger_keys
     select_columns = keys
-    _command = MetadataArtifactTable._command
 
     async def get_run_parameter_artifacts(self, flow_name, run_number, postprocess=None, invalidate_cache=False):
         run_id_key, run_id_value = translate_run_key(run_number)

--- a/services/ui_backend_service/data/db/tables/base.py
+++ b/services/ui_backend_service/data/db/tables/base.py
@@ -44,7 +44,6 @@ class AsyncPostgresTable(MetadataAsyncPostgresTable):
     joins: List[str] = None
     select_columns: List[str] = keys
     join_columns: List[str] = None
-    _command = None
     _filters = None
     _row_type = None
 

--- a/services/ui_backend_service/data/db/tables/flow.py
+++ b/services/ui_backend_service/data/db/tables/flow.py
@@ -12,7 +12,6 @@ class AsyncFlowTablePostgres(AsyncPostgresTable):
     primary_keys = MetadataFlowTable.primary_keys
     trigger_keys = MetadataFlowTable.trigger_keys
     select_columns = keys
-    _command = MetadataFlowTable._command
     _row_type = FlowRow
 
     async def get_flow_ids(self, conditions: List[str] = [],

--- a/services/ui_backend_service/data/db/tables/metadata.py
+++ b/services/ui_backend_service/data/db/tables/metadata.py
@@ -13,7 +13,6 @@ class AsyncMetadataTablePostgres(AsyncPostgresTable):
     keys = MetaserviceMetadataTable.keys
     primary_keys = MetaserviceMetadataTable.primary_keys
     trigger_keys = MetaserviceMetadataTable.trigger_keys
-    _command = MetaserviceMetadataTable._command
 
     @property
     def select_columns(self):

--- a/services/ui_backend_service/data/db/tables/run.py
+++ b/services/ui_backend_service/data/db/tables/run.py
@@ -200,7 +200,6 @@ class AsyncRunTablePostgres(AsyncPostgresTable):
             cutoff=OLD_RUN_FAILURE_CUTOFF_TIME
         )
     ]
-    _command = MetadataRunTable._command
 
     async def get_recent_runs(self):
         _records, *_ = await self.find_records(

--- a/services/ui_backend_service/data/db/tables/step.py
+++ b/services/ui_backend_service/data/db/tables/step.py
@@ -21,7 +21,6 @@ class AsyncStepTablePostgres(AsyncPostgresTable):
     primary_keys = MetadataStepTable.primary_keys
     trigger_keys = MetadataStepTable.trigger_keys
     run_table_name = MetadataRunTable.table_name
-    _command = MetadataStepTable._command
     task_table_name = MetadataTaskTable.table_name
     artifact_table_name = MetadataArtifactTable.table_name
     metadata_table_name = MetaMetadataTable.table_name

--- a/services/ui_backend_service/data/db/tables/task.py
+++ b/services/ui_backend_service/data/db/tables/task.py
@@ -223,7 +223,6 @@ class AsyncTaskTablePostgres(AsyncPostgresTable):
         )
     ]
     step_table_name = AsyncStepTablePostgres.table_name
-    _command = MetadataTaskTable._command
 
     async def get_task_attempt(self, flow_id: str, run_key: str,
                                step_name: str, task_key: str, attempt_id: int = None,

--- a/services/ui_backend_service/tests/integration_tests/utils.py
+++ b/services/ui_backend_service/tests/integration_tests/utils.py
@@ -44,7 +44,7 @@ async def init_app(aiohttp_client, queue_ttl=30):
     # Skip all creation processes, these are handled with migration service and init_db
     db_conf = get_test_dbconf()
     db = AsyncPostgresDB(name='api')
-    await db._init(db_conf=db_conf, create_tables=False, create_triggers=False)
+    await db._init(db_conf=db_conf, create_triggers=False)
 
     cache_store = CacheStore(db=db, event_emitter=app.event_emitter)
 


### PR DESCRIPTION
For some historical reason it looks like there are two ways the db tables are created: through Goose migrations, and some bespoke Python code. These two conflict; in some deployments they race and leave db in a state that is no longer upgradeable by Goose.

This PR removes these bespoke migrations, leaving goose the only way to manage schema.