### PR TITLE
Remove aiohttp-swagger

### DIFF
--- a/services/metadata_service/requirements.txt
+++ b/services/metadata_service/requirements.txt
@@ -1,5 +1,4 @@
 aiohttp >= 3.8.1, < 4
-aiohttp-swagger >= 1.0.13, < 2
 psycopg2
 boto3
 aiopg

--- a/services/metadata_service/server.py
+++ b/services/metadata_service/server.py
@@ -2,7 +2,6 @@ import asyncio
 import os
 
 from aiohttp import web
-from aiohttp_swagger import setup_swagger
 
 from .api.run import RunApi
 from .api.flow import FlowApi
@@ -30,7 +29,6 @@ def app(loop=None, db_conf: DBConfiguration = None, middlewares=None):
     MetadataApi(app)
     ArtificatsApi(app)
     AuthApi(app)
-    setup_swagger(app)
     return app
 
 

--- a/services/migration_service/migration_server.py
+++ b/services/migration_service/migration_server.py
@@ -2,7 +2,6 @@ import asyncio
 import os
 
 from aiohttp import web
-from aiohttp_swagger import setup_swagger
 
 from .api.admin import AdminApi
 
@@ -18,7 +17,6 @@ def app(loop=None, db_conf: DBConfiguration = None):
     async_db = AsyncPostgresDB()
     loop.run_until_complete(async_db._init(db_conf))
     AdminApi(app)
-    setup_swagger(app)
     return app
 
 

--- a/services/migration_service/requirements.txt
+++ b/services/migration_service/requirements.txt
@@ -1,4 +1,3 @@
 aiohttp >= 3.8.1, < 4
-aiohttp-swagger >= 1.0.13, < 2
 psycopg2
 aiopg

--- a/services/ui_backend_service/requirements.txt
+++ b/services/ui_backend_service/requirements.txt
@@ -1,5 +1,4 @@
 aiohttp >= 3.8.1, < 4
-aiohttp-swagger >= 1.0.13, < 2
 pyee==8.0.1
 throttler==1.2.0
 psycopg2

--- a/services/ui_backend_service/ui_server.py
+++ b/services/ui_backend_service/ui_server.py
@@ -4,7 +4,6 @@ import signal
 import concurrent
 
 from aiohttp import web
-from aiohttp_swagger import setup_swagger
 from pyee import AsyncIOEventEmitter
 from services.utils import DBConfiguration, logging
 
@@ -94,9 +93,6 @@ def app(loop=None, db_conf: DBConfiguration = None):
     LogApi(app, async_db, cache_store)
     AdminApi(app, cache_store)
 
-    setup_swagger(app,
-                  description=swagger_description,
-                  definitions=swagger_definitions)
     # Add Metadata Service as a sub application so that Metaflow Client
     # can use it as a service backend in case none provided via METAFLOW_SERVICE_URL
     #


### PR DESCRIPTION
`aiohttp-swagger` has a dep with [RCE](https://nvd.nist.gov/vuln/detail/CVE-2021-23369). While I don't believe it affects metaflow-service, it also doesn't seem like these swagger docs are actively used by anyone. So for now I'm thinking we can simply remove that stuff.

I'm not removing swagger definitions for API calls themselves -- there is a chance that we'll bring it back later, or we may validate against them as part of the test suite. 