### PR TITLE
[tag-mutation-project] Add tag mutation endpoint for Runs to metadata service

### DIFF
--- a/services/data/postgres_async_db.py
+++ b/services/data/postgres_async_db.py
@@ -162,7 +162,8 @@ class AsyncPostgresTable(object):
             await PostgresUtils.setup_trigger_notify(db=self.db, table_name=self.table_name, keys=self.trigger_keys)
 
     async def get_records(self, filter_dict={}, fetch_single=False,
-                          ordering: List[str] = None, limit: int = 0, expanded=False) -> DBResponse:
+                          ordering: List[str] = None, limit: int = 0, expanded=False,
+                          cur: aiopg.Cursor = None) -> DBResponse:
         conditions = []
         values = []
         for col_name, col_val in filter_dict.items():
@@ -171,13 +172,13 @@ class AsyncPostgresTable(object):
 
         response, _ = await self.find_records(
             conditions=conditions, values=values, fetch_single=fetch_single,
-            order=ordering, limit=limit, expanded=expanded
+            order=ordering, limit=limit, expanded=expanded, cur=cur
         )
         return response
 
     async def find_records(self, conditions: List[str] = None, values=[], fetch_single=False,
                            limit: int = 0, offset: int = 0, order: List[str] = None, expanded=False,
-                           enable_joins=False) -> Tuple[DBResponse, DBPagination]:
+                           enable_joins=False, cur: aiopg.Cursor = None) -> Tuple[DBResponse, DBPagination]:
         sql_template = """
         SELECT * FROM (
             SELECT
@@ -203,42 +204,46 @@ class AsyncPostgresTable(object):
         ).strip()
 
         return await self.execute_sql(select_sql=select_sql, values=values, fetch_single=fetch_single,
-                                      expanded=expanded, limit=limit, offset=offset)
+                                      expanded=expanded, limit=limit, offset=offset, cur=cur)
 
     async def execute_sql(self, select_sql: str, values=[], fetch_single=False,
-                          expanded=False, limit: int = 0, offset: int = 0) -> Tuple[DBResponse, DBPagination]:
+                          expanded=False, limit: int = 0, offset: int = 0,
+                          cur: aiopg.Cursor = None) -> Tuple[DBResponse, DBPagination]:
+        async def _execute_on_cursor(_cur):
+            await _cur.execute(select_sql, values)
+
+            rows = []
+            records = await _cur.fetchall()
+            for record in records:
+                row = self._row_type(**record)  # pylint: disable=not-callable
+                rows.append(row.serialize(expanded))
+
+            count = len(rows)
+
+            # Will raise IndexError in case fetch_single=True and there's no results
+            body = rows[0] if fetch_single else rows
+            pagination = DBPagination(
+                limit=limit,
+                offset=offset,
+                count=count,
+                page=math.floor(int(offset) / max(int(limit), 1)) + 1,
+            )
+            return body, pagination
+        if cur:
+            # if we are using the passed in cursor, we allow any errors to be managed by cursor owner
+            body, pagination = await _execute_on_cursor(cur)
+            return DBResponse(response_code=200, body=body), pagination
         try:
-            with (
-                await self.db.pool.cursor(
+            with (await self.db.pool.cursor(
                     cursor_factory=psycopg2.extras.DictCursor
-                )
-            ) as cur:
-                await cur.execute(select_sql, values)
-
-                rows = []
-                records = await cur.fetchall()
-                for record in records:
-                    row = self._row_type(**record)  # pylint: disable=not-callable
-                    rows.append(row.serialize(expanded))
-
-                count = len(rows)
-
-                # Will raise IndexError in case fetch_single=True and there's no results
-                body = rows[0] if fetch_single else rows
-
-                pagination = DBPagination(
-                    limit=limit,
-                    offset=offset,
-                    count=count,
-                    page=math.floor(int(offset) / max(int(limit), 1)) + 1,
-                )
-
-                cur.close()
-                return DBResponse(response_code=200, body=body), pagination
+            )) as cur:
+                body, pagination = await _execute_on_cursor(cur)
+                cur.close()  # unsure if needed, leaving in there for safety
+            return DBResponse(response_code=200, body=body), pagination
         except IndexError as error:
             return aiopg_exception_handling(error), None
         except (Exception, psycopg2.DatabaseError) as error:
-            self.db.logger.exception("Exception occured")
+            self.db.logger.exception("Exception occurred")
             return aiopg_exception_handling(error), None
 
     async def create_record(self, record_dict):
@@ -286,10 +291,28 @@ class AsyncPostgresTable(object):
                 cur.close()
             return DBResponse(response_code=200, body=response_body)
         except (Exception, psycopg2.DatabaseError) as error:
-            self.db.logger.exception("Exception occured")
+            self.db.logger.exception("Exception occurred")
             return aiopg_exception_handling(error)
 
-    async def update_row(self, filter_dict={}, update_dict={}):
+    async def run_in_transaction_with_serializable_isolation_level(self, fun):
+        try:
+            with (
+                    await self.db.pool.cursor(
+                        cursor_factory=psycopg2.extras.DictCursor,
+                    )
+            ) as cur:
+                async with cur.begin():
+                    await cur.execute('SET TRANSACTION ISOLATION LEVEL SERIALIZABLE')
+                    res = await fun(cur)
+                cur.close()  # is this really needed? TODO
+                return res
+        except psycopg2.errors.SerializationFailure:
+            return DBResponse(response_code=503, body="Conflicting concurrent tag mutation, please retry")
+        except (Exception, psycopg2.DatabaseError) as error:
+            self.db.logger.exception("Exception occurred")
+            return aiopg_exception_handling(error)
+
+    async def update_row(self, filter_dict={}, update_dict={}, cur: aiopg.Cursor = None):
         # generate where clause
         filters = []
         for col_name, col_val in filter_dict.items():
@@ -322,25 +345,29 @@ class AsyncPostgresTable(object):
         update_sql = """
                 UPDATE {0} SET {1} WHERE {2};
         """.format(self.table_name, set_clause, where_clause)
+
+        async def _execute_update_on_cursor(_cur):
+            await _cur.execute(update_sql)
+            if _cur.rowcount < 1:
+                return DBResponse(response_code=404,
+                                  body={"msg": "could not find row"})
+            if _cur.rowcount > 1:
+                return DBResponse(response_code=500,
+                                  body={"msg": "duplicate rows"})
+            return DBResponse(response_code=200, body={"rowcount": _cur.rowcount})
+        if cur:
+            return await _execute_update_on_cursor(cur)
         try:
             with (
                 await self.db.pool.cursor(
                     cursor_factory=psycopg2.extras.DictCursor
                 )
             ) as cur:
-                await cur.execute(update_sql)
-                if cur.rowcount < 1:
-                    return DBResponse(response_code=404,
-                                      body={"msg": "could not find row"})
-                if cur.rowcount > 1:
-                    return DBResponse(response_code=500,
-                                      body={"msg": "duplicate rows"})
-                body = {"rowcount": cur.rowcount}
-                # todo make sure connection is closed even with error
+                db_response = await _execute_update_on_cursor(cur)
                 cur.close()
-                return DBResponse(response_code=200, body=body)
+                return db_response
         except (Exception, psycopg2.DatabaseError) as error:
-            self.db.logger.exception("Exception occured")
+            self.db.logger.exception("Exception occurred")
             return aiopg_exception_handling(error)
 
 
@@ -484,11 +511,11 @@ class AsyncRunTablePostgres(AsyncPostgresTable):
         }
         return await self.create_record(dict)
 
-    async def get_run(self, flow_id: str, run_id: str, expanded: bool = False):
+    async def get_run(self, flow_id: str, run_id: str, expanded: bool = False, cur: aiopg.Cursor = None):
         key, value = translate_run_key(run_id)
         filter_dict = {"flow_id": flow_id, key: str(value)}
         return await self.get_records(filter_dict=filter_dict,
-                                      fetch_single=True, expanded=expanded)
+                                      fetch_single=True, expanded=expanded, cur=cur)
 
     async def get_all_runs(self, flow_id: str):
         filter_dict = {"flow_id": flow_id}
@@ -509,6 +536,17 @@ class AsyncRunTablePostgres(AsyncPostgresTable):
 
         return DBResponse(response_code=result.response_code,
                           body=json.dumps(body))
+
+    async def update_run_tags(self, flow_id: str, run_id: str, run_tags: list, cur: aiopg.Cursor = None):
+        run_key, run_value = translate_run_key(run_id)
+        filter_dict = {"flow_id": flow_id,
+                       run_key: str(run_value)}
+        set_dict = {"tags": "'" + json.dumps(run_tags) + "'"}  # TODO we can/should do better than manual quoting
+        result = await self.update_row(filter_dict=filter_dict,
+                                       update_dict=set_dict,
+                                       cur=cur)
+        return DBResponse(response_code=result.response_code,
+                          body=json.dumps(set_dict))
 
 
 class AsyncStepTablePostgres(AsyncPostgresTable):

--- a/services/data/postgres_async_db.py
+++ b/services/data/postgres_async_db.py
@@ -308,7 +308,8 @@ class AsyncPostgresTable(object):
                 cur.close()  # is this really needed? TODO
                 return res
         except psycopg2.errors.SerializationFailure:
-            return DBResponse(response_code=503, body="Conflicting concurrent tag mutation, please retry")
+            # See https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/409
+            return DBResponse(response_code=409, body="Conflicting concurrent tag mutation, please retry")
         except (Exception, psycopg2.DatabaseError) as error:
             self.db.logger.exception("Exception occurred")
             return aiopg_exception_handling(error)

--- a/services/data/postgres_async_db.py
+++ b/services/data/postgres_async_db.py
@@ -1,5 +1,6 @@
 import psycopg2
 import psycopg2.extras
+from psycopg2.extensions import QuotedString
 import os
 import aiopg
 import json
@@ -541,7 +542,8 @@ class AsyncRunTablePostgres(AsyncPostgresTable):
         run_key, run_value = translate_run_key(run_id)
         filter_dict = {"flow_id": flow_id,
                        run_key: str(run_value)}
-        set_dict = {"tags": "'" + json.dumps(run_tags) + "'"}  # TODO we can/should do better than manual quoting
+
+        set_dict = {"tags": QuotedString(json.dumps(run_tags)).getquoted().decode()}
         result = await self.update_row(filter_dict=filter_dict,
                                        update_dict=set_dict,
                                        cur=cur)

--- a/services/metadata_service/api/run.py
+++ b/services/metadata_service/api/run.py
@@ -1,4 +1,8 @@
 import asyncio
+import json
+from itertools import chain
+
+from services.data.db_utils import DBResponse
 from services.data.models import RunRow
 from services.utils import has_heartbeat_capable_version_tag, read_body
 from services.metadata_service.api.utils import format_response, \
@@ -18,6 +22,9 @@ class RunApi(object):
         app.router.add_route("POST",
                              "/flows/{flow_id}/runs/{run_number}/heartbeat",
                              self.runs_heartbeat)
+        app.router.add_route("PATCH",
+                             "/flows/{flow_id}/runs/{run_number}/tag/mutate",
+                             self.mutate_user_tags)
         self._async_table = AsyncPostgresDB.get_instance().run_table_postgres
 
     @format_response
@@ -135,6 +142,97 @@ class RunApi(object):
         )
 
         return await self._async_table.add_run(run_row, fill_heartbeat=client_supports_heartbeats)
+
+    @format_response
+    @handle_exceptions
+    async def mutate_user_tags(self, request):
+        """
+        ---
+        description: mutate user tags
+        tags:
+        - Run
+        parameters:
+        - name: "flow_id"
+          in: "path"
+          description: "flow_id"
+          required: true
+          type: "string"
+        - name: "run_number"
+          in: "path"
+          description: "run_number"
+          required: true
+          type: "string"
+        - name: "body"
+          in: "body"
+          description: "body"
+          required: true
+          schema:
+            type: object
+            properties:
+                tags_to_add:
+                    type: array of string
+                tags_to_remove:
+                    type: array of string
+        produces:
+        - 'text/plain'
+        responses:
+            "200":
+                description: successful operation. Tags updated.  Returns latest user tags
+            "400":
+                description: invalid HTTP Request
+            "405":
+                description: invalid HTTP Method
+        """
+        flow_name = request.match_info.get("flow_id")
+        run_number = request.match_info.get("run_number")
+        body = await read_body(request.content)
+        tags_to_add = body.get("tags_to_add", [])
+        tags_to_remove = body.get("tags_to_remove", [])
+
+        if not isinstance(tags_to_add, list):
+            return DBResponse(response_code=422, body="tags_to_add must be a list")
+
+        if not isinstance(tags_to_remove, list):
+            return DBResponse(response_code=422, body="tags_to_remove must be a list")
+
+        # let's make sure we have a list of strings
+        if not all(isinstance(t, str) for t in chain(tags_to_add, tags_to_remove)):
+            return DBResponse(response_code=422, body="All tag values must be strings")
+
+        tags_to_add_set = set(tags_to_add)
+        tags_to_remove_set = set(tags_to_remove)
+
+        async def _in_tx_mutation_logic(cur):
+            run_db_response = await self._async_table.get_run(flow_name, run_number, cur=cur)
+            if run_db_response.response_code != 200:
+                if run_db_response.response_code == 404:
+                    return run_db_response
+                return DBResponse(response_code=422,
+                                  body="Failed to get run (get_run status %d)" % run_db_response.response_code)
+            run = run_db_response.body
+            existing_tag_set = set(run["tags"])
+            existing_system_tag_set = set(run["system_tags"])
+
+            for tag in tags_to_remove_set:
+                if tag in existing_system_tag_set:
+                    return DBResponse(response_code=422,
+                                      body="Cannot remove a tag that is an existing system tag (%s)" % tag)
+
+            # Apply removals before additions.
+            # And, make sure no existing system tags get added as a user tag
+            next_run_tag_set = (existing_tag_set - tags_to_remove_set) | (tags_to_add_set - existing_system_tag_set)
+            if next_run_tag_set == existing_tag_set:
+                return DBResponse(response_code=200,
+                                  body=json.dumps({"tags": list(next_run_tag_set)}))
+            next_run_tags = list(next_run_tag_set)
+
+            update_db_response = await self._async_table.update_run_tags(flow_name, run_number, next_run_tags, cur=cur)
+            if update_db_response.response_code != 200:
+                return update_db_response
+            return DBResponse(response_code=200,
+                              body=json.dumps({"tags": next_run_tags}))
+
+        return await self._async_table.run_in_transaction_with_serializable_isolation_level(_in_tx_mutation_logic)
 
     @format_response
     @handle_exceptions

--- a/services/metadata_service/api/run.py
+++ b/services/metadata_service/api/run.py
@@ -182,11 +182,11 @@ class RunApi(object):
                 description: invalid HTTP Request
             "405":
                 description: invalid HTTP Method
+            "409":
+                description: mutation request conflicts with an existing in-flight mutation. Retry recommended
             "422":
                 description: illegal tag mutation. No update performed.  E.g. could be because we tried to remove
                              a system tag.
-            "503":
-                description: mutation request conflicts with an existing in-flight mutation. Retry recommended
         """
         flow_name = request.match_info.get("flow_id")
         run_number = request.match_info.get("run_number")

--- a/services/metadata_service/tests/integration_tests/run_test.py
+++ b/services/metadata_service/tests/integration_tests/run_test.py
@@ -1,7 +1,14 @@
+import asyncio
+import json
+import uuid
+import random
+
+import time
+
 from .utils import (
     cli, db,
     assert_api_get_response, assert_api_post_response, compare_partial,
-    add_flow, add_run
+    add_flow, add_run, assert_api_patch_response
 )
 import pytest
 
@@ -148,3 +155,105 @@ async def test_run_get(cli, db):
     # non-existent flow or run should return 404
     await assert_api_get_response(cli, "/flows/{flow_id}/runs/1234".format(**_run), status=404)
     await assert_api_get_response(cli, "/flows/NonExistentFlow/runs/{run_number}".format(**_run), status=404)
+
+
+async def test_run_mutate_user_tags(cli, db):
+    # create flow for test
+    _flow = (await add_flow(db, "TestFlow", "test_user-1", ["a_tag", "b_tag"], ["runtime:test"])).body
+
+    # add run to flow for testing
+    _run = (await add_run(db, flow_id=_flow["flow_id"])).body
+
+    async def assert_tags_unchanged():
+        _run_in_db = (await db.run_table_postgres.get_run(_run["flow_id"], _run["run_number"])).body
+        assert sorted(_run_in_db["system_tags"]) == sorted(_run["system_tags"])
+        assert sorted(_run_in_db["tags"]) == sorted(_run["tags"])
+
+    async def assert_tags_in_db(tags):
+        _run_in_db = (await db.run_table_postgres.get_run(_run["flow_id"], _run["run_number"])).body
+        assert all(tag in _run_in_db["tags"] for tag in tags)
+
+    async def assert_tags_not_in_db(tags):
+        _run_in_db = (await db.run_table_postgres.get_run(_run["flow_id"], _run["run_number"])).body
+        assert all(tag not in _run_in_db["tags"] for tag in tags)
+
+    # try invalid inputs (like tag lists that are not lists, or tag values that are not string)
+    await assert_api_patch_response(cli, '/flows/{flow_id}/runs/{run_number}/tag/mutate'.format(**_run),
+                                    payload={"tags_to_add": "so_meta"}, status=422)
+    await assert_api_patch_response(cli, '/flows/{flow_id}/runs/{run_number}/tag/mutate'.format(**_run),
+                                    payload={"tags_to_add": [5]}, status=422)
+    await assert_api_patch_response(cli, '/flows/{flow_id}/runs/{run_number}/tag/mutate'.format(**_run),
+                                    payload={"tags_to_remove": "so_meta"}, status=422)
+    await assert_api_patch_response(cli, '/flows/{flow_id}/runs/{run_number}/tag/mutate'.format(**_run),
+                                    payload={"tags_to_remove": [5]}, status=422)
+    await assert_api_patch_response(cli, '/flows/{flow_id}/runs/__NOT_A_RUN__/tag/mutate'.format(**_run),
+                                    payload={"tags_to_add": ["user_tag"]}, status=404)
+
+    # try to remove system tags - it should not work
+    await assert_api_patch_response(cli, '/flows/{flow_id}/runs/{run_number}/tag/mutate'.format(**_run),
+                                    payload={"tags_to_remove": _run["system_tags"]}, status=422)
+    await assert_tags_unchanged()
+
+    # try to add system tags - it should be no-op (but no error)
+    await assert_api_patch_response(cli, '/flows/{flow_id}/runs/{run_number}/tag/mutate'.format(**_run),
+                                    payload={"tags_to_add": _run["system_tags"]}, status=200)
+    await assert_tags_unchanged()
+
+    # try to add user tags
+    await assert_api_patch_response(cli, '/flows/{flow_id}/runs/{run_number}/tag/mutate'.format(**_run),
+                                    payload={"tags_to_add": ["coca-cola", "pepsi"]}, status=200)
+    await assert_tags_in_db(["coca-cola", "pepsi"])
+
+    # try to remove user tags
+    await assert_api_patch_response(cli, '/flows/{flow_id}/runs/{run_number}/tag/mutate'.format(**_run),
+                                    payload={"tags_to_remove": ["coca-cola", "pepsi"]}, status=200)
+    await assert_tags_not_in_db(["coca-cola", "pepsi"])
+
+    # try to replace user tags
+    await assert_api_patch_response(cli, '/flows/{flow_id}/runs/{run_number}/tag/mutate'.format(**_run),
+                                    payload={"tags_to_add": ["coca-cola", "pepsi"]}, status=200)
+    await assert_api_patch_response(cli, '/flows/{flow_id}/runs/{run_number}/tag/mutate'.format(**_run),
+                                    payload={"tags_to_add": ["sprite", "pepsi"],
+                                             "tags_to_remove": ["coca-cola", "pepsi"]}, status=200)
+    await assert_tags_in_db(["sprite", "pepsi"])
+    await assert_tags_not_in_db(["coca-cola"])
+
+
+async def test_run_mutate_user_tags_concurrency(cli, db):
+    # create flow for test
+    _flow = (await add_flow(db, "TestFlow", "test_user-1", ["a_tag", "b_tag"], ["runtime:test"])).body
+
+    # add run to flow for testing.  Start with 0 user tags
+    _run = (await add_run(db, flow_id=_flow["flow_id"], tags=[])).body
+
+    async def _mutation_request_with_retries(path, payload):
+        attempts = 0
+        delay = 0.2
+        r = random.Random(json.dumps(payload))
+        for _ in range(10):
+            attempts += 1
+            response = await cli.patch(path, json=payload)
+            if response.status == 200:
+                return attempts
+            # 503: temporarily conflicting with another mutate request
+            elif response.status == 503:
+                delay *= r.uniform(1.0, 1.2)
+                await asyncio.sleep(delay)
+            else:
+                raise AssertionError("Unexpected status %d" % response.status)
+        raise AssertionError("Retries exhausted")
+
+    # confirm that concurrent requests get serialized correctly, if they retry
+    # in other words, no mutations get lost
+    expected_tag_set = set()
+    awaitables = []
+    for i in range(50):
+        a_tag = str(i)
+        expected_tag_set.add(a_tag)
+        awaitables.append(_mutation_request_with_retries('/flows/{flow_id}/runs/{run_number}/tag/mutate'.format(**_run), {"tags_to_add": [a_tag]}))
+    attempt_counts = await asyncio.gather(*awaitables)
+    assert sum(attempt_counts) > 50
+
+    _run_in_db = (await db.run_table_postgres.get_run(_run["flow_id"], _run["run_number"])).body
+    assert sorted(_run_in_db["tags"]) == sorted(expected_tag_set)
+

--- a/services/metadata_service/tests/integration_tests/utils.py
+++ b/services/metadata_service/tests/integration_tests/utils.py
@@ -280,6 +280,45 @@ async def assert_api_post_response(cli, path: str, payload: object = None, statu
     return body
 
 
+async def assert_api_patch_response(cli, path: str, payload: object = None, status: int = 200,
+                                    expected_body: object = None, check_fn: Callable = None):
+    """
+    Perform a PATCH request with the provided http cli to the provided path with the payload,
+    asserts that the status and data received are correct.
+    Expectation is that the API returns text/plain format json.
+
+    Parameters
+    ----------
+    cli : aiohttp cli
+        aiohttp test client
+    path : str
+        url path to perform POST request to
+    payload : object (default None)
+        the payload to be sent with the PATCH request, as json.
+    status : int (default 200)
+        http status code to expect from response
+    expected_body : object
+        An object to assert the api response against.
+    check_fn: Callable
+        A function for checking the response body. It should raise AssertionError on check failure.
+
+    Returns
+    -------
+    Object
+        Always returns the body of the api response unless we fail some assertion and throw.
+    """
+    response = await cli.patch(path, json=payload)
+
+    assert response.status == status
+
+    body = json.loads(await response.text())
+    if expected_body:
+        assert body == expected_body
+    if check_fn:
+        check_fn(body)
+    return body
+
+
 def compare_partial(actual, partial):
     "compare that all keys of partial exist in actual, and that the values match."
     for k, v in partial.items():


### PR DESCRIPTION
This is part of project to add tag mutation support. RFC [here](https://www.notion.so/outerbounds/RFC-Implementing-tag-mutation-98ef6ba39aee4aeeb9c6150b4cffea2a) (see "Tagging CLI").

The new Metaflow client API (which tagging CLI will use) will call this new metadata service endpoint:

```
        app.router.add_route("PATCH",
                             "/flows/{flow_id}/runs/{run_number}/tag/mutate",
```

Some requirements:

- A - Tag changes should be atomic (e.g. we can add/remove multiple tags at once).
- B - Tag changes should not be lost for any concurrent requests.
- C - Fail if mutation is invalid w.r.t. to current tag content (e.g. system tags)

We implement tag updates in the most straightforward manner. In DB terms:

- Check mutation request inputs (without needing current run state)
- Start DB transaction - serializable isolation level (B)
  - Read current run system tags
  - Check mutation request inputs vs current system tags (C)
  - Perform user tag mutation in memory
  - Persist new full list of user tags to DB (A)
- Commit DB transaction.

With B, concurrent mutation requests may fail with 503, if another mutation is inflight. It will be up to the Metaflow client API to retry. We will implement a sensible retry policy in API client so that end user of the client API will not need to care, except in extreme circumstances.

Run tags are stored as a JSON list in a PostgresDB JSONB column. Why not use native Postgres JSON operations?

Pros:

- Efficiency for large tag sets (e.g. if modifying one tag.  O(N) either way, but less DB write load)

Cons:

- JSON only has lists, not sets. We will need to reconcile this in memory (e.g. for removals, we would need to build an index to know which position to remove, etc).
- JSON only has lists, not sets. It means we still need to explicitly take care to prevent dupes ending up in DB somehow.
- A native JSON manipulation implementation will be less readable, less "clearly correct".

The decision in this PR is to go with simple. Efficiency-wise: there will be no issues unless folks send hundreds of tag mutation requests per second and persisted tag lists are long (hundreds of tags). We can revisit this implementation detail in future if/when needed without changing outward facing API.