### PR TITLE
[tag-mutation-project] Tag mutation endpoint fix for double JSON encoding

### DIFF
--- a/services/data/postgres_async_db.py
+++ b/services/data/postgres_async_db.py
@@ -545,11 +545,9 @@ class AsyncRunTablePostgres(AsyncPostgresTable):
                        run_key: str(run_value)}
 
         set_dict = {"tags": QuotedString(json.dumps(run_tags)).getquoted().decode()}
-        result = await self.update_row(filter_dict=filter_dict,
-                                       update_dict=set_dict,
-                                       cur=cur)
-        return DBResponse(response_code=result.response_code,
-                          body=json.dumps(set_dict))
+        return await self.update_row(filter_dict=filter_dict,
+                                     update_dict=set_dict,
+                                     cur=cur)
 
 
 class AsyncStepTablePostgres(AsyncPostgresTable):

--- a/services/metadata_service/api/run.py
+++ b/services/metadata_service/api/run.py
@@ -1,5 +1,4 @@
 import asyncio
-import json
 from itertools import chain
 
 from services.data.db_utils import DBResponse
@@ -230,14 +229,14 @@ class RunApi(object):
             next_run_tag_set = (existing_tag_set - tags_to_remove_set) | (tags_to_add_set - existing_system_tag_set)
             if next_run_tag_set == existing_tag_set:
                 return DBResponse(response_code=200,
-                                  body=json.dumps({"tags": list(next_run_tag_set)}))
+                                  body={"tags": list(next_run_tag_set)})
             next_run_tags = list(next_run_tag_set)
 
             update_db_response = await self._async_table.update_run_tags(flow_name, run_number, next_run_tags, cur=cur)
             if update_db_response.response_code != 200:
                 return update_db_response
             return DBResponse(response_code=200,
-                              body=json.dumps({"tags": next_run_tags}))
+                              body={"tags": next_run_tags})
 
         return await self._async_table.run_in_transaction_with_serializable_isolation_level(_in_tx_mutation_logic)
 

--- a/services/metadata_service/tests/integration_tests/run_test.py
+++ b/services/metadata_service/tests/integration_tests/run_test.py
@@ -235,6 +235,9 @@ async def test_run_mutate_user_tags_concurrency(cli, db):
             attempts += 1
             response = await cli.patch(path, json=payload)
             if response.status == 200:
+                # Parse the response, to make sure that it is the JSON format we
+                # expect, AND the response correctly reflects the presence of the
+                # tag being added
                 data = json.loads(await response.text())
                 assert tag_to_add in data["tags"]
                 return attempts


### PR DESCRIPTION
The `/tag/mutate` is expected to return a JSON response:

```
{
   "tags": LIST_OF_LATEST_TAGS_AFTER_MUTATION
}
```

We erroneously serialized the JSON object one too many times on the way out.  This is the fix.