### PR TITLE
[Azure support] Support Azure artifacts in UI backend service

### DIFF
--- a/services/ui_backend_service/requirements.txt
+++ b/services/ui_backend_service/requirements.txt
@@ -4,5 +4,5 @@ throttler==1.2.0
 psycopg2
 aiopg
 pygit2==1.6.1
-metaflow>=2.6.1
+metaflow>=2.7.7
 click==8.0.3

--- a/services/ui_backend_service/requirements.txt
+++ b/services/ui_backend_service/requirements.txt
@@ -6,3 +6,5 @@ aiopg
 pygit2==1.6.1
 metaflow>=2.7.7
 click==8.0.3
+azure-storage-blob==12.13.1
+azure-identity==1.10.0


### PR DESCRIPTION
UI backend service to use the latest Metaflow release (which includes Azure support).

We also add Azure pip dependencies. A small amount of bloat, but beats creating new Docker images / tags for with/without Azure.

Note for default S3 support, Metaflow pip package bundles it by default already.