### PR TITLE
Set matching cache status http code

### DIFF
--- a/services/ui_backend_service/api/admin.py
+++ b/services/ui_backend_service/api/admin.py
@@ -258,7 +258,8 @@ class AdminApi(object):
                 "workers": worker_list
             }
 
-        return web_response(status=200, body={
+        status = 200 if all([x["is_alive"] for x in cache_status.values()]) else 500
+        return web_response(status=status, body={
             "cache": cache_status
         })
 


### PR DESCRIPTION
This endpoint always returns status 200 even if 1 or more caches are not alive. With this change, if 1 of the caches is dead, it will return status 500, which can then be used by health checking tools to restart the service.

I have previously monkey patched https://github.com/Netflix/metaflow-service/pull/292 into the service I maintain but I still found issues where the cache was not restarted correctly. With this change, I no longer need to restart the Metaflow service manually.