### PR TITLE
[UI backend] New options to restrict cards / logs loading

### DIFF
--- a/services/ui_backend_service/data/cache/get_log_file_action.py
+++ b/services/ui_backend_service/data/cache/get_log_file_action.py
@@ -4,10 +4,12 @@ import json
 from typing import Dict, List, Optional, Tuple
 from .client import CacheAction
 from .utils import streamed_errors
+import os
 
 # New imports
 
 from metaflow import namespace, Task
+
 namespace(None)  # Always use global namespace by default
 
 STDOUT = 'log_location_stdout'
@@ -79,11 +81,11 @@ class GetLogFile(CacheAction):
         result_key = log_result_id(task, logtype, limit, page, reverse_order, raw_log)
         stream_key = 'log:stream:%s' % lookup_id(task, logtype, limit, page, reverse_order, raw_log)
 
-        return msg,\
-            [log_key, result_key],\
-            stream_key,\
-            [stream_key, result_key],\
-            invalidate_cache
+        return msg, \
+               [log_key, result_key], \
+               stream_key, \
+               [stream_key, result_key], \
+               invalidate_cache
 
     @classmethod
     def response(cls, keys_objs):
@@ -124,22 +126,23 @@ class GetLogFile(CacheAction):
         result_key = log_result_id(task_dict, logtype, limit, page, reverse, output_raw)
 
         previous_log_file = existing_keys.get(log_key, None)
-        previous_log_size = json.loads(previous_log_file).get("log_size", None) if previous_log_file else None
+        previous_log_hash = json.loads(previous_log_file).get("log_hash", None) if previous_log_file else None
 
-        log_size_changed = False  # keep track if we loaded new content
+        log_provider = get_log_provider()
+        log_hash_changed = False  # keep track if we loaded new content
         with streamed_errors(stream_output):
             task = Task(pathspec, attempt=attempt)
             # check if log has grown since last time.
-            current_size = get_log_size(task, logtype)
-            log_size_changed = previous_log_size is None or previous_log_size != current_size
+            current_hash = log_provider.get_log_hash(task, logtype)
+            log_hash_changed = previous_log_hash is None or previous_log_hash != current_hash
 
-            if log_size_changed:
-                content = get_log_content(task, logtype)
-                results[log_key] = json.dumps({"log_size": current_size, "content": content})
+            if log_hash_changed:
+                content = log_provider.get_log_content(task, logtype)
+                results[log_key] = json.dumps({"log_hash": current_hash, "content": content})
             else:
                 results = {**existing_keys}
 
-        if log_size_changed or result_key not in existing_keys:
+        if log_hash_changed or result_key not in existing_keys:
             results[result_key] = json.dumps(
                 paginated_result(
                     json.loads(results[log_key])["content"],
@@ -152,7 +155,25 @@ class GetLogFile(CacheAction):
 
         return results
 
+
 # Utilities
+
+# TODOs in order
+# Implement same code for Cards
+# Add unit test coverage
+# Add integration test coverage
+# Minify, prettify everything
+# Add docs re new configs in project
+def get_log_provider():
+    log_file_policy = os.environ.get('MF_LOG_LOAD_POLICY', 'full').lower()
+    if log_file_policy == 'full':
+        return FullLogProvider
+    elif log_file_policy == 'tail':
+        return TailLogProvider
+    elif log_file_policy == 'blurb_only':
+        return BlurbOnlyLogProvider
+    else:
+        raise ValueError("Unknown log value for MF_LOG_LOAD_POLICY (%s). Must be 'full', 'tail', or 'blurb_only'" % log_file_policy)
 
 
 def get_log_size(task: Task, logtype: str):
@@ -178,7 +199,87 @@ def get_log_content(task: Task, logtype: str):
         ]
 
 
-def paginated_result(content: List[Tuple[Optional[int], str]], page: int = 1, limit: int = 0, reverse_order: bool = False, output_raw=False):
+class LogProviderBase:
+
+    @staticmethod
+    def get_log_hash(task: Task, logtype: str) -> int:
+        raise NotImplementedError
+
+    @staticmethod
+    def get_log_content(task: Task, logtype: str):
+        raise NotImplementedError
+
+
+class TailLogProvider(LogProviderBase):
+    @staticmethod
+    def get_log_hash(task: Task, logtype: str) -> int:
+        # We can still use the true log size as a hash - still valid way to detect log growth
+        return get_log_size(task, logtype)
+
+    @staticmethod
+    def get_log_content(task: Task, logtype: str):
+        # In number of characters (UTF-8)
+        tail_max_size = int(os.environ.get('MF_LOG_LOAD_TAIL_SIZE', 100 * 1024))
+        # Note this is inefficient - we will load a 1GB log even if we only want last 100 bytes.
+        # Doing this efficiently is a step change in complexity and effort - we can do it when justified in future.
+        raw_content = get_log_content(task, logtype)
+
+        chars_seen = 0
+        oldest_line_idx = None
+        for i in range(len(raw_content) - 1, -1, -1):
+            chars_seen += len(raw_content[i][1])
+            oldest_line_idx = i
+            if chars_seen > tail_max_size:
+                break
+        if oldest_line_idx is None:
+            return []
+        if oldest_line_idx == 0:
+            return raw_content
+        # peel the first timestamp in returned payload, attach to the user message here
+        result = [(raw_content[oldest_line_idx][0], f"...{oldest_line_idx} more earlier lines truncated...")]
+        result.extend(raw_content[oldest_line_idx:])
+        return result
+
+
+class BlurbOnlyLogProvider(LogProviderBase):
+    @staticmethod
+    def get_log_hash(task: Task, logtype: str) -> int:
+        # We know the content is static
+        return 42
+
+    @staticmethod
+    def get_log_content(task: Task, logtype: str):
+        stream_name = 'stderr' if logtype == STDERR else 'stdout'
+        # Improvement ideas:
+        # - Use a specific Metaflow namespace (not quite trivial as we need to check various system tags to resolve.
+        # - Is there anyway to also provide a CLI command, in addition to Python code?
+        blurb = f"""# Your organization has disabled logs viewing from the Metaflow UI. Here is a code snippet to retrieve logs using the Metaflow client library:
+            
+from metaflow import Task, namespace
+
+namespace(None)
+task = Task("{task.pathspec}", attempt={task.current_attempt})
+{stream_name} = task.{stream_name}
+            
+# Please visit https://docs.metaflow.org/api/client for detailed documentation."""
+
+        return [(None, line) for line in blurb.split("\n")]
+
+
+class FullLogProvider(LogProviderBase):
+
+    @staticmethod
+    def get_log_hash(task: Task, logtype: str) -> int:
+        """size is a valid hash function"""
+        return get_log_size(task, logtype)
+
+    @staticmethod
+    def get_log_content(task: Task, logtype: str):
+        return get_log_content(task, logtype)
+
+
+def paginated_result(content: List[Tuple[Optional[int], str]], page: int = 1, limit: int = 0,
+                     reverse_order: bool = False, output_raw=False):
     if not output_raw:
         loglines, total_pages = format_loglines(content, page, limit, reverse_order)
     else:
@@ -191,7 +292,8 @@ def paginated_result(content: List[Tuple[Optional[int], str]], page: int = 1, li
     }
 
 
-def format_loglines(content: List[Tuple[Optional[int], str]], page: int = 1, limit: int = 0, reverse: bool = False) -> Tuple[List, int]:
+def format_loglines(content: List[Tuple[Optional[int], str]], page: int = 1, limit: int = 0, reverse: bool = False) -> \
+        Tuple[List, int]:
     "format, order and limit the log content. Return a list of log lines with row numbers"
     lines = [
         {"row": row, "timestamp": line[0], "line": line[1]}
@@ -222,12 +324,14 @@ def log_cache_id(task: Dict, logtype: str):
     )
 
 
-def log_result_id(task: Dict, logtype: str, limit: int = 0, page: int = 1, reverse_order: bool = False, raw_log: bool = False):
+def log_result_id(task: Dict, logtype: str, limit: int = 0, page: int = 1, reverse_order: bool = False,
+                  raw_log: bool = False):
     "construct a unique cache key for a paginated log response"
     return "log:result:%s" % lookup_id(task, logtype, limit, page, reverse_order, raw_log)
 
 
-def lookup_id(task: Dict, logtype: str, limit: int = 0, page: int = 1, reverse_order: bool = False, raw_log: bool = False):
+def lookup_id(task: Dict, logtype: str, limit: int = 0, page: int = 1, reverse_order: bool = False,
+              raw_log: bool = False):
     "construct a unique id to be used with stream_key and result_key"
     _string = "{file}_{limit}_{page}_{reverse}_{raw}".format(
         file=log_cache_id(task, logtype),

--- a/services/ui_backend_service/docs/environment.md
+++ b/services/ui_backend_service/docs/environment.md
@@ -9,6 +9,8 @@ The following are optional environment variables that can be used to fine-tune t
   - [Baseurl configuration](#baseurl-configuration)
   - [Custom navigation links for UI](#custom-navigation-links-for-ui)
   - [System notifications for UI](#system-notifications-for-ui)
+  - [Log content restriction options](#log-content-restriction-options)
+  - [Card content restriction](#card-content-restriction)
 
 ## Web socket message retention
 
@@ -170,3 +172,17 @@ Plaintext example:
   }
 ]
 ```
+
+## Log content restriction options
+
+The `MF_LOG_LOAD_POLICY` environment variable restricts the amount of log content loaded by the UI. These values are supported:
+
+* `full` (default): loads entire log.
+* `tail`: loads the tail of the log only (up to a fixed size by number of characters. See `MF_LOG_LOAD_TAIL_SIZE` below.
+* `blurb_only`: does not load the log at all. Instead return Python code snippet to access logs using Metaflow client.
+
+`MF_LOG_LOAD_TAIL_SIZE` may be used when `MF_LOG_LOAD_POLICY=tail`. Returns the last N lines of the log file, where N is maximized without returning more than MF_LOG_LOAD_TAIL_SIZE number of characters. Defaults to `100*1024` characters.
+
+## Card content restriction
+
+The `MF_CARD_LOAD_POLICY` (default `full`) environment variable can be set to `blurb_only` to return a Python code snippet to access card using Metaflow client, instead of loading actual HTML card payload.

--- a/services/ui_backend_service/tests/unit_tests/get_log_file_action_test.py
+++ b/services/ui_backend_service/tests/unit_tests/get_log_file_action_test.py
@@ -1,12 +1,16 @@
 import pytest
 import datetime
 
-from services.ui_backend_service.data.cache.get_log_file_action import paginated_result, log_cache_id, lookup_id, _datetime_to_epoch
+from services.ui_backend_service.data.cache.get_log_file_action import paginated_result, log_cache_id, lookup_id, \
+    _datetime_to_epoch, FullLogProvider, STDOUT, TailLogProvider, BlurbOnlyLogProvider
+
+from unittest.mock import MagicMock, patch
 
 pytestmark = [pytest.mark.unit_tests]
 
 TEST_LOG = list((None, "log line {}".format(i)) for i in range(1, 1001))
 TEST_MFLOG = list((i, "log line {}".format(i)) for i in range(1, 1001))
+
 
 @pytest.mark.parametrize(
     "test_log, first_expected_item",
@@ -23,6 +27,7 @@ async def test_paginated_result(test_log, first_expected_item):
     assert body["pages"] == 1
     # order should be oldest to newest
     assert body['content'][0] == first_expected_item
+
 
 @pytest.mark.parametrize("test_log", [TEST_LOG, TEST_MFLOG])
 async def test_paginated_result_oob_page(test_log):
@@ -45,6 +50,7 @@ async def test_paginated_result_oob_page(test_log):
     assert body["pages"] == 1
     assert len(body['content']) == 0
 
+
 @pytest.mark.parametrize("test_log", [TEST_LOG, TEST_MFLOG])
 async def test_paginated_result_with_limit(test_log):
     body = paginated_result(
@@ -56,6 +62,7 @@ async def test_paginated_result_with_limit(test_log):
     assert len(body['content']) == 5
     assert body["pages"] == 200
     assert [obj["line"] for obj in body['content']] == list("log line {}".format(i) for i in range(6, 11))
+
 
 @pytest.mark.parametrize("test_log", [TEST_LOG, TEST_MFLOG])
 async def test_paginated_result_ordering(test_log):
@@ -72,6 +79,7 @@ async def test_paginated_result_ordering(test_log):
         output_raw=False
     )
     assert [obj["line"] for obj in body["content"]] == [line for _, line in test_log[::-1]]
+
 
 @pytest.mark.parametrize("test_log", [TEST_LOG, TEST_MFLOG])
 async def test_paginated_result_raw_output(test_log):
@@ -143,31 +151,119 @@ async def test_lookup_id_uniqueness():
     }
 
     assert lookup_id(first_task, "stdout", 0, 1, False, False) == \
-        lookup_id(first_task, "stdout", 0, 1, False, False)
+           lookup_id(first_task, "stdout", 0, 1, False, False)
 
     assert lookup_id(first_task, "stdout", 0, 1, False, False) != \
-        lookup_id(first_task_second_attempt, "stdout", 0, 1, False, False)
+           lookup_id(first_task_second_attempt, "stdout", 0, 1, False, False)
 
     assert lookup_id(first_task, "stdout", 0, 1, False, False) != \
-        lookup_id(second_task, "stdout", 0, 1, False, False)
+           lookup_id(second_task, "stdout", 0, 1, False, False)
 
     assert lookup_id(first_task, "stdout", 0, 1, False, False) != \
-        lookup_id(first_task, "stdout", 1, 1, False, False)
+           lookup_id(first_task, "stdout", 1, 1, False, False)
 
     assert lookup_id(first_task, "stdout", 1, 1, False, False) != \
-        lookup_id(first_task, "stdout", 1, 0, False, False)
+           lookup_id(first_task, "stdout", 1, 0, False, False)
 
     assert lookup_id(first_task, "stdout", 1, 1, False, False) != \
-        lookup_id(first_task, "stdout", 1, 1, True, False)
+           lookup_id(first_task, "stdout", 1, 1, True, False)
 
     assert lookup_id(first_task, "stdout", 1, 1, False, False) != \
-        lookup_id(first_task, "stdout", 1, 1, False, True)
+           lookup_id(first_task, "stdout", 1, 1, False, True)
+
 
 datetime_expectations = [
     (None, None),
     ("123", None),
-    (datetime.datetime(2021,10,27, 0, 0, tzinfo=datetime.timezone.utc), 1635292800000)
+    (datetime.datetime(2021, 10, 27, 0, 0, tzinfo=datetime.timezone.utc), 1635292800000)
 ]
+
+
 @pytest.mark.parametrize("datetime, output", datetime_expectations)
 async def test_datetime_to_epoch(datetime, output):
     assert _datetime_to_epoch(datetime) == output
+
+
+@patch("services.ui_backend_service.data.cache.get_log_file_action.get_log_content")
+@patch("services.ui_backend_service.data.cache.get_log_file_action.get_log_size")
+def test_full_log_provider(m_get_log_size, m_get_log_content):
+    mock_task = MagicMock()
+    mock_log_content = [(None, 'log line 1'),
+                        (None, 'log line 2'),
+                        (None, 'log line 3')]
+    # sum line lengths and account for newline characters
+    mock_log_size = sum(len(line) + 1 for _, line in mock_log_content)
+    m_get_log_size.return_value = mock_log_size
+    m_get_log_content.return_value = mock_log_content
+
+    full_log_provider = FullLogProvider()
+    assert full_log_provider.get_log_content(mock_task, STDOUT) == mock_log_content
+    assert full_log_provider.get_log_hash(mock_task, STDOUT) == mock_log_size
+
+
+@patch("services.ui_backend_service.data.cache.get_log_file_action.get_log_content")
+@patch("services.ui_backend_service.data.cache.get_log_file_action.get_log_size")
+def test_tail_log_provider(m_get_log_size, m_get_log_content):
+    mock_task = MagicMock()
+    mock_log_content = []
+    for i in range(1000):
+        # 3 chars per line
+        mock_log_content.append((None, '%03d' % i))
+
+    # sum line lengths and account for newline characters
+    mock_log_size = sum(len(line) + 1 for _, line in mock_log_content)
+    m_get_log_size.return_value = mock_log_size
+    m_get_log_content.return_value = mock_log_content
+
+    for case in [
+        {
+            "max_tail_chars": 10000,
+            "expected_tail_lines": 1000,
+            "expect_to_truncate": False,
+        },
+        {
+            "max_tail_chars": 1000,
+            "expected_tail_lines": 333,
+            "expect_to_truncate": True,
+        },
+        {
+            "max_tail_chars": 100,
+            "expected_tail_lines": 33,
+            "expect_to_truncate": True,
+        },
+        {
+            "max_tail_chars": 0,
+            "expected_tail_lines": 0,
+            "expect_to_truncate": True,
+        },
+    ]:
+        provider = TailLogProvider(case["max_tail_chars"])
+        # Log size should still report full log size (even if only partial content returned)
+        assert provider.get_log_hash(mock_task, STDOUT) == mock_log_size
+        tail_log_content = provider.get_log_content(mock_task, STDOUT)
+        if case["expect_to_truncate"]:
+            # Truncation IS expected, check for "truncated messaging", then the tailed content
+            assert len(tail_log_content) == case["expected_tail_lines"] + 1
+            assert 'truncated' in tail_log_content[0][1]
+            assert tail_log_content[1:] == mock_log_content[len(mock_log_content) - case["expected_tail_lines"]:]
+        else:
+            # If no truncation expected.... just check for full content... no "truncated" messaging
+            assert tail_log_content == mock_log_content
+
+
+@patch("services.ui_backend_service.data.cache.get_log_file_action.get_log_content")
+def test_blurb_only_log_provider(m_get_log_content):
+    mock_task = MagicMock()
+    mock_log_content = []
+
+    m_get_log_content.return_value = mock_log_content
+    provider = BlurbOnlyLogProvider()
+    eternal_log_hash = provider.get_log_hash(mock_task, STDOUT)
+    eternal_log_content = provider.get_log_content(mock_task, STDOUT)
+    for i in range(1000):
+        # 3 chars per line
+        mock_log_content.append((None, '%03d' % i))
+        # Log size should NOT report true log size. In fact it should stay constant even as raw log content changes.
+        assert provider.get_log_hash(mock_task, STDOUT) == eternal_log_hash
+        # Log content should always be the same blurb
+        assert provider.get_log_content(mock_task, STDOUT) == eternal_log_content


### PR DESCRIPTION
Introduces three new environment variables to influence cards and logs loading behavior:

`MF_LOG_LOAD_POLICY`
- `full` (default): loads entire log, matches existing behavior.
- `tail`: loads the tail of the log only (up to fixed size by number of characters).
- `blurb_only`: does not load the log at all. Instead return Python code snippet to access logs using Metaflow client.

`MF_LOG_LOAD_TAIL_SIZE`
Defaults to 100*1024.  Applies when `MF_LOG_LOAD_POLICY=tail`.  Returns the last N lines of the log file, where N is maximized without returning more than `MF_LOG_LOAD_TAIL_SIZE` number of characters.

`MF_CARD_LOAD_POLICY`
* `full` (default): Loads all cards, matches existing behavior.
* `blurb_only`: does not load cards at all.  Instead return Python code snippet to access cards using Metaflow client.