### PR TITLE
fix: update release image dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.19.6-buster
+FROM golang:1.20.2-buster
 
 ARG BUILD_TIMESTAMP
 ARG BUILD_COMMIT_HASH

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,11 +13,12 @@ ENV UI_VERSION=$UI_VERSION
 ENV FEATURE_RUN_GROUPS=0
 ENV FEATURE_DEBUG_VIEW=1
 
-RUN go install github.com/pressly/goose/v3/cmd/goose@v3.5.3
+RUN go install github.com/pressly/goose/v3/cmd/goose@v3.9.0
 
-RUN apt-get update -y && apt-get -y install python3.7 && apt-get -y install python3-pip && apt-get -y install libpq-dev unzip
+RUN apt-get update -y \
+    && apt-get -y install python3.7 python3-pip libpq-dev unzip
 
-RUN pip3 install virtualenv && pip3 install requests
+RUN pip3 install virtualenv requests
 
 RUN virtualenv /opt/v_1_0_1 -p python3
 RUN virtualenv /opt/latest -p python3

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.18.9-buster
+FROM golang:1.19.6-buster
 
 ARG BUILD_TIMESTAMP
 ARG BUILD_COMMIT_HASH


### PR DESCRIPTION
addresses vulnerabilities reported by Snyk scans
- update base image of the release image Dockerfile
- update goose to latest version and clean up install commands in dockerfile

some high severity issues remain due to no upgrades available for the base `buster` image, and any further steps would require moving from python 3.7 to a higher version, requiring more extensive testing. These vulnerabilities should not be affecting the actual runtime code though.