### PR TITLE
bump version for new release

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ long_description = open_and_read_if_exists("README.md")
 
 setup(
     name="metadata_service",
-    version="2.3.6",
+    version="2.3.7",
     license="Apache License 2.0",
     description="Metadata Service: backend service for Metaflow",
     long_description=long_description,


### PR DESCRIPTION
bump version to 2.3.7 for new release, as 2.3.6 was already taken by a prior release but had not been committed.