### PR TITLE
[TRIS-297] Configurable SSL connection

### DIFF
--- a/run_goose.py
+++ b/run_goose.py
@@ -51,13 +51,28 @@ def main():
     parser.add_argument("--wait", type=int, default=30, help="Wait for connection for X seconds")
     args = parser.parse_args()
 
-    db_connection_string = "postgresql://{}:{}@{}:{}/{}?sslmode=require".format(
+    
+
+    db_connection_string = "postgresql://{}:{}@{}:{}/{}".format(
         quote(os.environ["MF_METADATA_DB_USER"]),
         quote(os.environ["MF_METADATA_DB_PSWD"]),
         os.environ["MF_METADATA_DB_HOST"],
         os.environ["MF_METADATA_DB_PORT"],
         os.environ["MF_METADATA_DB_NAME"],
     )
+
+    _ssl_mode = os.environ["MF_METADATA_DB_SSL_MODE"]
+    _ssl_cert_path = os.environ["MF_METADATA_DB_SSL_CERT_PATH"]
+    _ssl_key_path = os.environ["MF_METADATA_DB_SSL_KEY_PATH"]
+    _ssl_root_cert_path = os.environ["MF_METADATA_DB_SSL_ROOT_CERT"]
+    ssl_query = ""
+    if(_ssl_mode == "require"):
+        ssl_query = "sslmode=require"
+        if _ssl_cert_path is not None: ssl_query = ssl_query + "&sslcert="+_ssl_cert_path
+        if _ssl_key_path is not None: ssl_query = ssl_query + "&sslkey="+_ssl_key_path
+        if _ssl_root_cert_path is not None: ssl_query = ssl_query + "&sslrootcert="+_ssl_root_cert_path
+    else: ssl_query = "sslmode=disable"
+    db_connection_string = db_connection_string + "?" + ssl_query
 
     if args.wait:
         wait_for_postgres(db_connection_string, timeout_seconds=args.wait)

--- a/run_goose.py
+++ b/run_goose.py
@@ -51,7 +51,7 @@ def main():
     parser.add_argument("--wait", type=int, default=30, help="Wait for connection for X seconds")
     args = parser.parse_args()
 
-    db_connection_string = "postgresql://{}:{}@{}:{}/{}?sslmode=disable".format(
+    db_connection_string = "postgresql://{}:{}@{}:{}/{}?sslmode=require".format(
         quote(os.environ["MF_METADATA_DB_USER"]),
         quote(os.environ["MF_METADATA_DB_PSWD"]),
         os.environ["MF_METADATA_DB_HOST"],

--- a/services/utils/__init__.py
+++ b/services/utils/__init__.py
@@ -248,7 +248,7 @@ class DBConfiguration(object):
     @property
     def connection_string_url(self):
         # postgresql://[user[:password]@][host][:port][/dbname][?param1=value1&...]
-        return f'postgresql://{quote(self._user)}:{quote(self._password)}@{self._host}:{self._port}/{self._database_name}?sslmode=disable'
+        return f'postgresql://{quote(self._user)}:{quote(self._password)}@{self._host}:{self._port}/{self._database_name}?sslmode=require'
 
     @property
     def dsn(self):

--- a/services/utils/__init__.py
+++ b/services/utils/__init__.py
@@ -193,6 +193,10 @@ class DBConfiguration(object):
                  user: str = "postgres",
                  password: str = "postgres",
                  database_name: str = "postgres",
+                 ssl_mode: str = "disabled",
+                 ssl_cert_path: str = None,
+                 ssl_key_path: str = None,
+                 ssl_root_cert_path: str = None,
                  prefix="MF_METADATA_DB_",
                  pool_min: int = 1,
                  pool_max: int = 10,
@@ -209,6 +213,10 @@ class DBConfiguration(object):
         self._user = os.environ.get(prefix + "USER", user)
         self._password = os.environ.get(prefix + "PSWD", password)
         self._database_name = os.environ.get(prefix + "NAME", database_name)
+        self._ssl_mode = os.environ.get(prefix+"SSL_MODE", ssl_mode)
+        self._ssl_cert_path = os.environ.get(prefix+"SSL_CERT_PATH", ssl_cert_path)
+        self._ssl_key_path = os.environ.get(prefix+"SSL_KEY_PATH", ssl_key_path),
+        self._ssl_root_cert_path = os.environ.get(prefix+"SSL_ROOT_CERT_PATH", ssl_root_cert_path)
         conn_str_required_values = [
             self._host,
             self._port,
@@ -248,8 +256,16 @@ class DBConfiguration(object):
     @property
     def connection_string_url(self):
         # postgresql://[user[:password]@][host][:port][/dbname][?param1=value1&...]
-        return f'postgresql://{quote(self._user)}:{quote(self._password)}@{self._host}:{self._port}/{self._database_name}?sslmode=require'
-
+        # return f'postgresql://{quote(self._user)}:{quote(self._password)}@{self._host}:{self._port}/{self._database_name}?sslmode=require'
+        base_url = f'postgresql://{quote(self._user)}:{quote(self._password)}@{self._host}:{self._port}/{self._database_name}'
+        ssl_query = ''
+        if(self._ssl_mode == 'require'):
+            ssl_query = 'sslmode=require'
+            if self._ssl_cert_path is not None: ssl_query = ssl_query + '&sslcert='+self._ssl_cert_path
+            if self._ssl_key_path is not None: ssl_query = ssl_query + '&sslkey='+self._ssl_key_path
+            if self._ssl_root_cert_path is not None: ssl_query = ssl_query + '&sslrootcert='+self._ssl_root_cert_path
+        else: ssl_query = 'sslmode=disable'
+        return base_url + '?' + ssl_query
     @property
     def dsn(self):
         if self._dsn is None:


### PR DESCRIPTION
Currently metaflow-service (metadata-service) does not support ssl connection to postgresql database. 

PR adds options to connect through SSL. 

Options are configurable by environment variables:
- MF_METADATA_DB_SSL_MODE (defaults to 'disable', must be set to 'require' if ssl is needed)
- MF_METADATA_DB_SSL_CERT_PATH (defaults to None, metadata services will use systems default SSL context)
- MF_METADATA_DB_SSL_KEY_PATH (defaults to None, metadata services will use systems default SSL context)
- MF_METADATA_DB_SSL_ROOT_CERT_PATH (defaults to None, metadata services will use systems default SSL context)

