### PR TITLE
fix: GitHub test workflow stop containers issues

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -78,7 +78,7 @@ jobs:
           POSTGRES_PASSWORD: test
           POSTGRES_DB: test
         options: >-
-          --health-cmd pg_isready -d test -U test
+          --health-cmd "pg_isready -d test -U test"
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -78,7 +78,7 @@ jobs:
           POSTGRES_PASSWORD: test
           POSTGRES_DB: test
         options: >-
-          --health-cmd pg_isready
+          --health-cmd pg_isready -d test -U test
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5


### PR DESCRIPTION
- try to get rid of `FATAL:  role "root" does not exist` in test workflow Stop Container step.