### PR TITLE
chore: fix Tox Pylint step

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,7 @@ deps =
 commands = pytest --cov=services
 passenv = MF_METADATA_DB_HOST,MF_METADATA_DB_PORT,MF_METADATA_DB_USER,MF_METADATA_DB_PSWD,MF_METADATA_DB_NAME,MF_UI_METADATA_PORT,MF_UI_METADATA_HOST
 extras = tests
+allowlist_externals = pylint
 
 [testenv:pylint]
 commands = pylint -E services --ignored-modules=psycopg2.errors,pygit2


### PR DESCRIPTION
- add pylint to allowedlist_externals for tox config