### PR TITLE
chore: update python version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [3.7]
+        python-version: [3.11]
 
     steps:
       - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
@@ -32,7 +32,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [3.7]
+        python-version: [3.11]
 
     steps:
       - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
@@ -52,7 +52,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [3.7]
+        python-version: [3.11]
 
     steps:
       - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
@@ -87,7 +87,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [3.7]
+        python-version: [3.11]
         golang-version: ["^1.14.5"]
 
     env:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20.5 as goose
+FROM golang:1.20.2-buster as goose
 RUN go install github.com/pressly/goose/v3/cmd/goose@v3.9.0
 
 FROM python:3.11.4-slim-bookworm

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM golang:1.20.5 as goose
 RUN go install github.com/pressly/goose/v3/cmd/goose@v3.9.0
 
-FROM python:3.11-bookworm
+FROM python:3.11-slim-bookworm
 COPY --from=goose /go/bin/goose /usr/local/bin/
 
 ARG BUILD_TIMESTAMP
@@ -16,6 +16,9 @@ ENV UI_VERSION=$UI_VERSION
 
 ENV FEATURE_RUN_GROUPS=0
 ENV FEATURE_DEBUG_VIEW=1
+
+RUN apt-get update -y \
+    && apt-get -y install libpq-dev unzip gcc curl
 
 RUN pip3 install virtualenv requests
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,8 @@
-FROM golang:1.20.2-buster
+FROM golang:1.20.5 as goose
+RUN go install github.com/pressly/goose/v3/cmd/goose@v3.9.0
+
+FROM python:3.11-bookworm
+COPY --from=goose /go/bin/goose /usr/local/bin/
 
 ARG BUILD_TIMESTAMP
 ARG BUILD_COMMIT_HASH
@@ -12,11 +16,6 @@ ENV UI_VERSION=$UI_VERSION
 
 ENV FEATURE_RUN_GROUPS=0
 ENV FEATURE_DEBUG_VIEW=1
-
-RUN go install github.com/pressly/goose/v3/cmd/goose@v3.9.0
-
-RUN apt-get update -y \
-    && apt-get -y install python3.11 python3-pip libpq-dev unzip
 
 RUN pip3 install virtualenv requests
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,9 @@ RUN apt-get update -y \
 
 RUN pip3 install virtualenv requests
 
+# TODO: possibly unused virtualenv. See if it can be removed
 RUN virtualenv /opt/v_1_0_1 -p python3
+# All of the official deployment templates reference this virtualenv for launching services.
 RUN virtualenv /opt/latest -p python3
 
 RUN /opt/v_1_0_1/bin/pip install https://github.com/Netflix/metaflow-service/archive/1.0.1.zip

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ ENV FEATURE_DEBUG_VIEW=1
 RUN go install github.com/pressly/goose/v3/cmd/goose@v3.9.0
 
 RUN apt-get update -y \
-    && apt-get -y install python3.7 python3-pip libpq-dev unzip
+    && apt-get -y install python3.11 python3-pip libpq-dev unzip
 
 RUN pip3 install virtualenv requests
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM golang:1.20.5 as goose
 RUN go install github.com/pressly/goose/v3/cmd/goose@v3.9.0
 
-FROM python:3.11-slim-bookworm
+FROM python:3.11.4-slim-bookworm
 COPY --from=goose /go/bin/goose /usr/local/bin/
 
 ARG BUILD_TIMESTAMP

--- a/Dockerfile.metadata_service
+++ b/Dockerfile.metadata_service
@@ -1,4 +1,4 @@
-FROM python:3.8
+FROM python:3.11
 ADD services/__init__.py /root/services/
 ADD services/data /root/services/data
 ADD services/utils /root/services/utils

--- a/Dockerfile.metadata_service
+++ b/Dockerfile.metadata_service
@@ -1,4 +1,8 @@
-FROM python:3.11.4
+FROM python:3.11.4-slim-bookworm
+
+RUN apt-get update -y \
+    && apt-get -y install libpq-dev gcc
+
 ADD services/__init__.py /root/services/
 ADD services/data /root/services/data
 ADD services/utils /root/services/utils

--- a/Dockerfile.metadata_service
+++ b/Dockerfile.metadata_service
@@ -1,4 +1,4 @@
-FROM python:3.7
+FROM python:3.8
 ADD services/__init__.py /root/services/
 ADD services/data /root/services/data
 ADD services/utils /root/services/utils

--- a/Dockerfile.metadata_service
+++ b/Dockerfile.metadata_service
@@ -1,4 +1,4 @@
-FROM python:3.11
+FROM python:3.11.4
 ADD services/__init__.py /root/services/
 ADD services/data /root/services/data
 ADD services/utils /root/services/utils

--- a/Dockerfile.migration_service
+++ b/Dockerfile.migration_service
@@ -1,8 +1,11 @@
 FROM golang:1.20.2 AS goose
 RUN go install github.com/pressly/goose/v3/cmd/goose@v3.9.0
 
-FROM python:3.11.4
+FROM python:3.11.4-slim-bookworm
 COPY --from=goose /go/bin/goose /usr/local/bin/
+
+RUN apt-get update -y \
+    && apt-get -y install libpq-dev
 
 ADD services/__init__.py /root/services/__init__.py
 ADD services/utils /root/services/utils

--- a/Dockerfile.migration_service
+++ b/Dockerfile.migration_service
@@ -1,7 +1,7 @@
-FROM golang:1.16.3 AS goose
-RUN go get -u github.com/pressly/goose/cmd/goose
+FROM golang:1.20.2 AS goose
+RUN go install github.com/pressly/goose/v3/cmd/goose@v3.9.0
 
-FROM python:3.7
+FROM python:3.8
 COPY --from=goose /go/bin/goose /usr/local/bin/
 
 ADD services/__init__.py /root/services/__init__.py

--- a/Dockerfile.migration_service
+++ b/Dockerfile.migration_service
@@ -1,7 +1,7 @@
 FROM golang:1.20.2 AS goose
 RUN go install github.com/pressly/goose/v3/cmd/goose@v3.9.0
 
-FROM python:3.8
+FROM python:3.11
 COPY --from=goose /go/bin/goose /usr/local/bin/
 
 ADD services/__init__.py /root/services/__init__.py

--- a/Dockerfile.migration_service
+++ b/Dockerfile.migration_service
@@ -1,7 +1,7 @@
 FROM golang:1.20.2 AS goose
 RUN go install github.com/pressly/goose/v3/cmd/goose@v3.9.0
 
-FROM python:3.11
+FROM python:3.11.4
 COPY --from=goose /go/bin/goose /usr/local/bin/
 
 ADD services/__init__.py /root/services/__init__.py

--- a/Dockerfile.service.test
+++ b/Dockerfile.service.test
@@ -1,7 +1,7 @@
 FROM golang:1.20.2 AS goose
 RUN go install github.com/pressly/goose/v3/cmd/goose@v3.9.0
 
-FROM python:3.11
+FROM python:3.11.4
 COPY --from=goose /go/bin/goose /usr/local/bin/
 
 RUN pip install tox

--- a/Dockerfile.service.test
+++ b/Dockerfile.service.test
@@ -1,7 +1,7 @@
 FROM golang:1.20.2 AS goose
 RUN go install github.com/pressly/goose/v3/cmd/goose@v3.9.0
 
-FROM python:3.8
+FROM python:3.11
 COPY --from=goose /go/bin/goose /usr/local/bin/
 
 RUN pip install tox

--- a/Dockerfile.service.test
+++ b/Dockerfile.service.test
@@ -1,7 +1,7 @@
-FROM golang:1.16.3 AS goose
-RUN go get -u github.com/pressly/goose/cmd/goose
+FROM golang:1.20.2 AS goose
+RUN go install github.com/pressly/goose/v3/cmd/goose@v3.9.0
 
-FROM python:3.7
+FROM python:3.8
 COPY --from=goose /go/bin/goose /usr/local/bin/
 
 RUN pip install tox

--- a/Dockerfile.service.test
+++ b/Dockerfile.service.test
@@ -1,8 +1,11 @@
 FROM golang:1.20.2 AS goose
 RUN go install github.com/pressly/goose/v3/cmd/goose@v3.9.0
 
-FROM python:3.11.4
+FROM python:3.11.4-slim-bookworm
 COPY --from=goose /go/bin/goose /usr/local/bin/
+
+RUN apt-get update -y \
+    && apt-get -y install libpq-dev gcc
 
 RUN pip install tox
 

--- a/Dockerfile.ui_service
+++ b/Dockerfile.ui_service
@@ -1,4 +1,4 @@
-FROM python:3.11.4
+FROM python:3.11.4-slim-bookworm
 
 ARG UI_ENABLED="1"
 ARG UI_VERSION="v1.3.2"
@@ -14,6 +14,9 @@ ENV BUILD_COMMIT_HASH=$BUILD_COMMIT_HASH
 ARG CUSTOM_QUICKLINKS
 
 ENV CUSTOM_QUICKLINKS=$CUSTOM_QUICKLINKS
+
+RUN apt-get update -y \
+    && apt-get -y install libpq-dev unzip gcc curl
 
 ADD services/__init__.py /root/services/__init__.py
 ADD services/data /root/services/data

--- a/Dockerfile.ui_service
+++ b/Dockerfile.ui_service
@@ -1,4 +1,4 @@
-FROM python:3.8
+FROM python:3.11
 
 ARG UI_ENABLED="1"
 ARG UI_VERSION="v1.3.2"

--- a/Dockerfile.ui_service
+++ b/Dockerfile.ui_service
@@ -1,4 +1,4 @@
-FROM python:3.11
+FROM python:3.11.4
 
 ARG UI_ENABLED="1"
 ARG UI_VERSION="v1.3.2"

--- a/Dockerfile.ui_service
+++ b/Dockerfile.ui_service
@@ -1,4 +1,4 @@
-FROM python:3.7.13
+FROM python:3.8
 
 ARG UI_ENABLED="1"
 ARG UI_VERSION="v1.3.2"

--- a/run_goose.py
+++ b/run_goose.py
@@ -72,7 +72,7 @@ def main():
 
     p = Popen(
         [
-            "/go/bin/goose",
+            "goose",
             "-dir",
             "/root/services/migration_service/migration_files/",
             "postgres",

--- a/services/ui_backend_service/requirements.txt
+++ b/services/ui_backend_service/requirements.txt
@@ -4,7 +4,7 @@ throttler==1.2.0
 packaging
 psycopg2
 aiopg
-pygit2==1.6.1
+pygit2==1.12.1
 aiohttp_cors==0.7.0
 metaflow>=2.7.7
 click==8.0.3

--- a/services/ui_backend_service/tests/unit_tests/custom_flowgraph_test.py
+++ b/services/ui_backend_service/tests/unit_tests/custom_flowgraph_test.py
@@ -82,7 +82,7 @@ if __name__ == '__main__':
           "start": {
               "name": "start",
               "type": "start",
-              "line": 9,
+              "line": 10,
               "doc": "",
               "next": [
                   "regular_step"
@@ -92,7 +92,7 @@ if __name__ == '__main__':
           "regular_step": {
               "name": "regular_step",
               "type": "split-static",
-              "line": 13,
+              "line": 14,
               "doc": "Just a regular step that splits into two",
               "next": [
                   "prepare_foreach",
@@ -103,7 +103,7 @@ if __name__ == '__main__':
           "prepare_foreach": {
               "name": "prepare_foreach",
               "type": "split-foreach",
-              "line": 22,
+              "line": 23,
               "doc": "Generate a list of things to process in the first foreach",
               "next": [
                   "process_foreach"
@@ -113,7 +113,7 @@ if __name__ == '__main__':
           "process_foreach": {
               "name": "process_foreach",
               "type": "linear",
-              "line": 34,
+              "line": 35,
               "doc": "",
               "next": [
                   "join"
@@ -123,7 +123,7 @@ if __name__ == '__main__':
           "join": {
               "name": "join",
               "type": "join",
-              "line": 46,
+              "line": 47,
               "doc": "",
               "next": [
                   "ultimate_join"
@@ -133,7 +133,7 @@ if __name__ == '__main__':
           "prepare_foreach2": {
               "name": "prepare_foreach2",
               "type": "split-foreach",
-              "line": 28,
+              "line": 29,
               "doc": "Generate a list of things to process in the second foreach",
               "next": [
                   "process_foreach2"
@@ -143,7 +143,7 @@ if __name__ == '__main__':
           "process_foreach2": {
               "name": "process_foreach2",
               "type": "linear",
-              "line": 39,
+              "line": 41,
               "doc": "Process second foreach and retry in case of failures",
               "next": [
                   "join2"
@@ -153,7 +153,7 @@ if __name__ == '__main__':
           "join2": {
               "name": "join2",
               "type": "join",
-              "line": 50,
+              "line": 51,
               "doc": "",
               "next": [
                   "after_join"
@@ -163,7 +163,7 @@ if __name__ == '__main__':
           "after_join": {
               "name": "after_join",
               "type": "linear",
-              "line": 54,
+              "line": 55,
               "doc": "",
               "next": [
                   "ultimate_join"
@@ -173,7 +173,7 @@ if __name__ == '__main__':
           "ultimate_join": {
               "name": "ultimate_join",
               "type": "join",
-              "line": 59,
+              "line": 60,
               "doc": "Join both process path results",
               "next": [
                   "end"
@@ -183,7 +183,7 @@ if __name__ == '__main__':
           "end": {
               "name": "end",
               "type": "end",
-              "line": 64,
+              "line": 65,
               "doc": "",
               "next": [],
               "foreach_artifact": None

--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,6 @@ setup(
         "Intended Audience :: Developers",
         "Topic :: Software Development :: Build Tools",
         "License :: OSI Approved :: Apache Software License",
-        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,6 @@ setup(
         "Intended Audience :: Developers",
         "Topic :: Software Development :: Build Tools",
         "License :: OSI Approved :: Apache Software License",
-        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.11",
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py37
+envlist = py38
 
 [testenv]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py38
+envlist = py311
 
 [testenv]
 deps =


### PR DESCRIPTION
In preparation for Python 3.7 being End-of-Life, update the Python version used for all the services Docker images

Addresses #352 

TODO:

- [x] Figure out if the /opt/v1_0_1 setup in Dockerfile is required or not.
- [ ] Look into why AST parsing linenumber counting changed from python 3.7 -> 3.8+
- [x] Update Github actions to target Python 3.11 