### PR TITLE
fix: add missing packaging dependency

### DIFF
--- a/services/metadata_service/requirements.txt
+++ b/services/metadata_service/requirements.txt
@@ -1,4 +1,5 @@
 aiohttp >= 3.8.1, < 4
+packaging
 psycopg2
 boto3
 aiopg

--- a/services/migration_service/requirements.txt
+++ b/services/migration_service/requirements.txt
@@ -1,3 +1,4 @@
 aiohttp >= 3.8.1, < 4
+packaging
 psycopg2
 aiopg

--- a/services/ui_backend_service/requirements.txt
+++ b/services/ui_backend_service/requirements.txt
@@ -1,6 +1,7 @@
 aiohttp >= 3.8.1, < 4
 pyee==8.0.1
 throttler==1.2.0
+packaging
 psycopg2
 aiopg
 pygit2==1.6.1


### PR DESCRIPTION
- adds `packaging` as a dependency after deprecation fixes. Tests were passing because `tox` already depends on it.