### PR TITLE
Add Google Cloud dependencies to UI backend service (#375)

### DIFF
--- a/services/ui_backend_service/requirements.txt
+++ b/services/ui_backend_service/requirements.txt
@@ -10,3 +10,4 @@ metaflow>=2.9.6
 click==8.0.3
 azure-storage-blob==12.13.1
 azure-identity==1.10.0
+google-cloud-storage~=2.10.0


### PR DESCRIPTION
Addresses https://github.com/Netflix/metaflow-service/issues/375

Adding `google-cloud-storage` dependencies to the UI backend service, so that viewing task logs and DAG structure no longer breaks when these artifacts are stored on GCS.