### PR TITLE
Upgrade Github actions used in `dockerimage` action

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -10,11 +10,11 @@ jobs:
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
       -
         name: Docker meta
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@818d4b7b91585d195f67373fd9cb0332e31a7175 # v4.6.0
         with:
           images: |
             netflixoss/metaflow_metadata_service
@@ -23,17 +23,14 @@ jobs:
             type=sha
             type=raw,value=latest
       -
-        name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-      -
         name: Login to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc # v2.2.0
         with:
           username: ${{ secrets.DOCKER_USERNAME_NETFLIX_OSS }}
           password: ${{ secrets.DOCKER_AUTH_TOKEN_NETFLIX_OSS }}
       -
-        name: Build and push
-        uses: docker/build-push-action@v4
+        name: Build and push # We have a single-platform build, so use of setup-buildx-action is currently omitted.
+        uses: docker/build-push-action@2eb1c1961a95fc15694676618e422e8ba1d63825 # v4.1.1
         with:
           context: .
           push: true

--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -2,22 +2,40 @@ name: Docker Image CI
 
 on:
   release:
-    branches: [ master ]    
+    branches: [ master ]
 
 jobs:
-
   build:
-
     runs-on: ubuntu-latest
-
     steps:
-      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
-      - uses: docker/build-push-action@3e7a4f6646880c6f63758d73ac32392d323eaf8f # v1.1.2
+      -
+        name: Checkout
+        uses: actions/checkout@v3
+      -
+        name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: |
+            netflixoss/metaflow_metadata_service
+          tags: |
+            type=semver,pattern={{raw}}
+            type=sha
+            type=raw,value=latest
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      -
+        name: Login to Docker Hub
+        uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKER_USERNAME_NETFLIX_OSS }}
           password: ${{ secrets.DOCKER_AUTH_TOKEN_NETFLIX_OSS }}
-          repository: netflixoss/metaflow_metadata_service
-          tag_with_ref: true
-          tag_with_sha: true
-          tags: "latest"
-          dockerfile: ${{ github.workspace }}/Dockerfile
+      -
+        name: Build and push
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
This `dockerimage` action in this repository is using old versions of `checkout` & `build-push-action`. 

This is causing some warnings during the actions. (See [here](https://github.com/Netflix/metaflow-service/actions/runs/5685654496) for more details.) This includes a warning `The following actions uses node12 which is deprecated and will be forced to run on node16`.

This PR updates the versions of `checkout` & `build-push-action` used in the `dockerimage` action. 

Due to the age of the old versions, to obtain like-for-like functionality the upgrade requires the additional use of `metadata-action`, `setup-buildx-action` & `login-action` actions. 