### PR TITLE
Docker changes to support M1 laptops

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM golang:1.20.2-buster as goose
 RUN go install github.com/pressly/goose/v3/cmd/goose@v3.9.0
 
-FROM python:3.11.4-slim-bookworm
+FROM python:3.11.4
 COPY --from=goose /go/bin/goose /usr/local/bin/
 
 ARG BUILD_TIMESTAMP

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM golang:1.20.2-buster as goose
 RUN go install github.com/pressly/goose/v3/cmd/goose@v3.9.0
 
-FROM python:3.11.4
+FROM python:3.11.4-slim-bookworm
 COPY --from=goose /go/bin/goose /usr/local/bin/
 
 ARG BUILD_TIMESTAMP

--- a/Dockerfile.metadata_service
+++ b/Dockerfile.metadata_service
@@ -1,4 +1,4 @@
-FROM python:3.11.4-slim-bookworm
+FROM python:3.11.4
 
 RUN apt-get update -y \
     && apt-get -y install libpq-dev gcc

--- a/Dockerfile.metadata_service
+++ b/Dockerfile.metadata_service
@@ -1,4 +1,4 @@
-FROM python:3.11.4
+FROM python:3.11.4-bookworm
 
 RUN apt-get update -y \
     && apt-get -y install libpq-dev gcc

--- a/Dockerfile.migration_service
+++ b/Dockerfile.migration_service
@@ -1,7 +1,7 @@
 FROM golang:1.20.2 AS goose
 RUN go install github.com/pressly/goose/v3/cmd/goose@v3.9.0
 
-FROM python:3.11.4-slim-bookworm
+FROM python:3.11.4
 COPY --from=goose /go/bin/goose /usr/local/bin/
 
 RUN apt-get update -y \

--- a/Dockerfile.migration_service
+++ b/Dockerfile.migration_service
@@ -1,7 +1,7 @@
 FROM golang:1.20.2 AS goose
 RUN go install github.com/pressly/goose/v3/cmd/goose@v3.9.0
 
-FROM python:3.11.4
+FROM python:3.11.4-bookworm
 COPY --from=goose /go/bin/goose /usr/local/bin/
 
 RUN apt-get update -y \

--- a/Dockerfile.migration_service
+++ b/Dockerfile.migration_service
@@ -10,7 +10,7 @@ RUN apt-get update -y \
 ADD services/__init__.py /root/services/__init__.py
 ADD services/utils /root/services/utils
 ADD services/migration_service /root/services/migration_service
-ADD setup.py setup.cfg /root/
+ADD setup.py setup.cfg run_goose.py /root/
 WORKDIR /root
 RUN pip install --editable .
 CMD migration_service

--- a/Dockerfile.service.test
+++ b/Dockerfile.service.test
@@ -1,7 +1,7 @@
 FROM golang:1.20.2 AS goose
 RUN go install github.com/pressly/goose/v3/cmd/goose@v3.9.0
 
-FROM python:3.11.4-slim-bookworm
+FROM python:3.11.4
 COPY --from=goose /go/bin/goose /usr/local/bin/
 
 RUN apt-get update -y \

--- a/Dockerfile.service.test
+++ b/Dockerfile.service.test
@@ -1,7 +1,7 @@
 FROM golang:1.20.2 AS goose
 RUN go install github.com/pressly/goose/v3/cmd/goose@v3.9.0
 
-FROM python:3.11.4
+FROM python:3.11.4-bookworm
 COPY --from=goose /go/bin/goose /usr/local/bin/
 
 RUN apt-get update -y \

--- a/Dockerfile.ui_service
+++ b/Dockerfile.ui_service
@@ -1,4 +1,4 @@
-FROM python:3.11.4
+FROM python:3.11.4-bookworm
 
 ARG UI_ENABLED="1"
 ARG UI_VERSION="v1.3.3"

--- a/Dockerfile.ui_service
+++ b/Dockerfile.ui_service
@@ -1,4 +1,4 @@
-FROM python:3.11.4-slim-bookworm
+FROM python:3.11.4
 
 ARG UI_ENABLED="1"
 ARG UI_VERSION="v1.3.3"

--- a/docker-compose.development.yml
+++ b/docker-compose.development.yml
@@ -1,6 +1,7 @@
 version: "3"
 services:
   ui_backend:
+    platform: linux/amd64
     build:
       context: .
       dockerfile: Dockerfile.ui_service
@@ -51,6 +52,7 @@ services:
     depends_on:
       - migration
   metadata:
+    platform: linux/amd64
     build:
       context: .
       dockerfile: Dockerfile.metadata_service
@@ -71,9 +73,10 @@ services:
       - migration
   migration:
     command: ["/opt/latest/bin/python3", "/root/run_goose.py"]
+    platform: linux/amd64
     build:
       context: .
-      dockerfile: Dockerfile
+      dockerfile: Dockerfile.migration_service
     volumes:
       - ./services:/root/services
     environment:

--- a/docker-compose.development.yml
+++ b/docker-compose.development.yml
@@ -72,7 +72,7 @@ services:
     depends_on:
       - migration
   migration:
-    command: ["/opt/latest/bin/python3", "/root/run_goose.py"]
+    command: ["python", "/root/run_goose.py"]
     platform: linux/amd64
     build:
       context: .


### PR DESCRIPTION
Context:

The docker build would fail on an M1 laptop with error messages like

```
Building wheels for collected packages: psycopg2
30.95   Building wheel for psycopg2 (setup.py): started
33.66   Building wheel for psycopg2 (setup.py): finished with status 'error'
33.71   error: subprocess-exited-with-error
33.71   
33.71   × python setup.py bdist_wheel did not run successfully.
33.71   │ exit code: 1
33.71   ╰─> [33 lines of output]
33.71       running bdist_wheel
33.71       running build
33.71       running build_py
33.71       creating build
33.71       creating build/lib.linux-x86_64-cpython-311
33.71       creating build/lib.linux-x86_64-cpython-311/psycopg2
33.71       copying lib/errorcodes.py -> build/lib.linux-x86_64-cpython-311/psycopg2
33.71       copying lib/errors.py -> build/lib.linux-x86_64-cpython-311/psycopg2
33.71       copying lib/extensions.py -> build/lib.linux-x86_64-cpython-311/psycopg2
33.71       copying lib/__init__.py -> build/lib.linux-x86_64-cpython-311/psycopg2
33.71       copying lib/sql.py -> build/lib.linux-x86_64-cpython-311/psycopg2
33.71       copying lib/_range.py -> build/lib.linux-x86_64-cpython-311/psycopg2
33.71       copying lib/tz.py -> build/lib.linux-x86_64-cpython-311/psycopg2
33.71       copying lib/pool.py -> build/lib.linux-x86_64-cpython-311/psycopg2
33.71       copying lib/_json.py -> build/lib.linux-x86_64-cpython-311/psycopg2
33.71       copying lib/extras.py -> build/lib.linux-x86_64-cpython-311/psycopg2
33.71       copying lib/_ipaddress.py -> build/lib.linux-x86_64-cpython-311/psycopg2
33.71       running build_ext
33.71       building 'psycopg2._psycopg' extension
33.71       creating build/temp.linux-x86_64-cpython-311
33.71       creating build/temp.linux-x86_64-cpython-311/psycopg
33.71       gcc -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -fPIC "-DPSYCOPG_VERSION=2.9.7 (dt dec pq3 ext lo64)" -DPSYCOPG_DEBUG=1 -DPG_VERSION_NUM=150003 -DHAVE_LO64=1 -DPSYCOPG_DEBUG=1 -I/usr/local/include/python3.11 -I. -I/usr/include/postgresql -I/usr/include/postgresql/15/server -I/usr/include/libxml2 -c psycopg/adapter_asis.c -o build/temp.linux-x86_64-cpython-311/psycopg/adapter_asis.o -Wdeclaration-after-statement
```

and

```
metaflow-service-ui_backend-1  | Traceback (most recent call last):
metaflow-service-ui_backend-1  |   File "/usr/local/bin/ui_backend_service", line 33, in <module>
metaflow-service-ui_backend-1  |     sys.exit(load_entry_point('metadata-service', 'console_scripts', 'ui_backend_service')())
metaflow-service-ui_backend-1  |   File "/usr/local/bin/ui_backend_service", line 25, in importlib_load_entry_point
metaflow-service-ui_backend-1  |     return next(matches).load()
metaflow-service-ui_backend-1  |   File "/usr/local/lib/python3.7/site-packages/importlib_metadata/__init__.py", line 208, in load
metaflow-service-ui_backend-1  |     module = import_module(match.group('module'))
metaflow-service-ui_backend-1  |   File "/usr/local/lib/python3.7/importlib/__init__.py", line 127, in import_module
metaflow-service-ui_backend-1  |     return _bootstrap._gcd_import(name[level:], package, level)
metaflow-service-ui_backend-1  |   File "<frozen importlib._bootstrap>", line 1006, in _gcd_import
metaflow-service-ui_backend-1  |   File "<frozen importlib._bootstrap>", line 983, in _find_and_load
metaflow-service-ui_backend-1  |   File "<frozen importlib._bootstrap>", line 967, in _find_and_load_unlocked
metaflow-service-ui_backend-1  |   File "<frozen importlib._bootstrap>", line 677, in _load_unlocked
metaflow-service-ui_backend-1  |   File "<frozen importlib._bootstrap_external>", line 728, in exec_module
metaflow-service-ui_backend-1  |   File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
metaflow-service-ui_backend-1  |   File "/root/services/ui_backend_service/ui_server.py", line 8, in <module>
metaflow-service-ui_backend-1  |     from services.utils import DBConfiguration, logging, ORIGIN_TO_ALLOW_CORS_FROM
metaflow-service-ui_backend-1  |   File "/root/services/utils/__init__.py", line 13, in <module>
metaflow-service-ui_backend-1  |     from packaging.version import Version, parse
metaflow-service-ui_backend-1  | ModuleNotFoundError: No module named 'packaging'
```

Fix:

Using the full version of python, rather than a slim one. The platform is also explicitly specified in the dev dockerfile.