### PR TITLE
In a previous commit, the detection of a failure became too aggressive.

### DIFF
--- a/services/ui_backend_service/data/db/tables/run.py
+++ b/services/ui_backend_service/data/db/tables/run.py
@@ -130,7 +130,7 @@ class AsyncRunTablePostgres(AsyncPostgresTable):
             WHEN end_attempt_ok IS NOT NULL AND end_attempt_ok.value IS FALSE
             THEN 'failed'
             WHEN {table_name}.last_heartbeat_ts IS NOT NULL
-                AND @(extract(epoch from now())-{table_name}.last_heartbeat_ts)<={heartbeat_threshold}
+                AND @(extract(epoch from now())-{table_name}.last_heartbeat_ts)<={heartbeat_cutoff}
             THEN 'running'
             ELSE 'failed'
         END) AS status

--- a/services/ui_backend_service/data/db/tables/run.py
+++ b/services/ui_backend_service/data/db/tables/run.py
@@ -111,7 +111,7 @@ class AsyncRunTablePostgres(AsyncPostgresTable):
             WHEN end_attempt_ok IS NOT NULL
             THEN end_attempt_ok.ts_epoch
             WHEN {table_name}.last_heartbeat_ts IS NOT NULL
-                AND @(extract(epoch from now())-{table_name}.last_heartbeat_ts)<={heartbeat_threshold}
+                AND @(extract(epoch from now())-{table_name}.last_heartbeat_ts)<={heartbeat_cutoff}
             THEN NULL
             ELSE {table_name}.last_heartbeat_ts*1000
         END) AS finished_at

--- a/services/ui_backend_service/data/db/tables/run.py
+++ b/services/ui_backend_service/data/db/tables/run.py
@@ -117,7 +117,6 @@ class AsyncRunTablePostgres(AsyncPostgresTable):
         END) AS finished_at
         """.format(
             table_name=table_name,
-            heartbeat_threshold=HEARTBEAT_THRESHOLD,
             heartbeat_cutoff=RUN_INACTIVE_CUTOFF_TIME,
         ),
         """
@@ -136,8 +135,6 @@ class AsyncRunTablePostgres(AsyncPostgresTable):
         END) AS status
         """.format(
             table_name=table_name,
-            heartbeat_threshold=HEARTBEAT_THRESHOLD,
-            cutoff=OLD_RUN_FAILURE_CUTOFF_TIME,
             heartbeat_cutoff=RUN_INACTIVE_CUTOFF_TIME,
         ),
         """
@@ -157,7 +154,6 @@ class AsyncRunTablePostgres(AsyncPostgresTable):
         END) AS duration
         """.format(
             table_name=table_name,
-            heartbeat_threshold=HEARTBEAT_THRESHOLD,
             cutoff=OLD_RUN_FAILURE_CUTOFF_TIME,
         ),
     ]


### PR DESCRIPTION
This remediates this by considering a run 'failed' if the hb hasn't been updated within heartbeat_cutoff time as opposed to the heartbeat_threshold time