### PR TITLE
chore: deprecated pkg_resources

### DIFF
--- a/services/metadata_service/api/utils.py
+++ b/services/metadata_service/api/utils.py
@@ -1,14 +1,14 @@
 import json
 from functools import wraps
 
-import pkg_resources
 import collections
 from aiohttp import web
 from multidict import MultiDict
+from importlib import metadata
 
 from services.utils import get_traceback_str
 
-version = pkg_resources.require("metadata_service")[0].version
+version = metadata.version("metadata_service")
 METADATA_SERVICE_VERSION = version
 METADATA_SERVICE_HEADER = 'METADATA_SERVICE_VERSION'
 

--- a/services/utils/__init__.py
+++ b/services/utils/__init__.py
@@ -2,7 +2,6 @@ import json
 import sys
 import os
 import traceback
-import pkg_resources
 from multidict import MultiDict
 from urllib.parse import urlencode, quote
 from aiohttp import web
@@ -11,8 +10,9 @@ from typing import Dict
 import logging
 import psycopg2
 from packaging.version import Version, parse
+from importlib import metadata
 
-version = pkg_resources.require("metadata_service")[0].version
+version = metadata.version("metadata_service")
 
 METADATA_SERVICE_VERSION = version
 METADATA_SERVICE_HEADER = 'METADATA_SERVICE_VERSION'


### PR DESCRIPTION
deprecated `pkg_resources` is blocking the execution of tests locally for whatever reason. Change to the preferred `importlib.metadata` fixes this.