### PR TITLE
fix: tone down run inactive cutoff default

### DIFF
--- a/services/ui_backend_service/data/db/tables/base.py
+++ b/services/ui_backend_service/data/db/tables/base.py
@@ -19,9 +19,9 @@ OLD_RUN_FAILURE_CUTOFF_TIME = int(
     os.environ.get("OLD_RUN_FAILURE_CUTOFF_TIME", 60 * 60 * 24 * 1000 * 1)
 )
 # Time before a run with a heartbeat will be considered inactive (and thus failed).
-# Default to 1 day (in seconds)
+# Default to 6 minutes (in seconds)
 RUN_INACTIVE_CUTOFF_TIME = int(
-    os.environ.get("RUN_INACTIVE_CUTOFF_TIME", 60 * 60 * 24 * 1)
+    os.environ.get("RUN_INACTIVE_CUTOFF_TIME", 60 * 6)
 )
 
 

--- a/services/ui_backend_service/data/db/tables/run.py
+++ b/services/ui_backend_service/data/db/tables/run.py
@@ -3,7 +3,6 @@ import time
 from typing import List, Tuple
 from .base import (
     AsyncPostgresTable,
-    HEARTBEAT_THRESHOLD,
     OLD_RUN_FAILURE_CUTOFF_TIME,
     RUN_INACTIVE_CUTOFF_TIME,
 )

--- a/services/ui_backend_service/docs/environment.md
+++ b/services/ui_backend_service/docs/environment.md
@@ -73,7 +73,7 @@ The threshold parameters for heartbeat checks can also be configured when necess
 
 `OLD_RUN_FAILURE_CUTOFF_TIME` [ for runs that do not have a heartbeat, controls at what point a running status run should be considered failed. Default is 1 day (in milliseconds)]
 
-`RUN_INACTIVE_CUTOFF_TIME` [ for runs that have a heartbeat, controls how long a run with a failed heartbeat should wait for possibly queued tasks to start and resume heartbeat updates. Default is 1 day (in seconds)]
+`RUN_INACTIVE_CUTOFF_TIME` [ for runs that have a heartbeat, controls how long a run with a failed heartbeat should wait for possibly queued tasks to start and resume heartbeat updates. Default is 6 minutes (in seconds)]
 
 ## Baseurl configuration
 


### PR DESCRIPTION
Changes the Run inactive cutoff time default to 6 minutes from 1 day. After the latest query changes this is used to determine whether a run heartbeat is expired or not.
This will give runs that have tasks stuck in a scheduler the 6 minutes grace period for any of them to launch, after which the run level heartbeat will expire and mark the run as failed. If a task starts after this, the run would flip back to `running` status, otherwise remaining `failed` (correctly)

Having to wait a whole day for runs to be marked as failed by default is such a huge departure from the way the UI used to display failed runs that this change is proposed as a possible middle-ground instead of reverting the query changes from #338 . 