### PR TITLE
Speed up log lookup in UI backend

### DIFF
--- a/services/ui_backend_service/tests/integration_tests/log_test.py
+++ b/services/ui_backend_service/tests/integration_tests/log_test.py
@@ -5,6 +5,8 @@ from .utils import (
     add_flow, add_run, add_step, add_task,
     _test_list_resources
 )
+from ...api.log import LogException
+
 pytestmark = [pytest.mark.integration_tests]
 
 
@@ -37,7 +39,10 @@ async def test_log_default_response(cli, db):
         assert page == 1
         assert reverse_order is False
         assert output_raw is False
-        return [], 1
+        if task['attempt_id'] == 0:
+            return [], 1
+        else:
+            raise LogException(id='MetaflowNotFound')
 
     with mock.patch("services.ui_backend_service.api.log.read_and_output", new=read_and_output):
         _, data = await _test_list_resources(cli, db, "/flows/{flow_id}/runs/{run_number}/steps/{step_name}/tasks/{task_id}/logs/out".format(**_task), 200, None)

--- a/services/ui_backend_service/tests/integration_tests/utils.py
+++ b/services/ui_backend_service/tests/integration_tests/utils.py
@@ -323,14 +323,14 @@ async def _test_single_resource(cli, db: AsyncPostgresDB, path: str, expected_st
     return resp.status, data
 
 
-def _test_dict_approx(actual, expected, approx_keys, threshold=1000):
+def _test_dict_approx(actual, expected, approx_keys, threshold=5000):
     "Assert that two dicts are almost equal, allowing for some leeway on specified keys"
     # NOTE: This is mainly required for testing resources that produce data during query execution. For example
     # when using extract(epoch from now()) we can not accurately expect what the timestamp returned from the api should be.
     # TODO: If possible, a less error prone solution would be to somehow mock/freeze the now() on a per-test basis.
     for k, v in actual.items():
         if k in approx_keys:
-            assert v == pytest.approx(expected[k], rel=threshold)
+            assert v == pytest.approx(expected[k], abs=threshold)
         else:
             assert v == expected[k]
 


### PR DESCRIPTION
We've run into issues with the STDOUT/STDERR log view feature in the
Metaflow UI.  The current code path does an expensive join query to
determine the latest attempt, which ends up timing out.  However, the
relevant request is already supplying the attempt_id provided by the UI
from an earlier query, so there is no need to perform this verification.

Additional unrelated change: one of the existing tests was failing due
to the async duration not falling within the expected tolerance.  This
tolerance appeared to be specified incorrectly, using '1000' as a
relative tolerance.  I assume this was meant to be absolute tolerance,
as in 'this request should take (0 +- 1000 ms) to complete."  In my
development environment I needed 5000 to guarantee success with the
async nature of the tests.
