### PR TITLE
chore: revert bundle fix for further discussion

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,8 +22,12 @@ RUN apt-get update -y \
 
 RUN pip3 install virtualenv requests
 
+# TODO: possibly unused virtualenv. See if it can be removed
+RUN virtualenv /opt/v_1_0_1 -p python3
 # All of the official deployment templates reference this virtualenv for launching services.
 RUN virtualenv /opt/latest -p python3
+
+RUN /opt/v_1_0_1/bin/pip install https://github.com/Netflix/metaflow-service/archive/1.0.1.zip
 
 ADD services/__init__.py /root/services/
 ADD services/data/service_configs.py /root/services/

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ long_description = open_and_read_if_exists("README.md")
 
 setup(
     name="metadata_service",
-    version="2.4.6",
+    version="2.4.5",
     license="Apache License 2.0",
     description="Metadata Service: backend service for Metaflow",
     long_description=long_description,


### PR DESCRIPTION
Reverting the removal of `/opt/v_1_0_1` virtual environment from the released Docker image for further discussion.
Also reverting version bump of unreleased 2.4.6.