### PR TITLE
[cache-memory-leak] Fix Memory leak in cache server

### DIFF
--- a/services/ui_backend_service/data/cache/client/cache_async_client.py
+++ b/services/ui_backend_service/data/cache/client/cache_async_client.py
@@ -56,7 +56,7 @@ class CacheAsyncClient(CacheClient):
 
             if self.logger.isEnabledFor(logging.INFO):
                 self.logger.info(
-                    "Pending stream keys: {}".format(list(self.pending_requests))
+                    "Pending stream keys: {}".format(len(list(self.pending_requests)))
                 )
         except JSONDecodeError as ex:
             if self.logger.isEnabledFor(logging.INFO):
@@ -73,6 +73,7 @@ class CacheAsyncClient(CacheClient):
         if self._is_alive:
             self._is_alive = False
             self._proc.terminate()
+            self.logger.info("Waiting for cache server to terminate")
             await self._proc.wait()
 
     async def send_request(self, blob):

--- a/services/ui_backend_service/data/cache/client/cache_server.py
+++ b/services/ui_backend_service/data/cache/client/cache_server.py
@@ -9,9 +9,12 @@ import multiprocessing
 from datetime import datetime
 from collections import deque
 from itertools import chain
+import time
 
 from .cache_worker import execute_action
 from .cache_async_client import OP_WORKER_CREATE, OP_WORKER_TERMINATE
+
+import sys
 
 import click
 
@@ -30,6 +33,10 @@ def send_message(op: str, data: dict):
         'op': op,
         **data
     }), flush=True)
+
+
+CACHE_PROCESS_POOL_REFRESH_DURATION = int(os.environ.get("CACHE_PROCESS_POOL_REFRESH_DURATION", 20 * 60))
+CACHE_PROCESS_POOL_FORCE_REFRESH_DURATION = int(os.environ.get("CACHE_PROCESS_POOL_FORCE_REFRESH_DURATION", 2 * 60))
 
 
 class CacheServerException(Exception):
@@ -101,6 +108,7 @@ class Worker(object):
         self.pool = pool
         self.callback = callback
         self.error_callback = error_callback
+        self.created_on = time.time()
 
         try:
             self.tempdir = self.filestore.open_tempdir(
@@ -198,6 +206,7 @@ class Scheduler(object):
             initializer=self.init_process,
             maxtasksperchild=512,  # Recycle each worker once 512 tasks have been completed
         )
+        self._pool_started_on = time.time()
 
     def init_process(self):
         echo("Init process %s pid: %s" % (multiprocessing.current_process().name, os.getpid()))
@@ -257,16 +266,64 @@ class Scheduler(object):
             send_message(OP_WORKER_TERMINATE, worker._worker_details())
             return None
 
+    def verify_stale_workers(self):
+        time_to_pool_refresh = CACHE_PROCESS_POOL_REFRESH_DURATION - (time.time() - self._pool_started_on)
+        # active_pids = ",".join([f"{c.name}[{c.pid}]" for c in multiprocessing.active_children()])
+        echo(
+            "number of workers: %d, number of pending requests: %d; Pool Refresh in : %d" % (
+                len(self.workers), len(self.pending_requests), time_to_pool_refresh)
+        )
+
+    def cleanup_if_necessary(self):
+        time_to_pool_refresh = CACHE_PROCESS_POOL_REFRESH_DURATION - (time.time() - self._pool_started_on)
+        if time_to_pool_refresh > 0:
+            return
+        # if workers are still running 30 seconds after the pool refresh timeout, then cleanup
+        no_workers_are_running = len(self.workers) == 0 and len(self.pending_requests) == 1
+        pool_needs_refresh = time_to_pool_refresh <= 0
+        pool_force_refresh = time_to_pool_refresh < - CACHE_PROCESS_POOL_FORCE_REFRESH_DURATION
+        if pool_force_refresh:
+            echo("Refreshing the pool as no workers are running and no pending requests are there.")
+            self.cleanup_workers()
+        elif no_workers_are_running and pool_needs_refresh:
+            echo("Refreshing the pool as no workers are running and no pending requests are there.")
+            self.cleanup_workers()
+
+    def cleanup_workers(self):
+        for worker in self.workers:
+            worker.echo("Terminating worker")
+            worker.terminate()
+            self.pending_requests.remove(worker.request['idempotency_token'])
+        self.workers = []
+        self.cleanup_pool()
+
+    def cleanup_pool(self):
+        self.pool.terminate()
+        self.pool.join()
+        del self.pool
+        self.pool = multiprocessing.Pool(
+            processes=self.max_workers,
+            initializer=self.init_process,
+            maxtasksperchild=512,  # Recycle each worker once 512 tasks have been completed
+        )
+        self._pool_started_on = time.time()
+
     def loop(self):
         def new_worker_from_request():
             worker = self.schedule()
             if worker:
                 self.workers.append(worker)
                 return worker
+        _counter = time.time()
 
         while True:
             self.process_incoming_request()
             new_worker_from_request()
+            if time.time() - _counter > 30:
+                self.verify_stale_workers()
+                _counter = time.time()
+
+            self.cleanup_if_necessary()
             time.sleep(0.1)
 
     def _callback(self, worker, res):

--- a/services/ui_backend_service/tests/unit_tests/get_log_file_action_test.py
+++ b/services/ui_backend_service/tests/unit_tests/get_log_file_action_test.py
@@ -218,26 +218,30 @@ def test_tail_log_provider(m_get_log_size, m_get_log_content):
     for case in [
         {
             "max_tail_chars": 10000,
+            "max_total_size": 200*1024,
             "expected_tail_lines": 1000,
             "expect_to_truncate": False,
         },
         {
             "max_tail_chars": 1000,
+            "max_total_size": 200*1024,
             "expected_tail_lines": 333,
             "expect_to_truncate": True,
         },
         {
             "max_tail_chars": 100,
+            "max_total_size": 200*1024,
             "expected_tail_lines": 33,
             "expect_to_truncate": True,
         },
         {
             "max_tail_chars": 0,
+            "max_total_size": 200*1024,
             "expected_tail_lines": 0,
             "expect_to_truncate": True,
         },
     ]:
-        provider = TailLogProvider(case["max_tail_chars"])
+        provider = TailLogProvider(case["max_tail_chars"], max_log_size_in_kb=case["max_total_size"])
         # Log size should still report full log size (even if only partial content returned)
         assert provider.get_log_hash(mock_task, STDOUT) == mock_log_size
         tail_log_content = provider.get_log_content(mock_task, STDOUT)


### PR DESCRIPTION

## Key changes
- Recreate the multiprocess pool at a regular cadence to avoid memory leaks
- Since the pool was never removed it resulted in unbounded growth of memory.
- Added a log size constraint to the `tail` based Log cache setting. 