### PR TITLE
[card-cache] optimizations to avoid deadlocks

### DIFF
--- a/services/ui_backend_service/api/card.py
+++ b/services/ui_backend_service/api/card.py
@@ -153,11 +153,12 @@ class CardsApi(object):
             task,
             hash,
         )
+        html_reload_script = "<script>window.needsReload = true;</script><body></body>"
         if cards is None:
             return web.Response(
                 content_type="text/html",
                 status=404,
-                body="Card not found for task. Possibly still being processed. Please refresh page to check again.",
+                body=html_reload_script,
             )
 
         if cards and hash in cards:
@@ -275,7 +276,7 @@ async def get_card_data_for_task_async(
         step_name=task.get("step_name"),
         task_id=task.get("task_name") or task.get("task_id"),
     )
-    await cache_client.cache_manager.register(pathspec)
+    await cache_client.cache_manager.register(pathspec, lock_timeout=0.2)
     _local_cache = cache_client.cache_manager.get_local_cache(pathspec, card_hash)
     if not _local_cache.read_ready():
         # Since this is a data update call we can return a 404 and the client

--- a/services/ui_backend_service/data/cache/store.py
+++ b/services/ui_backend_service/data/cache/store.py
@@ -37,7 +37,9 @@ CACHE_DAG_MAX_ACTIONS = int(os.environ.get("CACHE_DAG_MAX_ACTIONS", 16))
 CACHE_DAG_STORAGE_LIMIT = int(os.environ.get("CACHE_DAG_STORAGE_LIMIT", DISK_SIZE // 4))
 CACHE_LOG_MAX_ACTIONS = int(os.environ.get("CACHE_LOG_MAX_ACTIONS", 8))
 CACHE_LOG_STORAGE_LIMIT = int(os.environ.get("CACHE_LOG_STORAGE_LIMIT", DISK_SIZE // 5))
-CARD_CACHE_DISK_CLEANUP_INTERVAL = int(os.environ.get("CARD_CACHE_DISK_CLEANUP_INTERVAL", 60 * 60 * 4))
+CARD_CACHE_REGULAR_CLEANUP_INTERVAL = int(
+    os.environ.get("CARD_CACHE_PROCESS_CLEANUP_INTERVAL", 60 * 60 * 24 * 5)
+)  # 5 Days
 
 
 class CacheStore(object):
@@ -123,18 +125,15 @@ class CardCacheStore(object):
         self.cache_manager = CardCacheManager()
 
     async def start_cache(self):
-        self._cleanup_coroutine = asyncio.create_task(
-            self.cache_manager.start_process_cleanup_routine(120)
-        )
-        self._disk_cleanup_coroutine = asyncio.create_task(
-            self.cache_manager.cleanup_disk_routine(CARD_CACHE_DISK_CLEANUP_INTERVAL)
+        self._regualar_cleanup_routine = asyncio.create_task(
+            self.cache_manager.regular_cleanup_routine(
+                CARD_CACHE_REGULAR_CLEANUP_INTERVAL
+            )
         )
 
     async def stop_cache(self):
-        self._cleanup_coroutine.cancel()
-        await self._cleanup_coroutine
-        self._disk_cleanup_coroutine.cancel()
-        await self._disk_cleanup_coroutine
+        self._regualar_cleanup_routine.cancel()
+        await self._regualar_cleanup_routine
 
 
 class ArtifactCacheStore(object):


### PR DESCRIPTION
[card-cache] optimizations to avoid deadlocks
- deadlocks happened when cleanups coincided with heavy load 
- tests simulating a cleanup (disk + shared-objects) and heavy load together were successfully able to reproduce the deadlock situation
- Locking at the `context` level: 
    - Each time we want to clean up we lock to create a new context
    - All directories/processes are written within that new context.
    - Switching this context which ensure that all new processes get created differently and the cleanup process can safely remove everything. 
    - Context also sets the read/write directory for the cache object used in the API endpoint.
    - All locking on the API side now always time-bound. The code time's out if it can't acquire a lock. 
    - The method ensure that all operations won't in-definately hold the lock.
- Changed defaults for minimum amount to time to wait for cards in the cache process to 20 seconds (helps make things snappier)
- Added `timings` dict in card cache to optimize loading cycles (Ensured that it is set based on a per-card basis)
