### PR TITLE
Add missing metadata index.

### DIFF
--- a/services/migration_service/migration_files/20240509201906_add_missing_metadata_index.sql
+++ b/services/migration_service/migration_files/20240509201906_add_missing_metadata_index.sql
@@ -1,0 +1,10 @@
+-- +goose Up
+-- +goose StatementBegin
+CREATE INDEX IF NOT EXISTS metadata_v3_idx_str_ids_a_key_with_run_number_task_id
+    ON metadata_v3 (flow_id, run_number, step_name, task_id, field_name)
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+DROP INDEX IF EXISTS metadata_v3_idx_str_ids_a_key_with_run_number_task_id;
+-- +goose StatementEnd


### PR DESCRIPTION
We're running metaflow-service v2.4.4, and noticed the metaflow-backend was missing some metadata_v3 indices. This fixes the issue by adding the expected index.