### PR TITLE
feature: massive logs streaming

### DIFF
--- a/docker-compose.development.yml
+++ b/docker-compose.development.yml
@@ -25,6 +25,7 @@ services:
       - MF_UI_METADATA_HOST=${MF_UI_METADATA_HOST:-0.0.0.0}
       - MF_METADATA_DB_POOL_MIN=1
       - MF_METADATA_DB_POOL_MAX=10
+      - METAFLOW_S3_RETRY_COUNT=0
       - LOGLEVEL=INFO
       - AIOPG_ECHO=0
       - UI_ENABLED=0
@@ -51,6 +52,7 @@ services:
       - NOTIFICATIONS=$NOTIFICATIONS
       - GA_TRACKING_ID=none
       - PLUGINS=$PLUGINS
+      - AWS_PROFILE=$AWS_PROFILE
     depends_on:
       - migration
   metadata:

--- a/services/ui_backend_service/data/cache/client/cache_action.py
+++ b/services/ui_backend_service/data/cache/client/cache_action.py
@@ -31,7 +31,7 @@ class CacheAction(object):
         is proxied by `cache_client` as a client-facing API
         of the action.
 
-        Function returns a four-tuple:
+        Function returns a tuple:
         1. `message`: an arbitrary JSON-encodable payload that
            is passed to `execute`.
         2. `obj_keys`: a list of keys that the action promises
@@ -43,8 +43,9 @@ class CacheAction(object):
            be purged from the cache before other objects.
         5. `invalidate_cache`: boolean to indicate if existing
            cache keys should be invalidated.
+        6. `ephemeral_storage_path` : optional path for persisting files across cache action invocations
         """
-        # return message, obj_keys, stream_key, disposable_keys, invalidate_cache
+        # return message, obj_keys, stream_key, disposable_keys, invalidate_cache, ephemeral_storage_path
         raise NotImplementedError
 
     @classmethod
@@ -106,7 +107,7 @@ class Check(CacheAction):
     @classmethod
     def format_request(cls, *args, **kwargs):
         key = 'check-%s' % uuid.uuid4()
-        return None, [key], None, [key], False
+        return None, [key], None, [key], False, None
 
     @classmethod
     def response(cls, keys_objs):

--- a/services/ui_backend_service/data/cache/client/cache_client.py
+++ b/services/ui_backend_service/data/cache/client/cache_client.py
@@ -198,7 +198,7 @@ class CacheClient(object):
     def _action(self, cls):
 
         def _call(*args, **kwargs):
-            msg, keys, stream_key, disposable_keys, invalidate_cache =\
+            msg, keys, stream_key, disposable_keys, invalidate_cache, ephemeral_path =\
                 cls.format_request(*args, **kwargs)
             future = CacheFuture(keys, stream_key, self, cls, self._root)
             if future.key_paths_ready() and not invalidate_cache:
@@ -217,7 +217,8 @@ class CacheClient(object):
                                  stream_key=stream_key,
                                  message=msg,
                                  disposable_keys=disposable_keys,
-                                 invalidate_cache=invalidate_cache)
+                                 invalidate_cache=invalidate_cache,
+                                 ephemeral_path=ephemeral_path)
 
             return self.request_and_return([req] if req else [], future)
 
@@ -292,7 +293,8 @@ def server_request(op,
                    message=None,
                    disposable_keys=None,
                    idempotency_token=None,
-                   invalidate_cache=False):
+                   invalidate_cache=False,
+                   ephemeral_path=None):
 
     if idempotency_token is None:
         fields = [op]
@@ -315,5 +317,6 @@ def server_request(op,
         'message': message,
         'idempotency_token': token,
         'disposable_keys': disposable_keys,
-        'invalidate_cache': invalidate_cache
+        'invalidate_cache': invalidate_cache,
+        'ephemeral_path': ephemeral_path
     }

--- a/services/ui_backend_service/data/cache/client/cache_server.py
+++ b/services/ui_backend_service/data/cache/client/cache_server.py
@@ -170,7 +170,8 @@ class Worker(object):
         missing = self.filestore.commit(self.tempdir,
                                         self.request['keys'],
                                         self.request['stream_key'],
-                                        self.request['disposable_keys'])
+                                        self.request['disposable_keys'],
+                                        self.request['ephemeral_path'])
         if missing:
             self.echo("failed to produce the following keys: %s"
                       % ','.join(missing))

--- a/services/ui_backend_service/data/cache/client/cache_store.py
+++ b/services/ui_backend_service/data/cache/client/cache_store.py
@@ -292,7 +292,7 @@ class CacheStore(object):
                     self.total_size += sz
             else:
                 missing.append(key)
-        
+
         # Additionally, if the ephemeral path contains anything,
         # we want to make sure that these objects are tracked for GC as well.
         if ephemeral_path is not None and os.path.exists(ephemeral_path):
@@ -308,7 +308,6 @@ class CacheStore(object):
                         sz = (sz - old_size)
                     self.total_size += sz
                     _insert(self.objects_queue, p, sz)
-
 
         self._gc_objects()
         return missing

--- a/services/ui_backend_service/data/cache/generate_dag_action.py
+++ b/services/ui_backend_service/data/cache/generate_dag_action.py
@@ -58,7 +58,8 @@ class GenerateDag(CacheAction):
             [result_key], \
             stream_key, \
             [stream_key], \
-            invalidate_cache
+            invalidate_cache, \
+            None
 
     @classmethod
     def response(cls, keys_objs):

--- a/services/ui_backend_service/data/cache/get_data_action.py
+++ b/services/ui_backend_service/data/cache/get_data_action.py
@@ -49,7 +49,8 @@ class GetData(CacheAction):
             target_keys, \
             stream_key, \
             [stream_key], \
-            invalidate_cache
+            invalidate_cache, \
+            None
 
     @classmethod
     def response(cls, keys_objs):

--- a/services/ui_backend_service/data/cache/get_log_file_action.py
+++ b/services/ui_backend_service/data/cache/get_log_file_action.py
@@ -453,12 +453,16 @@ def paginated_result(content_iterator: Callable, page: int = 1, line_total: int 
     total_pages = max(-(line_total // -limit), 1) if limit else 1
     _offset = limit * (total_pages - page) if reverse_order else limit * (page - 1)
     loglines = []
+
     # lines included in the page should be [start, end[
     for lineno, item in enumerate(content_iterator()):
-        ts, line = item
-        if limit and lineno > (_offset + limit):
+        # OOB guard
+        if page > total_pages:
             break
-        if _offset and lineno <= _offset:
+        ts, line = item
+        if limit and lineno >= (_offset + limit):
+            break
+        if _offset and lineno < _offset:
             continue
         line = line if output_raw else {"row": lineno, "timestamp": ts, "line": line}
         if reverse_order:

--- a/services/ui_backend_service/data/cache/get_log_file_action.py
+++ b/services/ui_backend_service/data/cache/get_log_file_action.py
@@ -210,7 +210,8 @@ def fetch_logs(task: Task, to_path: str, logtype: str, force_reload: bool = Fals
     # TODO: This could theoretically be a part of the Metaflow client instead.
     paths = []
     stream = 'stderr' if logtype == STDERR else 'stdout'
-    log_location = task.metadata_dict.get('log_location_%s' % stream)
+    meta_dict = task.metadata_dict
+    log_location = meta_dict.get('log_location_%s' % stream)
 
     os.makedirs(to_path, exist_ok=True)
     log_paths = {}
@@ -239,7 +240,6 @@ def fetch_logs(task: Task, to_path: str, logtype: str, force_reload: bool = Fals
         log_paths[name] = os.path.join(to_path, name)
     else:
         # MFLog support
-        meta_dict = task.metadata_dict
         ds_type = meta_dict.get("ds-type")
         ds_root = meta_dict.get("ds-root")
         if ds_type is None or ds_root is None:

--- a/services/ui_backend_service/data/cache/get_log_file_action.py
+++ b/services/ui_backend_service/data/cache/get_log_file_action.py
@@ -207,8 +207,8 @@ def fetch_logs(task: Task, log_hash: str, logtype: str, force_reload: bool = Fal
     stream = 'stderr' if logtype == STDERR else 'stdout'
     log_location = task.metadata_dict.get('log_location_%s' % stream)
     
-    # TODO: move this into the cache_data directory and introduce some GC
-    log_tmp_path = os.path.join(".", "log_temp", log_hash)
+    # TODO: Check that this is also under GC
+    log_tmp_path = os.path.join("cache_data", "log", "blobs" , log_hash)
     os.makedirs(log_tmp_path, exist_ok=True)
     log_paths = {}
     

--- a/services/ui_backend_service/data/cache/get_log_file_action.py
+++ b/services/ui_backend_service/data/cache/get_log_file_action.py
@@ -143,7 +143,7 @@ class GetLogFile(CacheAction):
             # check if log has grown since last time.
             current_hash = log_provider.get_log_hash(task, logtype)
             log_hash_changed = previous_log_hash is None or previous_log_hash != current_hash
-            
+
             log_path = os.path.join(".", "cache_data", "log", "BLOBS", log_key)
             local_paths = fetch_logs(task, log_path, logtype, log_hash_changed)
             if log_hash_changed:

--- a/services/ui_backend_service/data/cache/get_log_file_action.py
+++ b/services/ui_backend_service/data/cache/get_log_file_action.py
@@ -445,7 +445,8 @@ class FullLogProvider(LogProviderBase):
 
 def paginated_result(content_iterator: Callable, page: int = 1, line_total: int = 0, limit: int = 0,
                      reverse_order: bool = False, output_raw=False):
-    total_pages = max(line_total // limit, 1) if limit else 1
+    # take the ceil for the number of pages so we dont end up with discarded lines
+    total_pages = max(-(line_total // -limit), 1) if limit else 1
     _offset = limit * (total_pages - page) if reverse_order else limit * (page - 1)
     loglines = []
     for lineno, item in enumerate(content_iterator()):

--- a/services/ui_backend_service/data/cache/search_artifacts_action.py
+++ b/services/ui_backend_service/data/cache/search_artifacts_action.py
@@ -62,7 +62,8 @@ class SearchArtifacts(CacheAction):
             [result_key, *artifact_keys], \
             stream_key, \
             [stream_key, result_key], \
-            invalidate_cache
+            invalidate_cache, \
+            None
 
     @classmethod
     def response(cls, keys_objs):

--- a/services/ui_backend_service/tests/integration_tests/log_test.py
+++ b/services/ui_backend_service/tests/integration_tests/log_test.py
@@ -94,6 +94,8 @@ async def test_log_download_response(cli, db):
 
     async def read_and_output(cache_client, task, logtype, limit=0, page=1, reverse_order=False, output_raw=False):
         assert output_raw is True
+        if page>1:
+            return "", 1
         return "some logs", 1
 
     with mock.patch("services.ui_backend_service.api.log.read_and_output", new=read_and_output):


### PR DESCRIPTION
Alternative approach to streaming massive logs. Does not require any changes to Metaflow client side.

Intended to supersede #423 

TODO:

- [x] support legacy logs
- [x] reliable cache/GC of the raw log downloads on disk so they can be reused across cache action calls.