### PR TITLE
feature: version table triggers

### DIFF
--- a/services/data/postgres_async_db.py
+++ b/services/data/postgres_async_db.py
@@ -759,8 +759,7 @@ class AsyncMetadataTablePostgres(AsyncPostgresTable):
     primary_keys = ["flow_id", "run_number",
                     "step_name", "task_id", "field_name"]
     trigger_keys = ["flow_id", "run_number",
-                    "step_name", "task_id", "field_name", "value", "tags"]
-    trigger_operations = ["INSERT"]
+                    "step_name", "task_id", "field_name", "value"]
     select_columns = keys
 
     async def add_metadata(
@@ -828,7 +827,6 @@ class AsyncArtifactTablePostgres(AsyncPostgresTable):
     primary_keys = ["flow_id", "run_number",
                     "step_name", "task_id", "attempt_id", "name"]
     trigger_keys = primary_keys
-    trigger_operations = ["INSERT"]
     select_columns = keys
 
     async def add_artifact(

--- a/services/data/postgres_async_db.py
+++ b/services/data/postgres_async_db.py
@@ -40,6 +40,7 @@ operator_match = re.compile('([^:]*):([=><]+)$')
 
 # use a ddmmyyy timestamp as the version for triggers
 TRIGGER_VERSION = "18012024"
+TRIGGER_NAME_PREFIX = "notify_ui"
 
 class _AsyncPostgresDB(object):
     connection = None
@@ -456,7 +457,7 @@ class PostgresUtils(object):
 
                 triggers_to_cleanup = [
                     res[0] for res in results
-                    if TRIGGER_VERSION not in res[0]
+                    if res[0].startswith(TRIGGER_NAME_PREFIX) and TRIGGER_VERSION not in res[0]
                 ]
                 if triggers_to_cleanup:
                     logging.getLogger("TriggerSetup").info("Cleaning up old triggers: %s" % triggers_to_cleanup)
@@ -474,7 +475,7 @@ class PostgresUtils(object):
         if not keys:
             pass
 
-        name_prefix = "notify_ui_%s" % TRIGGER_VERSION
+        name_prefix = "%s_%s" % (TRIGGER_NAME_PREFIX, TRIGGER_VERSION)
         operations = operations
         _commands = ["""
         CREATE OR REPLACE FUNCTION {schema}.{prefix}_{table}() RETURNS trigger

--- a/services/data/postgres_async_db.py
+++ b/services/data/postgres_async_db.py
@@ -42,6 +42,7 @@ operator_match = re.compile('([^:]*):([=><]+)$')
 TRIGGER_VERSION = "18012024"
 TRIGGER_NAME_PREFIX = "notify_ui"
 
+
 class _AsyncPostgresDB(object):
     connection = None
     flow_table_postgres = None
@@ -439,7 +440,7 @@ class PostgresUtils(object):
                         await cur.execute(command)
             finally:
                 cur.close()
-    
+
     @staticmethod
     async def cleanup_triggers(db: _AsyncPostgresDB, table_name):
         "Cleans up old versions of table triggers"
@@ -474,7 +475,14 @@ class PostgresUtils(object):
                 cur.close()
 
     @staticmethod
-    async def setup_trigger_notify(db: _AsyncPostgresDB, table_name, keys: List[str] = None, schema=DB_SCHEMA_NAME, operations: List[str] = None, conditions: List[str] = None):
+    async def setup_trigger_notify(
+        db: _AsyncPostgresDB,
+        table_name,
+        keys: List[str] = None,
+        schema=DB_SCHEMA_NAME,
+        operations: List[str] = None,
+        conditions: List[str] = None
+    ):
         if not keys:
             pass
 


### PR DESCRIPTION
this adds versioning to table triggers created by the ui_service.

triggers will now have a timestamp as part of their name, and as part of the trigger setup process when launching the ui_backend it will attempt to clean up table triggers and trigger functions that do not have the correct timestamp (or lack one completely) but otherwise match our trigger naming schema.

Custom triggers not set up by the ui_backend will remain untouched by the changes