### PR TITLE
Disable Python buffering of standard output/error streams

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,5 +46,9 @@ RUN /root/services/ui_backend_service/download_ui.sh
 ADD services/migration_service /root/services/migration_service
 RUN pip3 install -r /root/services/migration_service/requirements.txt
 
+# The program uses `print` to log messages, so disable buffering to output the messages as soon as
+# they are written.
+ENV PYTHONUNBUFFERED=1
+
 RUN chmod 777 /root/services/migration_service/run_script.py
 CMD python3  services/migration_service/run_script.py

--- a/Dockerfile.metadata_service
+++ b/Dockerfile.metadata_service
@@ -10,4 +10,9 @@ ADD services/metadata_service /root/services/metadata_service
 ADD setup.py setup.cfg /root/
 WORKDIR /root
 RUN pip install --editable .
+
+# The program uses `print` to log messages, so disable buffering to output the messages as soon as
+# they are written.
+ENV PYTHONUNBUFFERED=1
+
 CMD metadata_service

--- a/Dockerfile.migration_service
+++ b/Dockerfile.migration_service
@@ -13,4 +13,9 @@ ADD services/migration_service /root/services/migration_service
 ADD setup.py setup.cfg run_goose.py /root/
 WORKDIR /root
 RUN pip install --editable .
+
+# The program uses `print` to log messages, so disable buffering to output the messages as soon as
+# they are written.
+ENV PYTHONUNBUFFERED=1
+
 CMD migration_service

--- a/Dockerfile.ui_service
+++ b/Dockerfile.ui_service
@@ -32,4 +32,8 @@ RUN /root/services/ui_backend_service/download_ui.sh
 
 RUN pip install --editable .
 
+# The program uses `print` to log messages, so disable buffering to output the messages as soon as
+# they are written.
+ENV PYTHONUNBUFFERED=1
+
 CMD ui_backend_service


### PR DESCRIPTION
The code uses `print` to log messages, so disable buffering to output the messages as soon as they are written.

Fixes #437.