### PR TITLE
fix: version string parse failure leads to runs starting without a heartbeat

### DIFF
--- a/services/metadata_service/tests/unit_tests/task_test.py
+++ b/services/metadata_service/tests/unit_tests/task_test.py
@@ -8,9 +8,12 @@ expectations = [
     (["2.2.12"], False),
     (["metaflow_version:0.5"], False),
     (["metaflow_version:1.13"], False),
+    (["metaflow_version:1"], False),
     (["metaflow_version:1.14.0"], True),
     (["metaflow_version:1.22.1"], True),
     (["metaflow_version:2.0.0"], False),
+    (["metaflow_version:2.0"], False),
+    (["metaflow_version:2"], False),
     (["metaflow_version:2.0.5"], False),
     (["metaflow_version:2.2.11"], False),
     (["metaflow_version:2.2.12"], True),
@@ -18,6 +21,10 @@ expectations = [
     (["metaflow_version:2.3"], True),
     (["metaflow_version:2.3.1"], True),
     (["metaflow_version:2.4.1"], True),
+    (["metaflow_version:2.12.24.post9-git2a5367b+ob(v1)"], True),
+    (["metaflow_version:2.12.24+inconsequential+trailing-string"], True),
+    (["metaflow_version:2.12.24.break"], True),
+    (["metaflow_version:3"], True),
 ]
 
 


### PR DESCRIPTION
some Metaflow client versions failed the `Version` parsing which lead to runs starting initially without a heartbeat. This meant that runs start up with a 'failed' status with the recent service changes