### PR TITLE
feature: add task filtering based on metadata

### DIFF
--- a/services/data/models.py
+++ b/services/data/models.py
@@ -166,6 +166,8 @@ class TaskRow(object):
         tags=None,
         system_tags=None,
         last_heartbeat_ts=None,
+        metadata_field_name=None,  # Unused but required for serialization
+        metadata_value=None,  # Unused but required for serialization
     ):
         self.flow_id = flow_id
         self.run_number = run_number

--- a/services/data/models.py
+++ b/services/data/models.py
@@ -166,8 +166,6 @@ class TaskRow(object):
         tags=None,
         system_tags=None,
         last_heartbeat_ts=None,
-        metadata_field_name=None,  # Unused but required for serialization
-        metadata_value=None,  # Unused but required for serialization
     ):
         self.flow_id = flow_id
         self.run_number = run_number

--- a/services/data/postgres_async_db.py
+++ b/services/data/postgres_async_db.py
@@ -757,6 +757,7 @@ class AsyncTaskTablePostgres(AsyncPostgresTable):
                 enable_joins=True,
                 select_columns=["task_name, task_id"]
             )
+
             # flatten the ids in the response
             def _format_id(row):
                 # pick the task_name over task_id

--- a/services/data/postgres_async_db.py
+++ b/services/data/postgres_async_db.py
@@ -708,11 +708,6 @@ class AsyncTaskTablePostgres(AsyncPostgresTable):
         )
     ]
 
-    @property
-    def select_columns(self):
-        # NOTE: We must use a function scope in order to be able to access the table_name variable for list comprehension.
-        return ["{table_name}.{col} AS {col}".format(table_name=self.table_name, col=k) for k in self.keys]
-
     join_columns = [
         "metadata.field_name as metadata_field_name",
         "metadata.value as metadata_value"

--- a/services/data/postgres_async_db.py
+++ b/services/data/postgres_async_db.py
@@ -755,10 +755,13 @@ class AsyncTaskTablePostgres(AsyncPostgresTable):
                 values=[v for k, v in filter_dict.items() if v is not None],
                 order=["task_id"],
                 enable_joins=True,
-                select_columns=["task_id"]
+                select_columns=["task_name, task_id"]
             )
             # flatten the ids in the response
-            flattened_response = DBResponse(body=[id for row in db_response.body for id in row], response_code=db_response.response_code)
+            def _format_id(row):
+                # pick the task_name over task_id
+                return row[0] or row[1]
+            flattened_response = DBResponse(body=[_format_id(row) for row in db_response.body], response_code=db_response.response_code)
             return flattened_response, pagination
 
     async def get_task(self, flow_id: str, run_id: str, step_name: str,

--- a/services/data/postgres_async_db.py
+++ b/services/data/postgres_async_db.py
@@ -830,7 +830,7 @@ class AsyncMetadataTablePostgres(AsyncPostgresTable):
         }
         conditions = [f"{k} = %s" for k, v in filter_dict.items() if v is not None]
         values = [v for k, v in filter_dict.items() if v is not None]
-        
+
         if field_name:
             conditions.append("field_name = %s")
             values.append(field_name)

--- a/services/data/postgres_async_db.py
+++ b/services/data/postgres_async_db.py
@@ -217,9 +217,9 @@ class AsyncPostgresTable(object):
 
     async def find_records(self, conditions: List[str] = None, values=[], fetch_single=False,
                            limit: int = 0, offset: int = 0, order: List[str] = None, expanded=False,
-                           enable_joins=False, cur: aiopg.Cursor = None, select_columns: List[str] = None) -> Tuple[DBResponse, DBPagination]:
+                           enable_joins=False, cur: aiopg.Cursor = None) -> Tuple[DBResponse, DBPagination]:
         sql_template = """
-        SELECT {select_columns} FROM (
+        SELECT * FROM (
             SELECT
                 {keys}
             FROM {table_name}
@@ -239,14 +239,11 @@ class AsyncPostgresTable(object):
             where="WHERE {}".format(" AND ".join(conditions)) if conditions else "",
             order_by="ORDER BY {}".format(", ".join(order)) if order else "",
             limit="LIMIT {}".format(limit) if limit else "",
-            offset="OFFSET {}".format(offset) if offset else "",
-            select_columns="*" if select_columns is None else ",".join(select_columns)
+            offset="OFFSET {}".format(offset) if offset else ""
         ).strip()
 
-        # We should serialize the response if no custom select columns were provided, otherwise we return the raw result.
-        should_serialize = select_columns is None
         return await self.execute_sql(select_sql=select_sql, values=values, fetch_single=fetch_single,
-                                      expanded=expanded, limit=limit, offset=offset, cur=cur, serialize=should_serialize)
+                                      expanded=expanded, limit=limit, offset=offset, cur=cur)
 
     async def execute_sql(self, select_sql: str, values=[], fetch_single=False,
                           expanded=False, limit: int = 0, offset: int = 0,

--- a/services/data/postgres_async_db.py
+++ b/services/data/postgres_async_db.py
@@ -700,17 +700,24 @@ class AsyncTaskTablePostgres(AsyncPostgresTable):
                 {table_name}.flow_id = metadata.flow_id AND
                 {table_name}.run_number = metadata.run_number AND
                 {table_name}.step_name = metadata.step_name AND
-                {table_name}.task_id = metadata.task_id AND
-        ) as metadata
+                {table_name}.task_id = metadata.task_id
+        ) as metadata on true
         """.format(
             metadata_table=metadata_table_name,
             table_name=table_name
         )
     ]
+
+    @property
+    def select_columns(self):
+        # NOTE: We must use a function scope in order to be able to access the table_name variable for list comprehension.
+        return ["{table_name}.{col} AS {col}".format(table_name=self.table_name, col=k) for k in self.keys]
+
     join_columns = [
         "metadata.field_name as metadata_field_name",
         "metadata.value as metadata_value"
     ]
+
     async def add_task(self, task: TaskRow, fill_heartbeat=False):
         # todo backfill run_number if missing?
         dict = {

--- a/services/data/postgres_async_db.py
+++ b/services/data/postgres_async_db.py
@@ -689,7 +689,6 @@ class AsyncTaskTablePostgres(AsyncPostgresTable):
     trigger_keys = primary_keys
     select_columns = keys
     step_table_name = AsyncStepTablePostgres.table_name
-    metadata_table_name = METADATA_TABLE_NAME
 
     async def add_task(self, task: TaskRow, fill_heartbeat=False):
         # todo backfill run_number if missing?

--- a/services/metadata_service/api/task.py
+++ b/services/metadata_service/api/task.py
@@ -1,7 +1,6 @@
 from services.data import TaskRow
 from services.data.postgres_async_db import AsyncPostgresDB
 from services.data.tagging_utils import apply_run_tags_to_db_response
-from services.data.db_utils import translate_run_key
 from services.utils import has_heartbeat_capable_version_tag, read_body
 from services.metadata_service.api.utils import format_response, \
     handle_exceptions

--- a/services/metadata_service/api/task.py
+++ b/services/metadata_service/api/task.py
@@ -130,10 +130,6 @@ class TaskApi(object):
         metadata_field = request.query.get("metadata_field_name", None)
         pattern = request.query.get("pattern", None)
 
-        # We cannot do anything without filter values
-        if metadata_field is None and pattern is None:
-            raise web.HTTPBadRequest(reason="A metadata_field_name or metadata_value are required for filtering.")
-
         db_response, _ = await self._async_metadata_table.get_filtered_task_pathspecs(flow_id, run_number, step_name, metadata_field, pattern)
         return db_response
 

--- a/services/metadata_service/api/task.py
+++ b/services/metadata_service/api/task.py
@@ -39,6 +39,7 @@ class TaskApi(object):
                              self.tasks_heartbeat)
         self._async_table = AsyncPostgresDB.get_instance().task_table_postgres
         self._async_run_table = AsyncPostgresDB.get_instance().run_table_postgres
+        self._async_metadata_table = AsyncPostgresDB.get_instance().metadata_table_postgres
         self._db = AsyncPostgresDB.get_instance()
 
     @format_response
@@ -133,7 +134,7 @@ class TaskApi(object):
         if metadata_field is None and pattern is None:
             raise web.HTTPBadRequest(reason="A metadata_field_name or metadata_value are required for filtering.")
 
-        db_response, _ = await self._async_table.get_filtered_task_pathspecs(flow_id, run_number, step_name, metadata_field, pattern)
+        db_response, _ = await self._async_metadata_table.get_filtered_task_pathspecs(flow_id, run_number, step_name, metadata_field, pattern)
         return db_response
 
     @format_response

--- a/services/metadata_service/api/task.py
+++ b/services/metadata_service/api/task.py
@@ -109,9 +109,9 @@ class TaskApi(object):
           in: "query"
           description: "Metadata field name to filter with"
           type: "string"
-        - name: "metadata_value"
+        - name: "pattern"
           in: "query"
-          description: "Value for the metadata field to filter on"
+          description: "A regexp pattern to filter the metadata values on"
           type: "string"
         produces:
         - text/plain
@@ -127,13 +127,13 @@ class TaskApi(object):
 
         # possible filters
         metadata_field = request.query.get("metadata_field_name", None)
-        metadata_value = request.query.get("metadata_value", None)
+        pattern = request.query.get("pattern", None)
 
         # We cannot do anything without filter values
-        if metadata_field is None and metadata_value is None:
+        if metadata_field is None and pattern is None:
             raise web.HTTPBadRequest(reason="A metadata_field_name or metadata_value are required for filtering.")
 
-        db_response, _ = await self._async_table.get_filtered_task_ids(flow_id, run_number, step_name, metadata_field, metadata_value)
+        db_response, _ = await self._async_table.get_filtered_task_pathspecs(flow_id, run_number, step_name, metadata_field, pattern)
         return db_response
 
     @format_response

--- a/services/metadata_service/api/utils.py
+++ b/services/metadata_service/api/utils.py
@@ -59,6 +59,8 @@ def handle_exceptions(func):
     async def wrapper(*args, **kwargs):
         try:
             return await func(*args, **kwargs)
+        except web.HTTPClientError as ex:
+            return ServiceResponse(ex.status_code, ex.reason)
         except Exception as err:
             return http_500(str(err))
 

--- a/services/metadata_service/tests/integration_tests/task_test.py
+++ b/services/metadata_service/tests/integration_tests/task_test.py
@@ -244,8 +244,8 @@ async def test_filtered_tasks_mixed_ids_get(cli, db):
     _second_task = (await add_task(db, flow_id=_step["flow_id"], run_number=_step["run_number"], step_name=_step["step_name"])).body
 
     # add metadata to filter on
-    (await add_metadata(db, flow_id=_first_task["flow_id"], run_number=_first_task["run_number"], step_name=_first_task["step_name"], task_id=_first_task["task_id"], metadata={"field_name":"field_a", "value": "value_a"}))
-    (await add_metadata(db, flow_id=_first_task["flow_id"], run_number=_first_task["run_number"], step_name=_first_task["step_name"], task_id=_first_task["task_id"], metadata={"field_name":"field_b", "value": "value_b"}))
+    (await add_metadata(db, flow_id=_first_task["flow_id"], run_number=_first_task["run_number"], step_name=_first_task["step_name"], task_id=_first_task['task_id'], task_name=_first_task["task_name"], metadata={"field_name":"field_a", "value": "value_a"}))
+    (await add_metadata(db, flow_id=_first_task["flow_id"], run_number=_first_task["run_number"], step_name=_first_task["step_name"], task_id=_first_task['task_id'], task_name=_first_task["task_name"], metadata={"field_name":"field_b", "value": "value_b"}))
 
     (await add_metadata(db, flow_id=_second_task["flow_id"], run_number=_second_task["run_number"], step_name=_second_task["step_name"], task_id=_second_task["task_id"], metadata={"field_name": "field_a", "value": "not_value_a"}))
     (await add_metadata(db, flow_id=_second_task["flow_id"], run_number=_second_task["run_number"], step_name=_second_task["step_name"], task_id=_second_task["task_id"], metadata={"field_name": "field_b", "value": "value_b"}))
@@ -258,7 +258,7 @@ async def test_filtered_tasks_mixed_ids_get(cli, db):
     await assert_api_get_response(cli, "/flows/{flow_id}/runs/{run_number}/steps/{step_name}/filtered_tasks?pattern=value_b".format(**_first_task),
                                   data=[task_pathspec(_first_task), task_pathspec(_second_task)])
     
-    # filtering with a regexp should return all relevant tasks
+    # # filtering with a regexp should return all relevant tasks
     await assert_api_get_response(cli, "/flows/{flow_id}/runs/{run_number}/steps/{step_name}/filtered_tasks?pattern=value_.*".format(**_first_task),
                                   data=[task_pathspec(_first_task), task_pathspec(_second_task)])
 

--- a/services/metadata_service/tests/integration_tests/task_test.py
+++ b/services/metadata_service/tests/integration_tests/task_test.py
@@ -205,22 +205,26 @@ async def test_filtered_tasks_get(cli, db):
 
     # filtering with a shared key should return all relevant tasks
     await assert_api_get_response(cli, "/flows/{flow_id}/runs/{run_number}/steps/{step_name}/filtered_tasks?metadata_field_name=field_a".format(**_first_task),
-                                  data=[ _first_task["task_id"], _second_task["task_id"]])
+                                  data=[task_pathspec(_first_task), task_pathspec(_second_task)])
 
     # filtering with a shared value should return all relevant tasks
-    await assert_api_get_response(cli, "/flows/{flow_id}/runs/{run_number}/steps/{step_name}/filtered_tasks?metadata_value=value_b".format(**_first_task),
-                                  data=[_first_task["task_id"], _second_task["task_id"]])
+    await assert_api_get_response(cli, "/flows/{flow_id}/runs/{run_number}/steps/{step_name}/filtered_tasks?pattern=value_b".format(**_first_task),
+                                  data=[task_pathspec(_first_task), task_pathspec(_second_task)])
+    
+    # filtering with a regexp should return all relevant tasks
+    await assert_api_get_response(cli, "/flows/{flow_id}/runs/{run_number}/steps/{step_name}/filtered_tasks?pattern=value_.*".format(**_first_task),
+                                  data=[task_pathspec(_first_task), task_pathspec(_second_task)])
 
     # filtering with a shared key&value should return all relevant tasks
-    await assert_api_get_response(cli, "/flows/{flow_id}/runs/{run_number}/steps/{step_name}/filtered_tasks?metadata_field_name=field_b&metadata_value=value_b".format(**_first_task),
-                                  data=[_first_task["task_id"], _second_task["task_id"]])
+    await assert_api_get_response(cli, "/flows/{flow_id}/runs/{run_number}/steps/{step_name}/filtered_tasks?metadata_field_name=field_b&pattern=value_b".format(**_first_task),
+                                  data=[task_pathspec(_first_task), task_pathspec(_second_task)])
     
     # filtering with a shared value should return all relevant tasks
-    await assert_api_get_response(cli, "/flows/{flow_id}/runs/{run_number}/steps/{step_name}/filtered_tasks?metadata_field_name=field_a&metadata_value=not_value_a".format(**_first_task),
-                                  data=[_second_task["task_id"]])
+    await assert_api_get_response(cli, "/flows/{flow_id}/runs/{run_number}/steps/{step_name}/filtered_tasks?metadata_field_name=field_a&pattern=not_value_a".format(**_first_task),
+                                  data=[task_pathspec(_second_task)])
     
     # filtering with a mixed key&value should not return results
-    await assert_api_get_response(cli, "/flows/{flow_id}/runs/{run_number}/steps/{step_name}/filtered_tasks?metadata_field_name=field_a&metadata_value=value_b".format(**_first_task),
+    await assert_api_get_response(cli, "/flows/{flow_id}/runs/{run_number}/steps/{step_name}/filtered_tasks?metadata_field_name=field_a&pattern=value_b".format(**_first_task),
                                   data=[])
     
     # not providing filters should result in error
@@ -234,10 +238,9 @@ async def test_filtered_tasks_mixed_ids_get(cli, db):
     _step = (await add_step(db, flow_id=_run["flow_id"], run_number=_run["run_number"], step_name="first_step")).body
 
     # add tasks to the step
-    first_task_name = "first-task-1"
-    _first_task = (await add_task(db, flow_id=_step["flow_id"], run_number=_step["run_number"], step_name=_step["step_name"], task_name=first_task_name)).body
+    _first_task = (await add_task(db, flow_id=_step["flow_id"], run_number=_step["run_number"], step_name=_step["step_name"], task_name="first-task-1")).body
     # we need to refetch the task as the return does not contain the internal task ID we need for further record creation.
-    _first_task = (await db.task_table_postgres.get_task(flow_id=_step["flow_id"], run_id=_step["run_number"], step_name=_step["step_name"], task_id=first_task_name, expanded=True)).body
+    _first_task = (await db.task_table_postgres.get_task(flow_id=_step["flow_id"], run_id=_step["run_number"], step_name=_step["step_name"], task_id="first-task-1", expanded=True)).body
     _second_task = (await add_task(db, flow_id=_step["flow_id"], run_number=_step["run_number"], step_name=_step["step_name"])).body
 
     # add metadata to filter on
@@ -249,22 +252,26 @@ async def test_filtered_tasks_mixed_ids_get(cli, db):
 
     # filtering with a shared key should return all relevant tasks
     await assert_api_get_response(cli, "/flows/{flow_id}/runs/{run_number}/steps/{step_name}/filtered_tasks?metadata_field_name=field_a".format(**_first_task),
-                                  data=[first_task_name, _second_task["task_id"]])
+                                  data=[task_pathspec(_first_task), task_pathspec(_second_task)])
 
     # filtering with a shared value should return all relevant tasks
-    await assert_api_get_response(cli, "/flows/{flow_id}/runs/{run_number}/steps/{step_name}/filtered_tasks?metadata_value=value_b".format(**_first_task),
-                                  data=[first_task_name, _second_task["task_id"]])
+    await assert_api_get_response(cli, "/flows/{flow_id}/runs/{run_number}/steps/{step_name}/filtered_tasks?pattern=value_b".format(**_first_task),
+                                  data=[task_pathspec(_first_task), task_pathspec(_second_task)])
+    
+    # filtering with a regexp should return all relevant tasks
+    await assert_api_get_response(cli, "/flows/{flow_id}/runs/{run_number}/steps/{step_name}/filtered_tasks?pattern=value_.*".format(**_first_task),
+                                  data=[task_pathspec(_first_task), task_pathspec(_second_task)])
 
     # filtering with a shared key&value should return all relevant tasks
-    await assert_api_get_response(cli, "/flows/{flow_id}/runs/{run_number}/steps/{step_name}/filtered_tasks?metadata_field_name=field_b&metadata_value=value_b".format(**_first_task),
-                                  data=[first_task_name, _second_task["task_id"]])
+    await assert_api_get_response(cli, "/flows/{flow_id}/runs/{run_number}/steps/{step_name}/filtered_tasks?metadata_field_name=field_b&pattern=value_b".format(**_first_task),
+                                  data=[task_pathspec(_first_task), task_pathspec(_second_task)])
     
     # filtering with a shared value should return all relevant tasks
-    await assert_api_get_response(cli, "/flows/{flow_id}/runs/{run_number}/steps/{step_name}/filtered_tasks?metadata_field_name=field_a&metadata_value=not_value_a".format(**_first_task),
-                                  data=[_second_task["task_id"]])
+    await assert_api_get_response(cli, "/flows/{flow_id}/runs/{run_number}/steps/{step_name}/filtered_tasks?metadata_field_name=field_a&pattern=not_value_a".format(**_first_task),
+                                  data=[task_pathspec(_second_task)])
     
     # filtering with a mixed key&value should not return results
-    await assert_api_get_response(cli, "/flows/{flow_id}/runs/{run_number}/steps/{step_name}/filtered_tasks?metadata_field_name=field_a&metadata_value=value_b".format(**_first_task),
+    await assert_api_get_response(cli, "/flows/{flow_id}/runs/{run_number}/steps/{step_name}/filtered_tasks?metadata_field_name=field_a&pattern=value_b".format(**_first_task),
                                   data=[])
     
     # not providing filters should result in error
@@ -292,3 +299,9 @@ async def test_task_get(cli, db):
     await assert_api_get_response(cli, "/flows/{flow_id}/runs/1234/steps/{step_name}/tasks/{task_id}".format(**_task), status=404)
     await assert_api_get_response(cli, "/flows/{flow_id}/runs/{run_number}/steps/nonexistent_step/tasks/{task_id}".format(**_task), status=404)
     await assert_api_get_response(cli, "/flows/{flow_id}/runs/{run_number}/steps/{step_name}/tasks/1234".format(**_task), status=404)
+
+
+# Helpers
+
+def task_pathspec(task_dict):
+    return f"{task_dict['flow_id']}/{task_dict['run_number']}/{task_dict['step_name']}/{task_dict.get('task_name', task_dict['task_id'])}"

--- a/services/metadata_service/tests/integration_tests/task_test.py
+++ b/services/metadata_service/tests/integration_tests/task_test.py
@@ -227,8 +227,8 @@ async def test_filtered_tasks_get(cli, db):
     await assert_api_get_response(cli, "/flows/{flow_id}/runs/{run_number}/steps/{step_name}/filtered_tasks?metadata_field_name=field_a&pattern=value_b".format(**_first_task),
                                   data=[])
     
-    # not providing filters should result in error
-    await assert_api_get_response(cli, "/flows/{flow_id}/runs/{run_number}/steps/{step_name}/filtered_tasks".format(**_first_task), status=400)
+    # not providing filters should return all
+    await assert_api_get_response(cli, "/flows/{flow_id}/runs/{run_number}/steps/{step_name}/filtered_tasks".format(**_first_task), data=[task_pathspec(_first_task), task_pathspec(_second_task)])
 
 
 async def test_filtered_tasks_mixed_ids_get(cli, db):
@@ -274,8 +274,8 @@ async def test_filtered_tasks_mixed_ids_get(cli, db):
     await assert_api_get_response(cli, "/flows/{flow_id}/runs/{run_number}/steps/{step_name}/filtered_tasks?metadata_field_name=field_a&pattern=value_b".format(**_first_task),
                                   data=[])
     
-    # not providing filters should result in error
-    await assert_api_get_response(cli, "/flows/{flow_id}/runs/{run_number}/steps/{step_name}/filtered_tasks".format(**_first_task), status=400)
+    # not providing filters should return all
+    await assert_api_get_response(cli, "/flows/{flow_id}/runs/{run_number}/steps/{step_name}/filtered_tasks".format(**_first_task), data=[task_pathspec(_first_task), task_pathspec(_second_task)])
 
 
 

--- a/services/metadata_service/tests/integration_tests/task_test.py
+++ b/services/metadata_service/tests/integration_tests/task_test.py
@@ -195,26 +195,35 @@ async def test_filtered_tasks_get(cli, db):
     _first_task = (await add_task(db, flow_id=_step["flow_id"], run_number=_step["run_number"], step_name=_step["step_name"])).body
     _second_task = (await add_task(db, flow_id=_step["flow_id"], run_number=_step["run_number"], step_name=_step["step_name"])).body
     _third_task = (await add_task(db, flow_id=_step["flow_id"], run_number=_step["run_number"], step_name=_step["step_name"])).body
+    # expect tasks' tags to be overridden by tags of their ancestral run
+    update_objects_with_run_tags('task', [_first_task, _second_task, _third_task], _run)
 
     # add metadata to filter on
-    (await add_metadata(db, flow_id=_first_task["flow_id"], step_name=_first_task["step_name"], task_id=_first_task["task_id"], metadata={"field_a": "value_a", "field_b": "value_b"}))
-    (await add_metadata(db, flow_id=_second_task["flow_id"], step_name=_second_task["step_name"], task_id=_second_task["task_id"], metadata={"field_a": "not_value_a", "field_b": "value_b"}))
+    (await add_metadata(db, flow_id=_first_task["flow_id"], run_number=_first_task["run_number"], step_name=_first_task["step_name"], task_id=_first_task["task_id"], metadata={"field_name":"field_a", "value": "value_a"}))
+    (await add_metadata(db, flow_id=_first_task["flow_id"], run_number=_first_task["run_number"], step_name=_first_task["step_name"], task_id=_first_task["task_id"], metadata={"field_name":"field_b", "value": "value_b"}))
+
+    (await add_metadata(db, flow_id=_second_task["flow_id"], run_number=_second_task["run_number"], step_name=_second_task["step_name"], task_id=_second_task["task_id"], metadata={"field_name": "field_a", "value": "not_value_a"}))
+    (await add_metadata(db, flow_id=_second_task["flow_id"], run_number=_second_task["run_number"], step_name=_second_task["step_name"], task_id=_second_task["task_id"], metadata={"field_name": "field_b", "value": "value_b"}))
 
     # filtering with a shared key should return all relevant tasks
-    await assert_api_get_response(cli, "/flows/{flow_id}/runs/{run_number}/steps/{step_name}/tasks?metadata_field=field_a".format(**_first_task),
+    await assert_api_get_response(cli, "/flows/{flow_id}/runs/{run_number}/steps/{step_name}/tasks?metadata_field_name=field_a".format(**_first_task),
                                   data=[_second_task, _first_task], data_is_unordered_list_of_dicts=True)
 
     # filtering with a shared value should return all relevant tasks
     await assert_api_get_response(cli, "/flows/{flow_id}/runs/{run_number}/steps/{step_name}/tasks?metadata_value=value_b".format(**_first_task),
-                                  data=[_first_task], data_is_unordered_list_of_dicts=True)
+                                  data=[_first_task, _second_task], data_is_unordered_list_of_dicts=True)
 
     # filtering with a shared key&value should return all relevant tasks
-    await assert_api_get_response(cli, "/flows/{flow_id}/runs/{run_number}/steps/{step_name}/tasks?metadata_field=field_b&metadata_value=value_b".format(**_first_task),
-                                  data=[_first_task], data_is_unordered_list_of_dicts=True)
+    await assert_api_get_response(cli, "/flows/{flow_id}/runs/{run_number}/steps/{step_name}/tasks?metadata_field_name=field_b&metadata_value=value_b".format(**_first_task),
+                                  data=[_first_task, _second_task], data_is_unordered_list_of_dicts=True)
     
     # filtering with a shared value should return all relevant tasks
-    await assert_api_get_response(cli, "/flows/{flow_id}/runs/{run_number}/steps/{step_name}/tasks?metadata_field=field_a&metadata_value=not_value_a".format(**_first_task),
+    await assert_api_get_response(cli, "/flows/{flow_id}/runs/{run_number}/steps/{step_name}/tasks?metadata_field_name=field_a&metadata_value=not_value_a".format(**_first_task),
                                   data=[_second_task], data_is_unordered_list_of_dicts=True)
+    
+    # filtering with a mixed key&value should not return results
+    await assert_api_get_response(cli, "/flows/{flow_id}/runs/{run_number}/steps/{step_name}/tasks?metadata_field_name=field_a&metadata_value=value_b".format(**_first_task),
+                                  data=[], data_is_unordered_list_of_dicts=True)
 
 
 


### PR DESCRIPTION
adds ability to filter tasks by metadata via

```
GET /flows/{flow_id}/runs/{run_id}/steps/{step_name}/filtered_tasks?metadata_field_name=some-field
GET /flows/{flow_id}/runs/{run_id}/steps/{step_name}/filtered_tasks?pattern=some-value

GET /flows/{flow_id}/runs/{run_id}/steps/{step_name}/filtered_tasks?metadata_field_name=some-field&pattern=some-.*
```

API up for discussion. Required in order to enable https://github.com/Netflix/metaflow/pull/2124