### PR TITLE
fix: percent-encode forward slash in database connection string

### DIFF
--- a/run_goose.py
+++ b/run_goose.py
@@ -15,6 +15,7 @@ DB_SCHEMA_NAME = os.environ.get("DB_SCHEMA_NAME", "public")
 # Set safe="" to percent-encode everything.
 quote_all = partial(quote, safe="")
 
+
 def check_if_goose_table_exists(db_connection_string: str):
     conn = psycopg2.connect(db_connection_string)
     cur = conn.cursor()

--- a/run_goose.py
+++ b/run_goose.py
@@ -2,6 +2,7 @@ import os
 import sys
 import time
 import argparse
+from functools import partial
 from subprocess import Popen
 from urllib.parse import quote
 import psycopg2
@@ -10,6 +11,9 @@ import psycopg2.errorcodes
 
 DB_SCHEMA_NAME = os.environ.get("DB_SCHEMA_NAME", "public")
 
+# By default, urllib.parse.quote does NOT percent-encode "/"
+# Set safe="" to percent-encode everything.
+quote_all = partial(quote, safe="")
 
 def check_if_goose_table_exists(db_connection_string: str):
     conn = psycopg2.connect(db_connection_string)
@@ -51,8 +55,8 @@ def main():
     parser.add_argument("--wait", type=int, default=30, help="Wait for connection for X seconds")
     args = parser.parse_args()
 
-    db_connection_string = f'postgresql://{quote(os.environ["MF_METADATA_DB_USER"])}:'\
-        f'{quote(os.environ["MF_METADATA_DB_PSWD"])}@{os.environ["MF_METADATA_DB_HOST"]}:'\
+    db_connection_string = f'postgresql://{quote_all(os.environ["MF_METADATA_DB_USER"])}:'\
+        f'{quote_all(os.environ["MF_METADATA_DB_PSWD"])}@{os.environ["MF_METADATA_DB_HOST"]}:'\
         f'{os.environ["MF_METADATA_DB_PORT"]}/{os.environ["MF_METADATA_DB_NAME"]}'
 
     ssl_mode = os.environ.get("MF_METADATA_DB_SSL_MODE")

--- a/services/utils/__init__.py
+++ b/services/utils/__init__.py
@@ -38,6 +38,7 @@ ORIGIN_TO_ALLOW_CORS_FROM = os.environ.get('ORIGIN_TO_ALLOW_CORS_FROM', None)
 # Set safe="" to percent-encode everything.
 quote_all = partial(quote, safe="")
 
+
 async def read_body(request_content):
     byte_array = bytearray()
     while not request_content.at_eof():

--- a/services/utils/__init__.py
+++ b/services/utils/__init__.py
@@ -7,7 +7,7 @@ from multidict import MultiDict
 from urllib.parse import urlencode, quote
 from aiohttp import web
 from enum import Enum
-from functools import wraps
+from functools import partial, wraps
 from typing import Dict
 import logging
 import psycopg2
@@ -34,6 +34,9 @@ logging.basicConfig(level=log_level)
 # Setting to '*' to be maximally loose.
 ORIGIN_TO_ALLOW_CORS_FROM = os.environ.get('ORIGIN_TO_ALLOW_CORS_FROM', None)
 
+# By default, urllib.parse.quote does NOT percent-encode "/"
+# Set safe="" to percent-encode everything.
+quote_all = partial(quote, safe="")
 
 async def read_body(request_content):
     byte_array = bytearray()
@@ -275,9 +278,9 @@ class DBConfiguration(object):
     def connection_string_url(self, type=None):
         # postgresql://[user[:password]@][host][:port][/dbname][?param1=value1&...]
         if type is None or type == DBType.WRITER:
-            base_url = f'postgresql://{quote(self._user)}:{quote(self._password)}@{self._host}:{self._port}/{self._database_name}'
+            base_url = f'postgresql://{quote_all(self._user)}:{quote_all(self._password)}@{self._host}:{self._port}/{self._database_name}'
         elif type == DBType.READER:
-            base_url = f'postgresql://{quote(self._user)}:{quote(self._password)}@{self._read_replica_host}:{self._port}/{self._database_name}'
+            base_url = f'postgresql://{quote_all(self._user)}:{quote_all(self._password)}@{self._read_replica_host}:{self._port}/{self._database_name}'
         else:
             raise Exception("Unsupported DBType %s" % type)
 

--- a/services/utils/tests/unit_tests/utils_test.py
+++ b/services/utils/tests/unit_tests/utils_test.py
@@ -143,6 +143,21 @@ def test_db_conf_timeout():
         db_conf = DBConfiguration(timeout=5)
         assert db_conf.timeout == 5
 
+
+def test_db_conf_connection_str_escaping():
+    with set_env():
+        db_conf = DBConfiguration(
+            host="testhost",
+            user="test$?/user",
+            password="test$?/password",
+            port=5432,
+        )
+        assert (
+            db_conf.connection_string_url()
+            == "postgresql://test%24%3F%2Fuser:test%24%3F%2Fpassword@testhost:5432/postgres?sslmode=disable"
+        )
+
+
 async def test_handle_exceptions():
     class FakeException(Exception):
         def __init__(self, id, trace):


### PR DESCRIPTION
The DB connection string used `urllib.parse.quote` to percent-encode the username and password. However, `quote` has a default kwarg `safe="/"` that does NOT percent-encode forward slashes. If the username or password includes a forward slash, then the resulting connection string may be rejected by the postgres client.

For example, when the password contains an unescaped forward slash, psycopg incorrectly parses the password field as a port.

```
>>> import psycopg2
>>> conn = "postgresql://user:abc/123@localhost:5432/db"
>>> psycopg2.connect(conn)
Traceback (most recent call last):
  File "<python-input-3>", line 1, in <module>
    psycopg2.connect(conn)
    ~~~~~~~~~~~~~~~~^^^^^^
  File "/Users/willdaly/repos/metaflow-service/.venv/lib/python3.13/site-packages/psycopg2/__init__.py", line 122, in connect
    conn = _connect(dsn, connection_factory=connection_factory, **kwasync)
psycopg2.OperationalError: invalid integer value "abc" for connection option "port"
```

Fix it by percent-escaping forward slashes in all DB connection strings.