### PR TITLE
Patch CVEs in container images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM golang:1.20.2-buster as amd64-golang
-FROM arm64v8/golang:1.20.2-buster as arm64-golang
+FROM golang:1.24.4-bookworm as amd64-golang
+FROM arm64v8/golang:1.24.4-bookworm as arm64-golang
 
 FROM ${TARGETARCH}-golang as goose
-RUN go install github.com/pressly/goose/v3/cmd/goose@v3.9.0
+RUN go install github.com/pressly/goose/v3/cmd/goose@v3.24.3
 
-FROM python:3.11.6-slim-bookworm
+FROM python:3.13.5-slim-bookworm
 COPY --from=goose /go/bin/goose /usr/local/bin/
 
 ARG BUILD_TIMESTAMP
@@ -21,7 +21,7 @@ ENV FEATURE_RUN_GROUPS=0
 ENV FEATURE_DEBUG_VIEW=1
 
 RUN apt-get update -y \
-    && apt-get -y install libpq-dev unzip gcc curl
+    && apt-get -y install libgit2-dev libpq-dev unzip gcc curl
 
 RUN pip3 install virtualenv requests
 

--- a/Dockerfile.metadata_service
+++ b/Dockerfile.metadata_service
@@ -1,4 +1,4 @@
-FROM python:3.11.7-bookworm
+FROM python:3.13.5-bookworm
 
 RUN apt-get update -y \
     && apt-get -y install libpq-dev gcc

--- a/Dockerfile.migration_service
+++ b/Dockerfile.migration_service
@@ -1,11 +1,11 @@
-FROM golang:1.20.2 AS goose
-RUN go install github.com/pressly/goose/v3/cmd/goose@v3.9.0
+FROM golang:1.24.4 AS goose
+RUN go install github.com/pressly/goose/v3/cmd/goose@v3.24.3
 
-FROM python:3.11.7-bookworm
+FROM python:3.13.5-bookworm
 COPY --from=goose /go/bin/goose /usr/local/bin/
 
 RUN apt-get update -y \
-    && apt-get -y install libpq-dev
+    && apt-get -y install libpq-dev unzip gcc curl
 
 ADD services/__init__.py /root/services/__init__.py
 ADD services/utils /root/services/utils

--- a/Dockerfile.service.test
+++ b/Dockerfile.service.test
@@ -1,11 +1,11 @@
-FROM golang:1.20.2 AS goose
-RUN go install github.com/pressly/goose/v3/cmd/goose@v3.9.0
+FROM golang:1.24.4 AS goose
+RUN go install github.com/pressly/goose/v3/cmd/goose@v3.24.3
 
-FROM python:3.11.7-bookworm
+FROM python:3.13.5-bookworm
 COPY --from=goose /go/bin/goose /usr/local/bin/
 
 RUN apt-get update -y \
-    && apt-get -y install libpq-dev gcc
+    && apt-get -y install libgit2-dev libpq-dev gcc
 
 RUN pip install tox
 

--- a/Dockerfile.ui_service
+++ b/Dockerfile.ui_service
@@ -1,4 +1,4 @@
-FROM python:3.11.7-bookworm
+FROM python:3.13.5-bookworm
 
 ARG UI_ENABLED="1"
 ARG UI_VERSION="v1.3.13"
@@ -16,7 +16,7 @@ ARG CUSTOM_QUICKLINKS
 ENV CUSTOM_QUICKLINKS=$CUSTOM_QUICKLINKS
 
 RUN apt-get update -y \
-    && apt-get -y install libpq-dev unzip gcc curl
+    && apt-get -y install libgit2-dev libpq-dev unzip gcc curl
 
 ADD services/__init__.py /root/services/__init__.py
 ADD services/data /root/services/data

--- a/services/ui_backend_service/requirements.txt
+++ b/services/ui_backend_service/requirements.txt
@@ -4,7 +4,7 @@ throttler==1.2.0
 packaging
 psycopg2
 aiopg
-pygit2==1.12.1
+pygit2==1.18.0
 aiohttp_cors==0.7.0
 metaflow>=2.11.4
 click==8.0.3


### PR DESCRIPTION
[Trivy](https://trivy.dev/latest/) reports many CVEs in the metaflow-service container images.

```
trivy image --ignore-unfixed --scanners vuln netflixoss/metaflow_metadata_service:sha-9e47d2d@sha256:fb13700fde0b680271ca622d634ad9d780946c24caeaca929c97c239b0c8af7f

netflixoss/metaflow_metadata_service:sha-9e47d2d@sha256:fb13700fde0b680271ca622d634ad9d780946c24caeaca929c97c239b0c8af7f (debian 12.2)
Total: 392 (UNKNOWN: 1, LOW: 29, MEDIUM: 276, HIGH: 79, CRITICAL: 7)

Python (python-pkg)
Total: 15 (UNKNOWN: 0, LOW: 0, MEDIUM: 9, HIGH: 6, CRITICAL: 0)

usr/local/bin/goose (gobinary)
Total: 40 (UNKNOWN: 0, LOW: 0, MEDIUM: 22, HIGH: 14, CRITICAL: 4)
```

This PR patches all of these CVEs by updating:
* golang base image to 1.24.4-bookworm
* goose version to v3.24.3
* Python base image to 3.13.5-slim-bookworm
* pygit2 to 1.18.0 for compatibility with new Python base image

I have tested the main Dockerfile both in minikube (manually replacing the image in [devtools/Tiltfile](https://github.com/Netflix/metaflow/blob/master/devtools/Tiltfile)) and in an EKS cluster. For consistency, I've made the same changes in the other Dockerfiles as well, but I wasn't sure how to test these.