### PR TITLE
feature: non root images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,22 +32,26 @@ RUN virtualenv /opt/latest -p python3
 
 RUN /opt/v_1_0_1/bin/pip install https://github.com/Netflix/metaflow-service/archive/1.0.1.zip
 
-ADD services/__init__.py /root/services/
-ADD services/data/service_configs.py /root/services/
-ADD services/data /root/services/data
-ADD services/metadata_service /root/services/metadata_service
-ADD services/ui_backend_service /root/services/ui_backend_service
-ADD services/utils /root/services/utils
-ADD setup.py setup.cfg run_goose.py /root/
-WORKDIR /root
+ADD services/__init__.py /src/services/
+ADD services/data/service_configs.py /src/services/
+ADD services/data /src/services/data
+ADD services/metadata_service /src/services/metadata_service
+ADD services/ui_backend_service /src/services/ui_backend_service
+ADD services/utils /src/services/utils
+ADD setup.py setup.cfg run_goose.py /src/
+WORKDIR /src
 RUN /opt/latest/bin/pip install .
 
 # Install Netflix/metaflow-ui release artifact
-RUN /root/services/ui_backend_service/download_ui.sh
+RUN /src/services/ui_backend_service/download_ui.sh
 
 # Migration Service
-ADD services/migration_service /root/services/migration_service
-RUN pip3 install -r /root/services/migration_service/requirements.txt
+ADD services/migration_service /src/services/migration_service
+RUN pip3 install -r /src/services/migration_service/requirements.txt
 
-RUN chmod 777 /root/services/migration_service/run_script.py
+RUN chmod 777 /src/services/migration_service/run_script.py
+
+WORKDIR /tmp
+USER 1001
+
 CMD python3  services/migration_service/run_script.py

--- a/Dockerfile.metadata_service
+++ b/Dockerfile.metadata_service
@@ -3,11 +3,15 @@ FROM python:3.11.7-bookworm
 RUN apt-get update -y \
     && apt-get -y install libpq-dev gcc
 
-ADD services/__init__.py /root/services/
-ADD services/data /root/services/data
-ADD services/utils /root/services/utils
-ADD services/metadata_service /root/services/metadata_service
-ADD setup.py setup.cfg /root/
-WORKDIR /root
+ADD services/__init__.py /src/services/
+ADD services/data /src/services/data
+ADD services/utils /src/services/utils
+ADD services/metadata_service /src/services/metadata_service
+ADD setup.py setup.cfg /src/
+WORKDIR /src
 RUN pip install --editable .
+
+WORKDIR /tmp
+USER 1001
+
 CMD metadata_service

--- a/Dockerfile.migration_service
+++ b/Dockerfile.migration_service
@@ -7,10 +7,14 @@ COPY --from=goose /go/bin/goose /usr/local/bin/
 RUN apt-get update -y \
     && apt-get -y install libpq-dev
 
-ADD services/__init__.py /root/services/__init__.py
-ADD services/utils /root/services/utils
-ADD services/migration_service /root/services/migration_service
-ADD setup.py setup.cfg run_goose.py /root/
-WORKDIR /root
+ADD services/__init__.py /src/services/__init__.py
+ADD services/utils /src/services/utils
+ADD services/migration_service /src/services/migration_service
+ADD setup.py setup.cfg run_goose.py /src/
+WORKDIR /src
 RUN pip install --editable .
+
+WORKDIR /tmp
+USER 1001
+
 CMD migration_service

--- a/Dockerfile.ui_service
+++ b/Dockerfile.ui_service
@@ -18,18 +18,22 @@ ENV CUSTOM_QUICKLINKS=$CUSTOM_QUICKLINKS
 RUN apt-get update -y \
     && apt-get -y install libpq-dev unzip gcc curl
 
-ADD services/__init__.py /root/services/__init__.py
-ADD services/data /root/services/data
-ADD services/utils /root/services/utils
-ADD services/metadata_service /root/services/metadata_service
-ADD services/ui_backend_service /root/services/ui_backend_service
-ADD setup.py setup.cfg /root/
+ADD services/__init__.py /src/services/__init__.py
+ADD services/data /src/services/data
+ADD services/utils /src/services/utils
+ADD services/metadata_service /src/services/metadata_service
+ADD services/ui_backend_service /src/services/ui_backend_service
+ADD setup.py setup.cfg /src/
 
-WORKDIR /root
+WORKDIR /src
+
 
 # Install Netflix/metaflow-ui release artifact
-RUN /root/services/ui_backend_service/download_ui.sh
+RUN /src/services/ui_backend_service/download_ui.sh
 
 RUN pip install --editable .
+
+WORKDIR /tmp
+USER 1001
 
 CMD ui_backend_service

--- a/docker-compose.development.yml
+++ b/docker-compose.development.yml
@@ -10,8 +10,8 @@ services:
     ports:
       - "${MF_UI_METADATA_PORT:-8083}:${MF_UI_METADATA_PORT:-8083}"
     volumes:
-      - ./services:/root/services
-      - ${HOME}/.aws:/root/.aws
+      - ./services:/src/services
+      - ${HOME}/.aws:/src/.aws
     # Add container capability for benchmarking processes. required for py-spy
     cap_add:
       - SYS_PTRACE
@@ -63,7 +63,7 @@ services:
     ports:
       - "${MF_METADATA_PORT:-8080}:${MF_METADATA_PORT:-8080}"
     volumes:
-      - ./services:/root/services
+      - ./services:/src/services
     environment:
       - LOGLEVEL=WARNING
       - MF_METADATA_DB_HOST=db
@@ -77,13 +77,13 @@ services:
     depends_on:
       - migration
   migration:
-    command: ["python", "/root/run_goose.py"]
+    command: ["python", "/src/run_goose.py"]
     platform: linux/amd64
     build:
       context: .
       dockerfile: Dockerfile.migration_service
     volumes:
-      - ./services:/root/services
+      - ./services:/src/services
     environment:
       - MF_METADATA_DB_HOST=db
       - MF_METADATA_DB_PORT=5432

--- a/run_goose.py
+++ b/run_goose.py
@@ -88,7 +88,7 @@ def main():
         [
             "goose",
             "-dir",
-            "/root/services/migration_service/migration_files/",
+            "/src/services/migration_service/migration_files/",
             "postgres",
             db_connection_string,
             "up",

--- a/services/migration_service/get_virtual_env.py
+++ b/services/migration_service/get_virtual_env.py
@@ -38,6 +38,6 @@ except Exception as e:
 r = requests.get('http://localhost:{0}/version'.format(port))
 r.raise_for_status()
 
-conf_file = open('/root/services/migration_service/config', 'w')
+conf_file = open('/src/services/migration_service/config', 'w')
 print(r.text, file=conf_file)
 conf_file.close()

--- a/services/migration_service/run_script.py
+++ b/services/migration_service/run_script.py
@@ -32,7 +32,7 @@ if __name__ == "__main__":
             sys.exit(1)
 
         # read in version of metadata service to load
-        version_value_file = open('/root/services/migration_service/config', 'r')
+        version_value_file = open('/src/services/migration_service/config', 'r')
         version_value = str(version_value_file.read()).strip()
 
         # start proper version of metadata service


### PR DESCRIPTION
changes Docker images so they run as non-root.

Note that introducing this change moves the location of `run_goose.py`, which is a breaking change: This script is directly referenced in deployment templates for the services, so updating those is a requirement as well.