### PR TITLE
dd limit and offset pagination support to GET /flows/{flow_id}/runs

### DIFF
--- a/services/data/postgres_async_db.py
+++ b/services/data/postgres_async_db.py
@@ -200,9 +200,11 @@ class AsyncPostgresTable(object):
                     conditions=self.trigger_conditions
                 )
 
-    async def get_records(self, filter_dict={}, fetch_single=False,
-                          ordering: List[str] = None, limit: int = 0, expanded=False,
+    async def get_records(self, filter_dict=None, fetch_single=False,
+                          ordering: List[str] = None, limit: int = 0, offset: int = 0, expanded=False,
                           cur: aiopg.Cursor = None) -> DBResponse:
+        if filter_dict is None:
+            filter_dict = {}
         conditions = []
         values = []
         for col_name, col_val in filter_dict.items():
@@ -210,8 +212,9 @@ class AsyncPostgresTable(object):
             values.append(col_val)
 
         response, _ = await self.find_records(
-            conditions=conditions, values=values, fetch_single=fetch_single,
-            order=ordering, limit=limit, expanded=expanded, cur=cur
+            conditions=conditions, values=values, fetch_single=fetch_single, order=ordering,
+            limit=limit, offset=offset, 
+            expanded=expanded, cur=cur
         )
         return response
 
@@ -606,9 +609,20 @@ class AsyncRunTablePostgres(AsyncPostgresTable):
         return await self.get_records(filter_dict=filter_dict,
                                       fetch_single=True, expanded=expanded, cur=cur)
 
-    async def get_all_runs(self, flow_id: str):
+    async def get_all_runs(
+        self,
+        flow_id: str,
+        limit: int = 0,
+        offset: int = 0
+    ):
         filter_dict = {"flow_id": flow_id}
-        return await self.get_records(filter_dict=filter_dict)
+
+        return await self.get_records(
+            filter_dict=filter_dict,
+            ordering=["ts_epoch DESC"],
+            limit=limit,
+            offset=offset
+        )
 
     async def update_heartbeat(self, flow_id: str, run_id: str):
         run_key, run_value = translate_run_key(run_id)

--- a/services/metadata_service/api/run.py
+++ b/services/metadata_service/api/run.py
@@ -81,8 +81,17 @@ class RunApi(object):
             "405":
                 description: invalid HTTP Method
         """
+        try:
+            limit = int(request.query.get("limit", 0))
+            offset = int(request.query.get("offset", 0))
+        except ValueError:
+            raise ValueError("limit and offset must be integers")
+
+        # Prevent negative values
+        limit = max(0, limit)
+        offset= max(0, offset)
         flow_name = request.match_info.get("flow_id")
-        return await self._async_table.get_all_runs(flow_name)
+        return await self._async_table.get_all_runs(flow_name, limit=limit, offset=offset)
 
     @format_response
     @handle_exceptions


### PR DESCRIPTION
## Summary

This PR adds support for `limit` and `offset` query parameters to the `GET /flows/{flow_id}/runs` endpoint to enable pagination of runs.

## Changes

- Extended `AsyncPostgresTable.get_records` to support an optional `offset` parameter.
- Updated `AsyncRunTablePostgres.get_all_runs` to accept `limit` and `offset`.
- Modified `RunApi.get_all_runs` to:
  - Parse `limit` and `offset` from query parameters
  - Validate integer inputs
  - Default negative values to `0`
  - Return results ordered by `ts_epoch DESC` (latest runs first)

## Behavior

- `limit=0` returns all runs (existing behavior preserved)
- Negative values for `limit` and `offset` are clamped to `0`
- Non-integer values return a `400` error

## Backward Compatibility

- Existing calls without pagination parameters continue to behave as before.
- No changes to default response structure.

## Testing

Tested manually using:
- `?limit=2`
- `?limit=2&offset=2`
- `?limit=0`
- `?limit=-5`
- `?limit=abc`

Verified:
- Correct pagination behavior
- Stable ordering
- Proper validation handling