### PR TITLE
fix: handle non-serializable run parameters in UI

### DIFF
--- a/services/ui_backend_service/data/cache/get_parameters_action.py
+++ b/services/ui_backend_service/data/cache/get_parameters_action.py
@@ -1,3 +1,4 @@
+import json
 from typing import List, Callable
 
 from .get_data_action import GetData
@@ -59,7 +60,15 @@ class GetParameters(GetData):
                 continue
             try:
                 if artifact.size < MAX_S3_SIZE:
-                    values[artifact_name] = artifact.data
+                    value = artifact.data
+                    # Ensure the value is JSON-serializable before storing.
+                    # Some parameter values (e.g. logging.Logger) cannot be
+                    # serialized and would cause json.dumps to fail downstream.
+                    try:
+                        json.dumps(value)
+                    except (TypeError, ValueError):
+                        value = repr(value)
+                    values[artifact_name] = value
                 else:
                     values[artifact_name] = "Artifact too large: {} bytes".format(artifact.size)
             except Exception as ex:


### PR DESCRIPTION
Fixes #413

`GetParameters.fetch_data` passes `artifact.data` directly to the result dict, which later gets `json.dumps`'d in `GetData.execute`. If the artifact contains a non-serializable Python object (e.g. `logging.Logger`), this raises a `TypeError`.

This PR catches serialization failures and falls back to `repr()` for those values.
