### PR TITLE
fix: prevent SQL injection in update_row by using parameterized queries

### DIFF
--- a/services/data/postgres_async_db.py
+++ b/services/data/postgres_async_db.py
@@ -1,6 +1,5 @@
 import psycopg2
 import psycopg2.extras
-from psycopg2.extensions import QuotedString
 import os
 import aiopg
 import json
@@ -361,41 +360,39 @@ class AsyncPostgresTable(object):
             return aiopg_exception_handling(error)
 
     async def update_row(self, filter_dict={}, update_dict={}, cur: aiopg.Cursor = None):
-        # generate where clause
+        # Build a single values list in the same order as SQL placeholders:
+        # UPDATE ... SET col1=%s, col2=%s WHERE col3=%s AND col4=%s
+        values = []
+
+        # generate SET clause (values come first in SQL)
+        sets = []
+        for col_name, col_val in update_dict.items():
+            sets.append('%s = %%s' % col_name)
+            values.append(col_val)
+        set_clause = ", ".join(sets)
+
+        # generate WHERE clause (values come second in SQL)
         filters = []
         for col_name, col_val in filter_dict.items():
             operator = '='
-            v = str(col_val).strip("'")
-            if not v.isnumeric():
-                v = "'" + v + "'"
             find_operator = operator_match.match(col_name)
             if find_operator:
                 col_name = find_operator.group(1)
                 operator = find_operator.group(2)
-                filters.append('(%s IS NULL or %s %s %s)' %
-                               (col_name, col_name, operator, str(v)))
+                filters.append('(%s IS NULL or %s %s %%s)' %
+                               (col_name, col_name, operator))
             else:
-                filters.append(col_name + operator + str(v))
+                filters.append('%s %s %%s' % (col_name, operator))
+            values.append(col_val)
+        where_clause = " and ".join(filters)
 
-        seperator = " and "
-        where_clause = ""
-        if bool(filter_dict):
-            where_clause = seperator.join(filters)
-
-        sets = []
-        for col_name, col_val in update_dict.items():
-            sets.append(col_name + " = " + str(col_val))
-
-        set_seperator = ", "
-        set_clause = ""
-        if bool(filter_dict):
-            set_clause = set_seperator.join(sets)
         update_sql = """
                 UPDATE {0} SET {1} WHERE {2};
         """.format(self.table_name, set_clause, where_clause)
+        values = tuple(values)
 
         async def _execute_update_on_cursor(_cur):
-            await _cur.execute(update_sql)
+            await _cur.execute(update_sql, values)
             if _cur.rowcount < 1:
                 return DBResponse(response_code=404,
                                   body={"msg": "could not find row"})
@@ -631,7 +628,7 @@ class AsyncRunTablePostgres(AsyncPostgresTable):
         filter_dict = {"flow_id": flow_id,
                        run_key: str(run_value)}
 
-        set_dict = {"tags": QuotedString(json.dumps(run_tags)).getquoted().decode()}
+        set_dict = {"tags": json.dumps(run_tags)}
         return await self.update_row(filter_dict=filter_dict,
                                      update_dict=set_dict,
                                      cur=cur)


### PR DESCRIPTION
## Summary
Fix critical SQL injection vulnerability in `AsyncPostgresTable.update_row()` by replacing string concatenation with psycopg2 parameterized queries.

## Context / Motivation
The [update_row](cci:1://file:///home/ahmed-elgyar/metaflow-service/services/data/postgres_async_db.py:362:4-420:50) method constructed SQL WHERE and SET clauses using direct string concatenation, allowing potential SQL injection through user-controlled inputs like `flow_id`, `run_number`, `step_name`, and [task_id](cci:1://file:///home/ahmed-elgyar/metaflow-service/services/data/postgres_async_db.py:139:4-145:59) (which come from URL path parameters). Fixes the SQL injection vulnerability in [update_row()](cci:1://file:///home/ahmed-elgyar/metaflow-service/services/data/postgres_async_db.py:362:4-420:50).

## Changes Made
- **[update_row()](cci:1://file:///home/ahmed-elgyar/metaflow-service/services/data/postgres_async_db.py:362:4-420:50)**: Replaced direct value interpolation with `%s` placeholders and separate value lists (`set_values`, `filter_values`) passed to `cur.execute()`
- **[update_run_tags()](cci:1://file:///home/ahmed-elgyar/metaflow-service/services/data/postgres_async_db.py:630:4-638:45)**: Removed `QuotedString` wrapper — it produced pre-quoted SQL literals that caused double-escaping with the now-parameterized [update_row()](cci:1://file:///home/ahmed-elgyar/metaflow-service/services/data/postgres_async_db.py:362:4-420:50). Values are now passed as plain `json.dumps()` and escaped by psycopg2 automatically
- Column names and operators remain as Python string formatting since they originate from hardcoded server code, not user input

## Testing
- All 207 integration tests pass via `docker-compose -f docker-compose.test.yml`
- Verified all 3 callers of [update_row()](cci:1://file:///home/ahmed-elgyar/metaflow-service/services/data/postgres_async_db.py:362:4-420:50):
  - `AsyncRunTablePostgres.update_heartbeat` — passes server-generated integers ✅
  - `AsyncRunTablePostgres.update_run_tags` — now passes `json.dumps()` directly ✅
  - `AsyncTaskTablePostgres.update_heartbeat` — passes server-generated integers ✅