### PR TITLE
feat: derive killed status for externally terminated tasks 

### DIFF
--- a/services/ui_backend_service/data/db/tables/task.py
+++ b/services/ui_backend_service/data/db/tables/task.py
@@ -174,6 +174,12 @@ class AsyncTaskTablePostgres(AsyncPostgresTable):
             THEN 'completed'
             WHEN attempt.attempt_ok IS FALSE
             THEN 'failed'
+            WHEN attempt.attempt_ok IS NULL
+                AND attempt.task_ok_location IS NULL
+                AND {table_name}.last_heartbeat_ts IS NOT NULL
+                AND @(extract(epoch from now())-{table_name}.last_heartbeat_ts)>{heartbeat_threshold}
+                AND {finished_at_column} IS NULL
+            THEN 'killed'
             WHEN COALESCE(attempt.attempt_finished_at, attempt.task_ok_finished_at) IS NOT NULL
                 AND attempt_ok IS NULL
             THEN 'unknown'

--- a/services/ui_backend_service/data/refiner/task_refiner.py
+++ b/services/ui_backend_service/data/refiner/task_refiner.py
@@ -4,9 +4,7 @@ from .refinery import Refinery
 class TaskRefiner(Refinery):
     """
     Refiner class for postprocessing Task rows.
-
     Uses Metaflow Client API to refine Task's actual status from Metaflow Service and Datastore.
-
     Parameters
     -----------
     cache : AsyncCacheClient
@@ -36,11 +34,12 @@ class TaskRefiner(Refinery):
                 record['status'] = 'failed'
             elif value is True:
                 record['status'] = 'completed'
-
+        # If task is failed and _task_ok key exists in values but is None,
+        # the process was killed externally (SIGKILL bypasses finally in task.py)
+        elif record['status'] == 'failed' and '_task_ok' in values and values['_task_ok'] is None:
+            record['status'] = 'killed'
         if values.get('_foreach_stack'):
             value = values['_foreach_stack']
             if len(value) > 0 and len(value[0]) >= 4:
-                # The third one in the tuple is the foreach index. We access this way for backwards compatibility.
                 record['foreach_label'] = "{}[{}]".format(record['task_id'], value[0][3])
-
         return record


### PR DESCRIPTION


## Summary

Companion to Netflix/metaflow-ui issue 84 https://github.com/Netflix/metaflow-ui/pull/187

Adds a new killed task status to distinguish tasks terminated externally (SIGKILL, OOM killer, Kubernetes eviction) from tasks that failed due to Python exceptions. The fix could have been implemented on the frontend by checking for attempt_ok absence in the task metadata response. This was considered and rejected for two reasons. First, task metadata loads asynchronously after the task row itself, which would cause a visible flicker from killed back to failed during the loading window. Second, it would create two sources of truth for task status, the SQL-derived status field and the frontend-derived killed flag, which conflicts with how every other status in the codebase is handled. Deriving killed in the SQL status CASE statement in task.py keeps the backend as the single source of truth, consistent with Sakari's stated design preference.

---

## Problem

When a Metaflow task terminates abnormally, the UI currently shows a red "Failed" indicator regardless of the cause. But there are two fundamentally different failure modes — a Python exception means the user's code has a bug, while an external kill (SIGKILL, OOM killer, Kubernetes eviction) means the infrastructure failed. Conflating these forces engineers to manually inspect raw metadata just to know where to start debugging, which defeats the purpose of having a monitoring UI.


---

## Investigation

The distinguishing signal is already in the backend. When a task fails via a Python exception, Metaflow writes attempt_ok = "False" in the finally block of task.py. When a task is killed externally with SIGKILL, the finally block never executes, leaving three observable differences in the data:

No attempt_ok metadata entry is written
No _task_ok artifact exists at any location
last_heartbeat_ts is present but the heartbeat eventually times out

This means the backend already has everything needed to distinguish the two cases — no new schema changes or API endpoints are required.



Verified by running both flow types locally and diffing the metadata API responses:

Code failure (ValueError)

* curl http://localhost:8080/flows/FailFlow/runs/8/steps/start/tasks/16/metadata
* attempt_ok field present with value "False"

Killed task (SIGKILL)

* curl http://localhost:8080/flows/KillFlow/runs/9/steps/start/tasks/18/metadata
* no attempt_ok entry at all

![WhatsApp Image 2026-03-21 at 17 33 14 (1)](https://github.com/user-attachments/assets/9a5ca223-b59b-49b4-baf2-62416935e4c6)

![WhatsApp Image 2026-03-21 at 17 33 14 (2)](https://github.com/user-attachments/assets/dd072a7b-3bf6-4c0c-b597-71d9926d182c)



---

## Solution

Added a new WHEN clause to the SQL status CASE statement in services/ui_backend_service/data/db/tables/task.py, placed before the existing heartbeat-based failed condition:

WHEN attempt.attempt_ok IS NULL
AND attempt.task_ok_location IS NULL
AND {table_name}.last_heartbeat_ts IS NOT NULL
AND (extract(epoch from now()) - {table_name}.last_heartbeat_ts) > {heartbeat_threshold}
AND {finished_at_column} IS NULL
THEN 'killed'

This correctly identifies tasks where:

* No attempt_ok was written (SIGKILL bypassed finally)
* No _task_ok artifact location exists
* Heartbeat has timed out (task is definitively dead)

No new database columns, no new API endpoints, no performance impact. It uses existing indexed columns already queried in the lateral join.

Also updated task_refiner.py to be aware of the killed status so it does not incorrectly override it during postprocessing.

---

## Files changed

* services/ui_backend_service/data/db/tables/task.py: SQL status CASE statement
* services/ui_backend_service/data/refiner/task_refiner.py: refiner awareness of killed status

---

## Verification

KillFlow: SIGKILL task

* sleep 90 && curl http://localhost:8083/flows/KillFlow/runs/9/steps/start/tasks?postprocess=false
* "status": "killed"

FailFlow: ValueError task

* sleep 15 && curl http://localhost:8083/flows/FailFlow/runs/8/steps/start/tasks?postprocess=false
* "status": "failed"


![WhatsApp Image 2026-03-21 at 17 33 14 (3)](https://github.com/user-attachments/assets/7febba84-c60d-4e6f-ac36-72b2fe787bb9)

