### PR TITLE
feat: expose `is_inside_foreach` in DAG step info endpoint response

### DIFF
--- a/services/ui_backend_service/data/cache/custom_flowgraph.py
+++ b/services/ui_backend_service/data/cache/custom_flowgraph.py
@@ -250,6 +250,7 @@ class FlowGraph(object):
                 "doc": node.doc,
                 "next": node.out_funcs,
                 "foreach_artifact": node.foreach_param,
+                "is_inside_foreach": node.is_inside_foreach,
             }
 
         def populate_block(start_name, end_name):

--- a/services/ui_backend_service/tests/unit_tests/custom_flowgraph_test.py
+++ b/services/ui_backend_service/tests/unit_tests/custom_flowgraph_test.py
@@ -87,7 +87,8 @@ if __name__ == '__main__':
               "next": [
                   "regular_step"
               ],
-              "foreach_artifact": None
+              "foreach_artifact": None,
+              "is_inside_foreach": False
           },
           "regular_step": {
               "name": "regular_step",
@@ -98,7 +99,8 @@ if __name__ == '__main__':
                   "prepare_foreach",
                   "prepare_foreach2"
               ],
-              "foreach_artifact": None
+              "foreach_artifact": None,
+              "is_inside_foreach": False
           },
           "prepare_foreach": {
               "name": "prepare_foreach",
@@ -108,7 +110,8 @@ if __name__ == '__main__':
               "next": [
                   "process_foreach"
               ],
-              "foreach_artifact": "things"
+              "foreach_artifact": "things",
+              "is_inside_foreach": False
           },
           "process_foreach": {
               "name": "process_foreach",
@@ -118,7 +121,8 @@ if __name__ == '__main__':
               "next": [
                   "join"
               ],
-              "foreach_artifact": None
+              "foreach_artifact": None,
+              "is_inside_foreach": True
           },
           "join": {
               "name": "join",
@@ -128,7 +132,8 @@ if __name__ == '__main__':
               "next": [
                   "ultimate_join"
               ],
-              "foreach_artifact": None
+              "foreach_artifact": None,
+              "is_inside_foreach": False
           },
           "prepare_foreach2": {
               "name": "prepare_foreach2",
@@ -138,7 +143,8 @@ if __name__ == '__main__':
               "next": [
                   "process_foreach2"
               ],
-              "foreach_artifact": "things"
+              "foreach_artifact": "things",
+              "is_inside_foreach": False
           },
           "process_foreach2": {
               "name": "process_foreach2",
@@ -148,7 +154,8 @@ if __name__ == '__main__':
               "next": [
                   "join2"
               ],
-              "foreach_artifact": None
+              "foreach_artifact": None,
+              "is_inside_foreach": True
           },
           "join2": {
               "name": "join2",
@@ -158,7 +165,8 @@ if __name__ == '__main__':
               "next": [
                   "after_join"
               ],
-              "foreach_artifact": None
+              "foreach_artifact": None,
+              "is_inside_foreach": False
           },
           "after_join": {
               "name": "after_join",
@@ -168,7 +176,8 @@ if __name__ == '__main__':
               "next": [
                   "ultimate_join"
               ],
-              "foreach_artifact": None
+              "foreach_artifact": None,
+              "is_inside_foreach": False
           },
           "ultimate_join": {
               "name": "ultimate_join",
@@ -178,7 +187,8 @@ if __name__ == '__main__':
               "next": [
                   "end"
               ],
-              "foreach_artifact": None
+              "foreach_artifact": None,
+              "is_inside_foreach": False
           },
           "end": {
               "name": "end",
@@ -186,7 +196,8 @@ if __name__ == '__main__':
               "line": 65,
               "doc": "",
               "next": [],
-              "foreach_artifact": None
+              "foreach_artifact": None,
+              "is_inside_foreach": False
           }
       },
       "graph_structure": [
@@ -273,3 +284,4 @@ if __name__ == '__main__':
         pass  # expect a raised exception
     else:
         assert False  # Parsing should have failed
+


### PR DESCRIPTION
### Requirements for a pull request

- [x] Unit tests related to the change have been updated
- [x] Documentation related to the change has been updated

### Description of the Change

This PR exposes the `is_inside_foreach` boolean for DAG steps in the API response. While the service was already calculating this value during graph traversal, it was not being serialized in the final JSON output.

Exposing this field is the backend enhancement for the **Expanded DAG Mode** implemented in [metaflow-ui#180](https://github.com/Netflix/metaflow-ui/pull/180). It allows the UI to:
- Identify steps that belong to a foreach branch.
- Render task iteration grids and foreach-specific metadata correctly.
- Support better task identification (TaskID · Value) as requested in UI [Issue #88](https://github.com/Netflix/metaflow-ui/issues/88). 

### Alternate Designs
\-

### Possible Drawbacks
\-
This is a purely additive change to a JSON response and maintains full backwards compatibility.

### Verification Process

1. **Unit Tests:** Updated [services/ui_backend_service/tests/unit_tests/custom_flowgraph_test.py](cci:7://file:///Users/mac/Desktop/SOB/GSOC/metaflow/metaflow-service/services/ui_backend_service/tests/unit_tests/custom_flowgraph_test.py:0:0-0:0) to verify the new field exists and is correct for all node types (start, linear, split-foreach, join, end).
2. **Logic Validation:** Verified using a test script that `is_inside_foreach` returns `True` only for nodes within the foreach block and `False` for the splitting node and subsequent joins.
3. Addresses Issue #469 

### Release Notes
Exposed `is_inside_foreach` in DAG step metadata to support enhanced foreach visualization in the Metaflow UI.

<img width="803" height="534" alt="Screenshot 2026-03-23 at 3 00 34 PM" src="https://github.com/user-attachments/assets/da0c5f1a-2868-4b0b-9c2f-e0d7172c8814" />
