### PR TITLE
Add limit cap to prevent large payload in runs API

### DIFF
--- a/services/ui_backend_service/api/run.py
+++ b/services/ui_backend_service/api/run.py
@@ -100,6 +100,10 @@ class RunApi(object):
         # due to lack of pg statistics on JSONB fields. To battle this, first execute
         # subquery of ordered list from runs_v3 table in and filter by tags on outer query.
         # This needs more research in the future to further improve performance.
+        _, limit, offset, _, _, _ = pagination_query(request)
+
+        # Prevent very large payloads
+        limit = min(limit, 100)
         builtin_conditions, _ = builtin_conditions_query(request)
         has_tag_filter = len([s for s in builtin_conditions if 'tags||system_tags' in s]) > 0
         if has_tag_filter:


### PR DESCRIPTION
> This PR adds a limit cap to the get_all_runs endpoint to prevent excessively large payloads.

Currently, users can request a very large number of runs which may impact performance. This change ensures that the maximum limit is capped at 100.

This improves API stability and prevents potential performance issues.