### PR TITLE
fix: issues with integration tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,6 @@ deps =
     -rrequirements.dev.txt
 commands = pytest --cov=services
 passenv = MF_METADATA_DB_HOST,MF_METADATA_DB_PORT,MF_METADATA_DB_USER,MF_METADATA_DB_PSWD,MF_METADATA_DB_NAME,MF_UI_METADATA_PORT,MF_UI_METADATA_HOST
-extras = tests
 
 [testenv:pylint]
 commands = pylint -E services --ignored-modules=psycopg2,pygit2


### PR DESCRIPTION
Fixes integration tests not passing due to issues with existing tox.ini and new tox versions.

This was an existing misconfiguration in our tox.ini, and tox has started to validate extras from version `4.36.0` onward. CI broke due to tox not being a pinned dependency