### PR TITLE
ci: declare contents:read on Docker Image CI workflow

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -4,6 +4,9 @@ on:
   release:
     branches: [ master ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Pins `dockerimage.yml` to `contents: read` at workflow scope. The job checks out, runs `docker/metadata-action`, logs into Docker Hub via `DOCKER_USERNAME_NETFLIX_OSS` + `DOCKER_AUTH_TOKEN_NETFLIX_OSS` (external secrets), and pushes via `docker/build-push-action`. The image registry is Docker Hub, not GHCR, so the workflow `GITHUB_TOKEN` is unused for the push path.

Defense-in-depth motivation is [CVE-2025-30066](https://github.com/advisories/GHSA-mrrh-fwg8-r2c3) on `tj-actions/changed-files`: a compromised third-party action runs inside the existing job context and exfiltrates the workflow `GITHUB_TOKEN` via build logs. With `contents: read` only, the token has no write authority to leak.

YAML validated locally with `yaml.safe_load`.