### PR TITLE
Add filtering to the runs endpoint (status, time, user, tags) with cursor support

### DIFF
--- a/services/data/filter_grammar.py
+++ b/services/data/filter_grammar.py
@@ -1,0 +1,132 @@
+"""Filter-condition grammar shared by the metadata service and ui_backend.
+
+Pure functions that parse query params (a MultiDict) into parameterised SQL
+(conditions, values). No web/aiohttp dependency, so either service can import this
+without pulling in the other's web layer. Conditions use %s placeholders with a
+separate values list, so user input is always bound, never interpolated.
+
+The functions are lifted verbatim from services/ui_backend_service/api/utils.py so
+the two services parse filters identically. Once the shared-module location is
+confirmed, ui_backend should import these from here instead of keeping its own copy.
+"""
+
+from typing import List
+from multidict import MultiDict
+
+
+# Built-in conditions, always prefixed with '_' (currently just _tags).
+def builtin_conditions_query_dict(query: MultiDict):
+    conditions = []
+    values = []
+
+    for key, val in query.items():
+        if not key.startswith("_"):
+            continue
+
+        deconstruct = key.split(":", 1)
+        if len(deconstruct) > 1:
+            field = deconstruct[0]
+            operator = deconstruct[1]
+        else:
+            field = key
+            operator = None
+
+        # Tags
+        if field == "_tags":
+            tags = val.split(",")
+            if operator == "likeany" or operator == "likeall":
+                # ?_tags:likeany => LIKE ANY (OR), ?_tags:likeall => LIKE ALL (AND)
+                compare = "ANY" if operator == "likeany" else "ALL"
+                conditions.append(
+                    "tags||system_tags::text LIKE {}(array[{}])".format(
+                        compare, ",".join(["%s"] * len(tags))
+                    )
+                )
+                values += map(lambda t: "%{}%".format(t), tags)
+            else:
+                # ?_tags:any => ?| (OR), ?_tags:all => ?& (AND, the default)
+                compare = "?|" if operator == "any" else "?&"
+                conditions.append(
+                    "tags||system_tags {} array[{}]".format(
+                        compare, ",".join(["%s"] * len(tags))
+                    )
+                )
+                values += tags
+
+    return conditions, values
+
+
+operators_to_sql = {
+    "eq": '"{}" = %s',  # equals
+    "ne": '"{}" != %s',  # not equals
+    "lt": '"{}" < %s',  # less than
+    "le": '"{}" <= %s',  # less than or equals
+    "gt": '"{}" > %s',  # greater than
+    "ge": '"{}" >= %s',  # greater than or equals
+    "co": '"{}" ILIKE %s',  # contains
+    "sw": '"{}" ILIKE %s',  # starts with
+    "ew": '"{}" ILIKE %s',  # ends with
+    "li": '"{}" ILIKE %s',  # ILIKE (caller supplies % in the value)
+    "is": '"{}" IS %s',  # IS
+}
+
+operators_to_sql_values = {
+    "eq": "{}",
+    "ne": "{}",
+    "lt": "{}",
+    "le": "{}",
+    "gt": "{}",
+    "ge": "{}",
+    "co": "%{}%",
+    "sw": "{}%",
+    "ew": "%{}",
+    "li": "{}",
+    "is": "{}",
+}
+
+
+# Custom conditions on table columns, never prefixed with '_'.
+def custom_conditions_query_dict(query: MultiDict, allowed_keys: List[str] = []):
+    conditions = []
+    values = []
+
+    for key, val in query.items():
+        if key.startswith("_"):
+            continue
+
+        deconstruct = key.split(":", 1)
+        if len(deconstruct) > 1:
+            field = deconstruct[0]
+            operator = deconstruct[1]
+        else:
+            field = key
+            operator = "eq"
+
+        if allowed_keys is not None and field not in allowed_keys:
+            continue
+
+        if operator not in operators_to_sql:
+            continue
+
+        vals = val.split(",")
+
+        conditions.append(
+            "({})".format(
+                " OR ".join(
+                    map(
+                        lambda v: operators_to_sql[
+                            "is" if v == "null" else operator
+                        ].format(field),
+                        vals,
+                    )
+                )
+            )
+        )
+        values += map(
+            lambda v: (
+                None if v == "null" else operators_to_sql_values[operator].format(v)
+            ),
+            vals,
+        )
+
+    return conditions, values

--- a/services/data/models.py
+++ b/services/data/models.py
@@ -43,6 +43,8 @@ class RunRow(object):
         tags=None,
         system_tags=None,
         last_heartbeat_ts=None,
+        status=None,
+        user=None,
     ):
         self.flow_id = flow_id
         self.user_name = user_name
@@ -55,10 +57,14 @@ class RunRow(object):
 
         self.ts_epoch = ts_epoch
         self.last_heartbeat_ts = last_heartbeat_ts
+        # derived, only present when the row was fetched with the status join
+        self.status = status
+        # derived verified owner, present when fetched with the filter select columns
+        self.user = user
 
     def serialize(self, expanded: bool = False):
         if expanded:
-            return {
+            body = {
                 "flow_id": self.flow_id,
                 "run_number": self.run_number,
                 "run_id": self.run_id,
@@ -69,7 +75,7 @@ class RunRow(object):
                 "last_heartbeat_ts": self.last_heartbeat_ts,
             }
         else:
-            return {
+            body = {
                 "flow_id": self.flow_id,
                 "run_number": get_exposed_run_id(self.run_number, self.run_id),
                 "user_name": self.user_name,
@@ -78,6 +84,11 @@ class RunRow(object):
                 "system_tags": self.system_tags,
                 "last_heartbeat_ts": self.last_heartbeat_ts,
             }
+        if self.status is not None:
+            body["status"] = self.status
+        if self.user is not None:
+            body["user"] = self.user
+        return body
 
 
 class StepRow(object):

--- a/services/data/postgres_async_db.py
+++ b/services/data/postgres_async_db.py
@@ -784,38 +784,6 @@ class AsyncRunTablePostgres(AsyncPostgresTable):
 
         return await self.get_records(filter_dict=filter_dict)
 
-    async def get_filtered_runs(
-        self,
-        conditions: List[str],
-        values: list,
-        enable_joins: bool = False,
-        limit: int = 0,
-        offset: int = 0,
-        order: List[str] = None,
-    ):
-        # conditions/values come pre-built from the shared filter grammar
-        # (services/data/filter_grammar.py), with a leading flow_id predicate. The
-        # caller sets enable_joins=True only when a status filter is present, since
-        # status is the only derived column needing the lateral joins; user, tags and
-        # ts_epoch filter base (or join-free derived) columns.
-        if len(conditions) <= 1 and not enable_joins:
-            # nothing beyond the flow itself: keep the original join-free query so an
-            # unfiltered listing stays byte-identical to before.
-            flow_id = values[0] if values else None
-            return await self.get_records(
-                filter_dict={"flow_id": flow_id}, ordering=order, limit=limit
-            )
-
-        response, _ = await self.find_records(
-            conditions=conditions,
-            values=values,
-            limit=limit,
-            offset=offset,
-            order=order,
-            enable_joins=enable_joins,
-        )
-        return response
-
     async def get_filtered_runs_paginated(
         self,
         conditions: List[str],

--- a/services/data/postgres_async_db.py
+++ b/services/data/postgres_async_db.py
@@ -44,6 +44,11 @@ METADATA_TABLE_NAME = os.environ.get("DB_TABLE_NAME_METADATA", "metadata_v3")
 ARTIFACT_TABLE_NAME = os.environ.get("DB_TABLE_NAME_ARTIFACT", "artifact_v3")
 DB_SCHEMA_NAME = os.environ.get("DB_SCHEMA_NAME", "public")
 
+# Time before a run with a heartbeat is considered inactive (and thus failed).
+# Default 6 minutes (in seconds). Kept in sync with the ui_backend definition so
+# that status filtering here agrees with the status the UI reports.
+RUN_INACTIVE_CUTOFF_TIME = int(os.environ.get("RUN_INACTIVE_CUTOFF_TIME", 60 * 6))
+
 operator_match = re.compile("([^:]*):([=><]+)$")
 
 # use a ddmmyyy timestamp as the version for triggers
@@ -244,46 +249,6 @@ class AsyncPostgresTable(object):
             cur=cur,
         )
         return response
-
-    async def get_records_paginated(
-        self,
-        filter_dict={},
-        fetch_single=False,
-        ordering: List[str] = None,
-        limit: int = 50,
-        expanded=False,
-        cur: aiopg.Cursor = None,
-    ) -> Tuple[DBResponse, DBPagination]:
-        conditions = []
-        values = []
-        for col_name, col_val in filter_dict.items():
-            if "ts_epoch" in col_name:
-                conditions.append("{} < (%s,%s)".format(col_name))
-                values.extend(col_val)
-                continue
-            conditions.append("{} = %s".format(col_name))
-            values.append(col_val)
-
-        cur_limit = limit + 1
-
-        response, pagination = await self.find_records(
-            conditions=conditions,
-            values=values,
-            fetch_single=fetch_single,
-            order=ordering,
-            limit=cur_limit,
-            expanded=expanded,
-            cur=cur,
-        )
-
-        if len(response.body) > limit:
-            response = response._replace(body=response.body[:limit])
-        else:
-            pagination = pagination._replace(next_cursor_record=None)
-
-        pagination = pagination._replace(limit=str(limit))
-
-        return response, pagination
 
     async def find_records(
         self,
@@ -710,8 +675,85 @@ class AsyncRunTablePostgres(AsyncPostgresTable):
     ]
     primary_keys = ["flow_id", "run_number"]
     trigger_keys = primary_keys + ["last_heartbeat_ts"]
-    select_columns = keys
     flow_table_name = AsyncFlowTablePostgres.table_name
+
+    # Derived run status (running/completed/failed). This mirrors the definition in
+    # ui_backend_service so filtering agrees with what the UI shows. The two lateral
+    # joins below pull the 'end' step's attempt metadata that the status depends on.
+    # Only used when joins are enabled (i.e. when filtering by status), so the plain
+    # get_all_runs path stays a simple, join-free query.
+    joins = [
+        """
+        LEFT JOIN LATERAL (
+            SELECT
+                ts_epoch,
+                (CASE
+                    WHEN pg_typeof(value)='jsonb'::regtype
+                    THEN value::jsonb->>0
+                    ELSE value::text
+                END)::boolean as value
+            FROM {metadata_table} as attempt_ok
+            WHERE
+                {table_name}.flow_id = attempt_ok.flow_id AND
+                {table_name}.run_number = attempt_ok.run_number AND
+                attempt_ok.step_name = 'end' AND
+                attempt_ok.field_name = 'attempt_ok'
+            ORDER BY ts_epoch DESC
+            LIMIT 1
+        ) as end_attempt_ok ON true
+        """.format(table_name=RUN_TABLE_NAME, metadata_table=METADATA_TABLE_NAME),
+        """
+        LEFT JOIN LATERAL (
+            SELECT ts_epoch
+            FROM {metadata_table} as attempt
+            WHERE
+                {table_name}.flow_id = attempt.flow_id AND
+                {table_name}.run_number = attempt.run_number AND
+                attempt.step_name = 'end' AND
+                attempt.field_name = 'attempt' AND
+                end_attempt_ok.value IS FALSE
+            ORDER BY ts_epoch DESC
+            LIMIT 1
+        ) as end_attempt ON true
+        """.format(table_name=RUN_TABLE_NAME, metadata_table=METADATA_TABLE_NAME),
+    ]
+
+    join_columns = [
+        """
+        (CASE
+            WHEN end_attempt IS NOT NULL
+                AND end_attempt_ok.ts_epoch < end_attempt.ts_epoch
+            THEN 'running'
+            WHEN end_attempt_ok IS NOT NULL AND end_attempt_ok.value IS TRUE
+            THEN 'completed'
+            WHEN end_attempt_ok IS NOT NULL AND end_attempt_ok.value IS FALSE
+            THEN 'failed'
+            WHEN {table_name}.last_heartbeat_ts IS NOT NULL
+                AND @(extract(epoch from now())-{table_name}.last_heartbeat_ts)<={cutoff}
+            THEN 'running'
+            ELSE 'failed'
+        END) AS status
+        """.format(table_name=RUN_TABLE_NAME, cutoff=RUN_INACTIVE_CUTOFF_TIME),
+    ]
+
+    @property
+    def select_columns(self):
+        # NOTE: a function scope is used so the comprehension can access table_name.
+        # Base columns are qualified so they stay unambiguous once the status joins are in
+        # play. 'user' is the verified owner: NULL unless a 'user:<name>' system tag is
+        # present (e.g. AWS Step Functions runs have none). Mirrors the ui_backend run
+        # table so filtering agrees with what the UI labels as the owner.
+        return [
+            "{table_name}.{col} AS {col}".format(table_name=self.table_name, col=k)
+            for k in self.keys
+        ] + [
+            """
+                (CASE
+                    WHEN system_tags ? ('user:' || user_name)
+                    THEN user_name
+                    ELSE NULL
+                END) AS user"""
+        ]
 
     async def add_run(self, run: RunRow, fill_heartbeat: bool = False):
         dict = {
@@ -742,21 +784,78 @@ class AsyncRunTablePostgres(AsyncPostgresTable):
 
         return await self.get_records(filter_dict=filter_dict)
 
-    async def get_all_runs_paginated(
-        self, flow_id: str, cur_ts: int = None, cur_run: int = None, limit: int = None
+    async def get_filtered_runs(
+        self,
+        conditions: List[str],
+        values: list,
+        enable_joins: bool = False,
+        limit: int = 0,
+        offset: int = 0,
+        order: List[str] = None,
     ):
-        if cur_ts is None or cur_run is None:
-            filter_dict = {"flow_id": flow_id}
-        else:
-            filter_dict = {
-                "flow_id": flow_id,
-                "(ts_epoch, run_number)": [cur_ts, cur_run],
-            }
-        order = ["ts_epoch DESC", "run_number DESC"]
+        # conditions/values come pre-built from the shared filter grammar
+        # (services/data/filter_grammar.py), with a leading flow_id predicate. The
+        # caller sets enable_joins=True only when a status filter is present, since
+        # status is the only derived column needing the lateral joins; user, tags and
+        # ts_epoch filter base (or join-free derived) columns.
+        if len(conditions) <= 1 and not enable_joins:
+            # nothing beyond the flow itself: keep the original join-free query so an
+            # unfiltered listing stays byte-identical to before.
+            flow_id = values[0] if values else None
+            return await self.get_records(
+                filter_dict={"flow_id": flow_id}, ordering=order, limit=limit
+            )
 
-        return await self.get_records_paginated(
-            filter_dict=filter_dict, limit=limit, ordering=order
+        response, _ = await self.find_records(
+            conditions=conditions,
+            values=values,
+            limit=limit,
+            offset=offset,
+            order=order,
+            enable_joins=enable_joins,
         )
+        return response
+
+    async def get_filtered_runs_paginated(
+        self,
+        conditions: List[str],
+        values: list,
+        enable_joins: bool = False,
+        limit: int = 50,
+        cur_ts: int = None,
+        cur_run: int = None,
+    ) -> Tuple[DBResponse, DBPagination]:
+        # Cursor pagination over the filtered result set. Keys off
+        # (ts_epoch, run_number) DESC, identical to the cursor pagination added for the
+        # unfiltered endpoint (#482), so a client can page filtered runs the same way.
+        # The filter conditions/values come pre-built from the grammar; we append the
+        # keyset predicate so paging walks the ordered, filtered set deterministically.
+        conditions = list(conditions)
+        values = list(values)
+        if cur_ts is not None and cur_run is not None:
+            conditions.append("(ts_epoch, run_number) < (%s,%s)")
+            values.extend([cur_ts, cur_run])
+
+        order = ["ts_epoch DESC", "run_number DESC"]
+        # fetch one extra row to detect whether a further page exists
+        cur_limit = limit + 1
+
+        response, pagination = await self.find_records(
+            conditions=conditions,
+            values=values,
+            limit=cur_limit,
+            order=order,
+            enable_joins=enable_joins,
+        )
+
+        if len(response.body) > limit:
+            response = response._replace(body=response.body[:limit])
+        else:
+            pagination = pagination._replace(next_cursor_record=None)
+
+        pagination = pagination._replace(limit=str(limit))
+
+        return response, pagination
 
     async def update_heartbeat(self, flow_id: str, run_id: str):
         run_key, run_value = translate_run_key(run_id)

--- a/services/metadata_service/api/run.py
+++ b/services/metadata_service/api/run.py
@@ -6,6 +6,67 @@ from services.data.models import RunRow
 from services.utils import has_heartbeat_capable_version_tag, read_body
 from services.metadata_service.api.utils import format_response, handle_exceptions
 from services.data.postgres_async_db import AsyncPostgresDB
+from services.data.filter_grammar import (
+    builtin_conditions_query_dict,
+    custom_conditions_query_dict,
+    operators_to_sql,
+)
+
+# Statuses a run can be filtered by, matching the values the status query derives.
+SUPPORTED_RUN_STATUSES = {"running", "completed", "failed"}
+
+# Fields the runs endpoint accepts in the field:operator filter grammar: the base run
+# columns plus the derived 'status' (lateral joins) and 'user' (verified owner).
+RUN_ALLOWED_FILTERS = [
+    "flow_id",
+    "run_number",
+    "run_id",
+    "user_name",
+    "ts_epoch",
+    "last_heartbeat_ts",
+    "tags",
+    "system_tags",
+    "user",
+    "status",
+]
+# Fields whose values must be integer epoch milliseconds.
+_NUMERIC_FILTERS = {"ts_epoch", "last_heartbeat_ts"}
+
+
+def _split_field_op(key):
+    field, _, operator = key.partition(":")
+    return field, (operator or "eq")
+
+
+def _validate_run_filters(query):
+    """Fail loud on malformed filters the generic grammar would otherwise silently drop.
+
+    Returns an error string, or None when the filters are acceptable. Preserves the
+    contract that a bad status value, a non-integer time bound, or an unknown operator
+    on a known field is a 400 rather than a silently-ignored filter.
+    """
+    for key, val in query.items():
+        if key.startswith("_"):
+            continue
+        field, operator = _split_field_op(key)
+        if field not in RUN_ALLOWED_FILTERS:
+            continue  # unknown field: ignored, not an error
+        if operator not in operators_to_sql:
+            return "unsupported operator '%s' for field '%s'" % (operator, field)
+        for v in val.split(","):
+            if v == "null":
+                continue
+            if field == "status" and v not in SUPPORTED_RUN_STATUSES:
+                return "unsupported status filter: %s" % v
+            if field in _NUMERIC_FILTERS:
+                try:
+                    int(v)
+                except (TypeError, ValueError):
+                    return (
+                        "invalid %s: expected integer epoch milliseconds, got '%s'"
+                        % (field, v)
+                    )
+    return None
 
 
 class RunApi(object):
@@ -64,7 +125,7 @@ class RunApi(object):
     async def get_all_runs(self, request):
         """
         ---
-        description: Get all runs
+        description: Get all runs of a flow, optionally filtered and/or cursor-paginated
         tags:
         - Run
         parameters:
@@ -73,29 +134,76 @@ class RunApi(object):
           description: "flow_id"
           required: true
           type: "string"
+        - name: "status"
+          in: "query"
+          description: "filter by status, e.g. status:eq=running or status:eq=running,failed (OR). Status is derived relative to the heartbeat cutoff, so a multi-status filter that includes running is time-relative, not fully deterministic."
+          required: false
+          type: "string"
+        - name: "user"
+          in: "query"
+          description: "filter by verified owner, e.g. user:eq=alice (system tag user:<name>)."
+          required: false
+          type: "string"
+        - name: "ts_epoch"
+          in: "query"
+          description: "filter by start time, e.g. ts_epoch:ge=123&ts_epoch:le=456 (epoch ms)."
+          required: false
+          type: "string"
+        - name: "_tags"
+          in: "query"
+          description: "filter by tags, e.g. _tags:any=a,b (OR) or _tags:all=a,b (AND)."
+          required: false
+          type: "string"
         - name: "_cursor"
           in: "query"
-          description: "cursor"
+          description: "opaque pagination cursor, returned via the X-Next-Cursor header."
           required: false
           type: "string"
         - name: "_limit"
           in: "query"
-          description: "limit"
+          description: "page size (default 50, max 500). Supplying _limit or _cursor turns on cursor pagination."
           required: false
           type: "string"
         produces:
         - text/plain
         responses:
             "200":
-                description: Returned all runs of specified flow
+                description: Returned the matching runs of the specified flow
+            "400":
+                description: unsupported status value, non-integer time bound, unknown operator, or invalid cursor
             "405":
                 description: invalid HTTP Method
-            "400":
-                description: invalid cursor
         """
         flow_name = request.match_info.get("flow_id")
-        cursor = request.query.get("_cursor")
-        limit = request.query.get("_limit")
+        query = request.query
+
+        err = _validate_run_filters(query)
+        if err:
+            return DBResponse(response_code=400, body=err)
+
+        # Parse the field:operator filter grammar into parameterised SQL (shared with
+        # the ui_backend so the two services filter identically).
+        builtin_cond, builtin_vals = builtin_conditions_query_dict(
+            query
+        )  # _tags:any/all
+        custom_cond, custom_vals = custom_conditions_query_dict(
+            query, RUN_ALLOWED_FILTERS
+        )
+        conditions = ['"flow_id" = %s'] + builtin_cond + custom_cond
+        values = [flow_name] + list(builtin_vals) + list(custom_vals)
+
+        # status is the only derived column needing the lateral joins; turn them on
+        # only when a status predicate is actually requested.
+        requested_fields = {
+            _split_field_op(k)[0] for k in query if not k.startswith("_")
+        }
+        enable_joins = "status" in requested_fields
+
+        # Cursor pagination (mirrors the unfiltered endpoint added in #482): _cursor
+        # encodes the last (ts_epoch, run_number) seen; _limit sets the page size. When
+        # neither is present we keep the legacy raw-array response over the filtered set.
+        cursor = query.get("_cursor")
+        limit = query.get("_limit")
 
         cur_ts, cur_run = None, None
         if cursor:
@@ -108,12 +216,19 @@ class RunApi(object):
                 return DBResponse(response_code=400, body="Invalid cursor")
 
         if limit is None and cursor is None:
-            return await self._async_table.get_all_runs(flow_name)
+            return await self._async_table.get_filtered_runs(
+                conditions=conditions, values=values, enable_joins=enable_joins
+            )
 
         limit = min(int(limit), 500) if limit else 50
 
-        response, pagination = await self._async_table.get_all_runs_paginated(
-            flow_name, cur_ts, cur_run, limit
+        response, pagination = await self._async_table.get_filtered_runs_paginated(
+            conditions=conditions,
+            values=values,
+            enable_joins=enable_joins,
+            limit=limit,
+            cur_ts=cur_ts,
+            cur_run=cur_run,
         )
 
         if pagination.next_cursor_record:

--- a/services/metadata_service/api/run.py
+++ b/services/metadata_service/api/run.py
@@ -189,7 +189,19 @@ class RunApi(object):
         custom_cond, custom_vals = custom_conditions_query_dict(
             query, RUN_ALLOWED_FILTERS
         )
-        conditions = ['"flow_id" = %s'] + builtin_cond + custom_cond
+        filter_conditions = builtin_cond + custom_cond
+
+        cursor = query.get("_cursor")
+        limit = query.get("_limit")
+
+        # Backwards-compatible fast path: with neither filters nor pagination, fall back
+        # to the original unfiltered, join-free listing (raw array) that older clients
+        # expect. New clients support filtering and cursor pagination together, so any
+        # filter or pagination param drops through to the paginated path below.
+        if not filter_conditions and cursor is None and limit is None:
+            return await self._async_table.get_all_runs(flow_name)
+
+        conditions = ['"flow_id" = %s'] + filter_conditions
         values = [flow_name] + list(builtin_vals) + list(custom_vals)
 
         # status is the only derived column needing the lateral joins; turn them on
@@ -198,12 +210,6 @@ class RunApi(object):
             _split_field_op(k)[0] for k in query if not k.startswith("_")
         }
         enable_joins = "status" in requested_fields
-
-        # Cursor pagination (mirrors the unfiltered endpoint added in #482): _cursor
-        # encodes the last (ts_epoch, run_number) seen; _limit sets the page size. When
-        # neither is present we keep the legacy raw-array response over the filtered set.
-        cursor = query.get("_cursor")
-        limit = query.get("_limit")
 
         cur_ts, cur_run = None, None
         if cursor:
@@ -214,11 +220,6 @@ class RunApi(object):
                 )
             except ValueError:
                 return DBResponse(response_code=400, body="Invalid cursor")
-
-        if limit is None and cursor is None:
-            return await self._async_table.get_filtered_runs(
-                conditions=conditions, values=values, enable_joins=enable_joins
-            )
 
         limit = min(int(limit), 500) if limit else 50
 

--- a/services/metadata_service/tests/integration_tests/run_test.py
+++ b/services/metadata_service/tests/integration_tests/run_test.py
@@ -333,11 +333,10 @@ async def test_runs_get_status_filter_composes_with_pagination(cli, db):
     # conditions/values shaped exactly as the handler builds them from ?status:eq=failed
     conditions = ['"flow_id" = %s', '("status" = %s)']
     values = [_flow["flow_id"], "failed"]
-    page = (
-        await db.run_table_postgres.get_filtered_runs(
-            conditions, values, enable_joins=True, limit=2, order=["run_number DESC"]
-        )
-    ).body
+    response, _ = await db.run_table_postgres.get_filtered_runs_paginated(
+        conditions, values, enable_joins=True, limit=2
+    )
+    page = response.body
 
     assert len(page) == 2
     assert all(r["status"] == "failed" for r in page)

--- a/services/metadata_service/tests/integration_tests/run_test.py
+++ b/services/metadata_service/tests/integration_tests/run_test.py
@@ -371,6 +371,37 @@ async def test_runs_get_time_range_filter(cli, db):
     assert await _run_numbers(cli, flow_id) == everyone
 
 
+async def test_runs_get_time_range_strict_operators(cli, db):
+    # multiple operators on the same field compose (the ts_epoch:gt=..&ts_epoch:lt=..
+    # example from the review). gt/lt are exclusive, so a strict window drops the runs
+    # sitting exactly on the bounds.
+    _flow = (
+        await add_flow(db, "StrictTimeFlow", "test_user-1", ["a_tag"], ["runtime:test"])
+    ).body
+    flow_id = _flow["flow_id"]
+
+    async def run_at(ts):
+        run = (await add_run(db, flow_id=flow_id)).body
+        await db.run_table_postgres.update_row(
+            filter_dict={"flow_id": flow_id, "run_number": run["run_number"]},
+            update_dict={"ts_epoch": ts},
+        )
+        return run["run_number"]
+
+    low = await run_at(1000)
+    mid = await run_at(2000)
+    high = await run_at(3000)
+
+    # gt and lt on one field, together: strictly between the bounds -> only the middle run
+    assert await _run_numbers(cli, flow_id, "?ts_epoch:gt=1000&ts_epoch:lt=3000") == {
+        mid
+    }
+    # exclusive lower bound drops the run sitting on it
+    assert await _run_numbers(cli, flow_id, "?ts_epoch:gt=1000") == {mid, high}
+    # exclusive upper bound drops the run sitting on it
+    assert await _run_numbers(cli, flow_id, "?ts_epoch:lt=3000") == {low, mid}
+
+
 async def test_runs_get_time_range_partitions_runs(cli, db):
     # stamp deterministic timestamps so the window genuinely splits the set.
     _flow = (

--- a/services/metadata_service/tests/integration_tests/run_test.py
+++ b/services/metadata_service/tests/integration_tests/run_test.py
@@ -13,12 +13,21 @@ from .utils import (
     compare_partial,
     add_flow,
     add_run,
+    add_metadata,
     assert_api_patch_response,
     assert_paginated_api_get_response,
 )
+from services.data.postgres_async_db import RUN_INACTIVE_CUTOFF_TIME
 import pytest
 
 pytestmark = [pytest.mark.integration_tests]
+
+
+async def _run_numbers(cli, flow_id, query=""):
+    # the metadata service serves json as text/plain, so parse the body ourselves
+    resp = await cli.get("/flows/{flow_id}/runs{q}".format(flow_id=flow_id, q=query))
+    assert resp.status == 200
+    return {r["run_number"] for r in json.loads(await resp.text())}
 
 
 async def test_run_post(cli, db):
@@ -155,29 +164,458 @@ async def test_runs_get(cli, db):
     )
 
 
-async def test_run_get(cli, db):
-    # create flow for test
+async def test_runs_get_status_filter(cli, db):
+    # a run with a fresh heartbeat reads as "running"; one without ever reads as "failed".
+    # that's enough to exercise filtering without seeding attempt metadata.
     _flow = (
-        await add_flow(
-            db, "TestFlow", "test_user-1", ["a_tag", "b_tag"], ["runtime:test"]
+        await add_flow(db, "StatusFlow", "test_user-1", ["a_tag"], ["runtime:test"])
+    ).body
+
+    _running = (
+        await add_run(db, flow_id=_flow["flow_id"], last_heartbeat_ts=int(time.time()))
+    ).body
+    _failed = (await add_run(db, flow_id=_flow["flow_id"])).body
+
+    flow_id = _flow["flow_id"]
+    assert await _run_numbers(cli, flow_id, "?status:eq=running") == {
+        _running["run_number"]
+    }
+    assert await _run_numbers(cli, flow_id, "?status:eq=failed") == {
+        _failed["run_number"]
+    }
+    # comma-separated values in one param are an OR
+    assert await _run_numbers(cli, flow_id, "?status:eq=running,failed") == {
+        _running["run_number"],
+        _failed["run_number"],
+    }
+    # no filter still returns everything
+    assert await _run_numbers(cli, flow_id) == {
+        _running["run_number"],
+        _failed["run_number"],
+    }
+
+
+async def test_runs_get_status_filter_completed(cli, db):
+    # a run whose 'end' step recorded a successful attempt reads as "completed".
+    # this is the path that actually exercises the attempt-metadata join.
+    _flow = (
+        await add_flow(db, "DoneFlow", "test_user-1", ["a_tag"], ["runtime:test"])
+    ).body
+
+    _done = (await add_run(db, flow_id=_flow["flow_id"])).body
+    await add_metadata(
+        db,
+        flow_id=_done["flow_id"],
+        run_number=_done["run_number"],
+        step_name="end",
+        task_id=1,
+        metadata={"field_name": "attempt_ok", "value": "true"},
+    )
+    _bare = (await add_run(db, flow_id=_flow["flow_id"])).body
+
+    flow_id = _flow["flow_id"]
+    assert await _run_numbers(cli, flow_id, "?status:eq=completed") == {
+        _done["run_number"]
+    }
+    assert await _run_numbers(cli, flow_id, "?status:eq=failed") == {
+        _bare["run_number"]
+    }
+
+
+async def test_runs_get_status_filter_rejects_unknown(cli, db):
+    _flow = (
+        await add_flow(db, "BadFlow", "test_user-1", ["a_tag"], ["runtime:test"])
+    ).body
+    await add_run(db, flow_id=_flow["flow_id"])
+
+    resp = await cli.get("/flows/{flow_id}/runs?status:eq=bogus".format(**_flow))
+    assert resp.status == 400
+
+
+async def test_runs_get_status_filter_classification(cli, db):
+    # one run per branch of the status expression, asserted as three disjoint buckets.
+    _flow = (
+        await add_flow(db, "MatrixFlow", "test_user-1", ["a_tag"], ["runtime:test"])
+    ).body
+    now = int(time.time())
+
+    async def end_attempt_ok(run, ok):
+        await add_metadata(
+            db,
+            flow_id=run["flow_id"],
+            run_number=run["run_number"],
+            step_name="end",
+            task_id=1,
+            metadata={"field_name": "attempt_ok", "value": str(ok)},
+        )
+
+    # a successful end attempt wins even over a fresh heartbeat
+    _completed = (
+        await add_run(db, flow_id=_flow["flow_id"], last_heartbeat_ts=now)
+    ).body
+    await end_attempt_ok(_completed, True)
+    # an explicitly unsuccessful end attempt
+    _failed_attempt = (await add_run(db, flow_id=_flow["flow_id"])).body
+    await end_attempt_ok(_failed_attempt, False)
+    # a heartbeat too old to still count as running
+    _stale = (
+        await add_run(
+            db,
+            flow_id=_flow["flow_id"],
+            last_heartbeat_ts=now - RUN_INACTIVE_CUTOFF_TIME - 60,
+        )
+    ).body
+    # a recent heartbeat with no end attempt
+    _running = (await add_run(db, flow_id=_flow["flow_id"], last_heartbeat_ts=now)).body
+
+    flow_id = _flow["flow_id"]
+    assert await _run_numbers(cli, flow_id, "?status:eq=completed") == {
+        _completed["run_number"]
+    }
+    assert await _run_numbers(cli, flow_id, "?status:eq=running") == {
+        _running["run_number"]
+    }
+    assert await _run_numbers(cli, flow_id, "?status:eq=failed") == {
+        _failed_attempt["run_number"],
+        _stale["run_number"],
+    }
+
+
+async def test_runs_get_status_filter_retrying(cli, db):
+    # the first CASE branch: a run whose 'end' step failed (attempt_ok=false) but has a
+    # *newer* 'attempt' record is being retried, so it reads as running, not failed.
+    # The branch turns on a strict ts_epoch comparison between the two metadata rows, so
+    # stamp their timestamps explicitly rather than trusting insert order.
+    _flow = (
+        await add_flow(db, "RetryFlow", "test_user-1", ["a_tag"], ["runtime:test"])
+    ).body
+    flow_id = _flow["flow_id"]
+    _retrying = (await add_run(db, flow_id=flow_id)).body
+
+    async def stamp_end_metadata(field_name, value, ts):
+        md = (
+            await add_metadata(
+                db,
+                flow_id=flow_id,
+                run_number=_retrying["run_number"],
+                step_name="end",
+                task_id=1,
+                metadata={"field_name": field_name, "value": value},
+            )
+        ).body
+        await db.metadata_table_postgres.update_row(
+            filter_dict={"id": md["id"]}, update_dict={"ts_epoch": ts}
+        )
+
+    # end step failed at T=1000, then a new attempt started at T=2000 (the retry)
+    await stamp_end_metadata("attempt_ok", "false", 1000)
+    await stamp_end_metadata("attempt", "1", 2000)
+
+    assert await _run_numbers(cli, flow_id, "?status:eq=running") == {
+        _retrying["run_number"]
+    }
+    assert await _run_numbers(cli, flow_id, "?status:eq=failed") == set()
+
+
+async def test_runs_get_status_filter_composes_with_pagination(cli, db):
+    # a filter has to ride on top of pagination: a limited page of "failed" runs must
+    # be the matching rows taken *after* filtering, not a limited slice that then gets
+    # filtered down.
+    _flow = (
+        await add_flow(db, "PageFlow", "test_user-1", ["a_tag"], ["runtime:test"])
+    ).body
+
+    failed = [(await add_run(db, flow_id=_flow["flow_id"])).body for _ in range(3)]
+    await add_run(
+        db, flow_id=_flow["flow_id"], last_heartbeat_ts=int(time.time())
+    )  # running
+
+    # conditions/values shaped exactly as the handler builds them from ?status:eq=failed
+    conditions = ['"flow_id" = %s', '("status" = %s)']
+    values = [_flow["flow_id"], "failed"]
+    page = (
+        await db.run_table_postgres.get_filtered_runs(
+            conditions, values, enable_joins=True, limit=2, order=["run_number DESC"]
         )
     ).body
 
-    # add run to flow for testing
-    _run = (await add_run(db, flow_id=_flow["flow_id"])).body
+    assert len(page) == 2
+    assert all(r["status"] == "failed" for r in page)
+    newest_two = sorted((r["run_number"] for r in failed), reverse=True)[:2]
+    assert [r["run_number"] for r in page] == newest_two
 
-    # try to get created flow
-    await assert_api_get_response(
-        cli, "/flows/{flow_id}/runs/{run_number}".format(**_run), data=_run
+
+async def test_runs_get_time_range_filter(cli, db):
+    # ts_epoch is stamped by the DB, so read it back and use the observed min/max as
+    # bounds. Bounds are inclusive; a window outside the data returns nothing.
+    _flow = (
+        await add_flow(db, "TimeFlow", "test_user-1", ["a_tag"], ["runtime:test"])
+    ).body
+    flow_id = _flow["flow_id"]
+
+    runs = [(await add_run(db, flow_id=flow_id)).body for _ in range(3)]
+    epochs = [int(r["ts_epoch"]) for r in runs]
+    lo, hi = min(epochs), max(epochs)
+    everyone = {r["run_number"] for r in runs}
+
+    # inclusive bounds: an endpoint exactly on the data still matches it
+    assert await _run_numbers(cli, flow_id, "?ts_epoch:ge=%d" % lo) == everyone
+    assert await _run_numbers(cli, flow_id, "?ts_epoch:le=%d" % hi) == everyone
+    assert (
+        await _run_numbers(cli, flow_id, "?ts_epoch:ge=%d&ts_epoch:le=%d" % (lo, hi))
+        == everyone
+    )
+    # windows that sit entirely outside the data are empty, not an error
+    assert await _run_numbers(cli, flow_id, "?ts_epoch:ge=%d" % (hi + 1)) == set()
+    assert await _run_numbers(cli, flow_id, "?ts_epoch:le=%d" % (lo - 1)) == set()
+    # no bound still returns everything
+    assert await _run_numbers(cli, flow_id) == everyone
+
+
+async def test_runs_get_time_range_partitions_runs(cli, db):
+    # stamp deterministic timestamps so the window genuinely splits the set.
+    _flow = (
+        await add_flow(db, "StampFlow", "test_user-1", ["a_tag"], ["runtime:test"])
+    ).body
+    flow_id = _flow["flow_id"]
+
+    async def run_at(ts):
+        run = (await add_run(db, flow_id=flow_id)).body
+        await db.run_table_postgres.update_row(
+            filter_dict={"flow_id": flow_id, "run_number": run["run_number"]},
+            update_dict={"ts_epoch": ts},
+        )
+        return run["run_number"]
+
+    old = await run_at(1000)
+    mid = await run_at(2000)
+    new = await run_at(3000)
+
+    assert await _run_numbers(cli, flow_id, "?ts_epoch:ge=2000") == {mid, new}
+    assert await _run_numbers(cli, flow_id, "?ts_epoch:le=2000") == {old, mid}
+    assert await _run_numbers(cli, flow_id, "?ts_epoch:ge=1500&ts_epoch:le=2500") == {
+        mid
+    }
+
+
+async def test_runs_get_time_range_rejects_non_integer(cli, db):
+    _flow = (
+        await add_flow(db, "BadTimeFlow", "test_user-1", ["a_tag"], ["runtime:test"])
+    ).body
+    await add_run(db, flow_id=_flow["flow_id"])
+
+    # a programmatic consumer passing a malformed bound should fail loud, not be
+    # silently ignored (same stance as an unknown status).
+    assert (
+        await cli.get("/flows/{flow_id}/runs?ts_epoch:ge=notanumber".format(**_flow))
+    ).status == 400
+    assert (
+        await cli.get("/flows/{flow_id}/runs?ts_epoch:le=2026-01-01".format(**_flow))
+    ).status == 400
+
+
+async def test_runs_get_status_and_time_range_compose(cli, db):
+    # status and time-range are ANDed, so a run must satisfy both to be returned.
+    _flow = (
+        await add_flow(db, "ComposeFlow", "test_user-1", ["a_tag"], ["runtime:test"])
+    ).body
+    flow_id = _flow["flow_id"]
+
+    async def run_at(ts, **kw):
+        run = (await add_run(db, flow_id=flow_id, **kw)).body
+        await db.run_table_postgres.update_row(
+            filter_dict={"flow_id": flow_id, "run_number": run["run_number"]},
+            update_dict={"ts_epoch": ts},
+        )
+        return run["run_number"]
+
+    now = int(time.time())
+    old_failed = await run_at(1000)  # failed, before window
+    new_failed = await run_at(3000)  # failed, inside window
+    new_running = await run_at(3000, last_heartbeat_ts=now)  # running, inside window
+
+    # status alone catches both failed runs regardless of time
+    assert await _run_numbers(cli, flow_id, "?status:eq=failed") == {
+        old_failed,
+        new_failed,
+    }
+    # adding a time bound narrows it to the failed run inside the window
+    assert await _run_numbers(cli, flow_id, "?status:eq=failed&ts_epoch:ge=2000") == {
+        new_failed
+    }
+    # the running run is inside the window but excluded by the status predicate
+    assert await _run_numbers(cli, flow_id, "?status:eq=running&ts_epoch:ge=2000") == {
+        new_running
+    }
+    # a status that matches but a window that does not yields nothing
+    assert (
+        await _run_numbers(cli, flow_id, "?status:eq=running&ts_epoch:le=2000") == set()
     )
 
-    # non-existent flow or run should return 404
-    await assert_api_get_response(
-        cli, "/flows/{flow_id}/runs/1234".format(**_run), status=404
-    )
-    await assert_api_get_response(
-        cli, "/flows/NonExistentFlow/runs/{run_number}".format(**_run), status=404
-    )
+
+async def test_runs_get_user_filter(cli, db):
+    # 'user' is the verified owner: the run must carry a 'user:<name>' system tag.
+    # A run with a user_name but no such tag (e.g. Step Functions) must not match.
+    _flow = (
+        await add_flow(db, "UserFlow", "test_user-1", ["a_tag"], ["runtime:test"])
+    ).body
+    flow_id = _flow["flow_id"]
+
+    _alice = (
+        await add_run(
+            db, flow_id=flow_id, user_name="alice", system_tags=["user:alice"]
+        )
+    ).body
+    _bob = (
+        await add_run(db, flow_id=flow_id, user_name="bob", system_tags=["user:bob"])
+    ).body
+    # user_name is set but there is no 'user:' system tag -> unverified -> no match
+    _ghost = (
+        await add_run(
+            db, flow_id=flow_id, user_name="carol", system_tags=["runtime:sfn"]
+        )
+    ).body
+
+    assert await _run_numbers(cli, flow_id, "?user:eq=alice") == {_alice["run_number"]}
+    # comma-separated values are an OR
+    assert await _run_numbers(cli, flow_id, "?user:eq=alice,bob") == {
+        _alice["run_number"],
+        _bob["run_number"],
+    }
+    # the unverified run is excluded even though its user_name is 'carol'
+    assert await _run_numbers(cli, flow_id, "?user:eq=carol") == set()
+    # no filter still returns everything, including the unverified run
+    assert await _run_numbers(cli, flow_id) == {
+        _alice["run_number"],
+        _bob["run_number"],
+        _ghost["run_number"],
+    }
+
+
+async def test_runs_get_status_user_and_time_compose(cli, db):
+    # status, user and time-range compose into compound filtering
+    # ("alice's failed runs since T") with no special-casing.
+    _flow = (
+        await add_flow(db, "TriadFlow", "test_user-1", ["a_tag"], ["runtime:test"])
+    ).body
+    flow_id = _flow["flow_id"]
+
+    async def run_at(ts, user, **kw):
+        run = (
+            await add_run(
+                db,
+                flow_id=flow_id,
+                user_name=user,
+                system_tags=["user:%s" % user],
+                **kw,
+            )
+        ).body
+        await db.run_table_postgres.update_row(
+            filter_dict={"flow_id": flow_id, "run_number": run["run_number"]},
+            update_dict={"ts_epoch": ts},
+        )
+        return run["run_number"]
+
+    now = int(time.time())
+    alice_old_failed = await run_at(1000, "alice")  # wrong window
+    alice_new_failed = await run_at(3000, "alice")  # the target
+    await run_at(3000, "alice", last_heartbeat_ts=now)  # wrong status (running)
+    await run_at(3000, "bob")  # wrong user
+
+    # each predicate removes one decoy; only alice_new_failed satisfies all three
+    assert await _run_numbers(
+        cli, flow_id, "?status:eq=failed&user:eq=alice&ts_epoch:ge=2000"
+    ) == {alice_new_failed}
+    # drop the time bound -> both of alice's failed runs, but still not bob's/running
+    assert await _run_numbers(cli, flow_id, "?status:eq=failed&user:eq=alice") == {
+        alice_old_failed,
+        alice_new_failed,
+    }
+
+
+async def test_runs_get_tag_filter(cli, db):
+    # _tags:any matches tags and system_tags combined (OR over the listed tags).
+    _flow = (
+        await add_flow(db, "TagFlow", "test_user-1", ["a_tag"], ["runtime:test"])
+    ).body
+    flow_id = _flow["flow_id"]
+
+    _prod = (await add_run(db, flow_id=flow_id, tags=["env:prod"])).body
+    _dev = (await add_run(db, flow_id=flow_id, tags=["env:dev"])).body
+    # tag lives in system_tags, not tags -> still matches the combined set
+    _sys = (
+        await add_run(db, flow_id=flow_id, tags=["x"], system_tags=["team:ml"])
+    ).body
+
+    assert await _run_numbers(cli, flow_id, "?_tags:any=env:prod") == {
+        _prod["run_number"]
+    }
+    # comma-separated values are an OR
+    assert await _run_numbers(cli, flow_id, "?_tags:any=env:prod,env:dev") == {
+        _prod["run_number"],
+        _dev["run_number"],
+    }
+    # a system tag matches too
+    assert await _run_numbers(cli, flow_id, "?_tags:any=team:ml") == {
+        _sys["run_number"]
+    }
+    # _tags:all requires every listed tag (AND): only _prod has env:prod AND run_sys_tag
+    assert await _run_numbers(cli, flow_id, "?_tags:all=env:prod,run_sys_tag") == {
+        _prod["run_number"]
+    }
+    # unknown tag matches nothing
+    assert await _run_numbers(cli, flow_id, "?_tags:any=nope") == set()
+    # no filter still returns everything
+    assert await _run_numbers(cli, flow_id) == {
+        _prod["run_number"],
+        _dev["run_number"],
+        _sys["run_number"],
+    }
+
+
+async def test_runs_get_tag_and_status_compose(cli, db):
+    # tag is just one more ANDed predicate, so it composes with status.
+    _flow = (
+        await add_flow(db, "TagStatusFlow", "test_user-1", ["a_tag"], ["runtime:test"])
+    ).body
+    flow_id = _flow["flow_id"]
+    now = int(time.time())
+
+    _failed_prod = (await add_run(db, flow_id=flow_id, tags=["env:prod"])).body
+    _running_prod = (
+        await add_run(db, flow_id=flow_id, tags=["env:prod"], last_heartbeat_ts=now)
+    ).body
+    _failed_dev = (await add_run(db, flow_id=flow_id, tags=["env:dev"])).body
+
+    # failed AND tagged prod -> only the failed prod run
+    assert await _run_numbers(cli, flow_id, "?status:eq=failed&_tags:any=env:prod") == {
+        _failed_prod["run_number"]
+    }
+    # tag alone catches both prod runs regardless of status
+    assert await _run_numbers(cli, flow_id, "?_tags:any=env:prod") == {
+        _failed_prod["run_number"],
+        _running_prod["run_number"],
+    }
+
+
+async def test_runs_get_unknown_filter_field_ignored(cli, db):
+    # a field not in the allow-list is silently ignored (returns everything), while an
+    # unknown operator on a known field is a 400. (Exclusion/NOT filters are held
+    # pending the mentor's call on grammar semantics, so they are not tested here.)
+    _flow = (
+        await add_flow(db, "IgnoreFlow", "test_user-1", ["a_tag"], ["runtime:test"])
+    ).body
+    flow_id = _flow["flow_id"]
+    a = (await add_run(db, flow_id=flow_id)).body
+    b = (await add_run(db, flow_id=flow_id)).body
+
+    assert await _run_numbers(cli, flow_id, "?nonsense:eq=x") == {
+        a["run_number"],
+        b["run_number"],
+    }
+    assert (
+        await cli.get("/flows/{flow_id}/runs?status:zz=running".format(**_flow))
+    ).status == 400
 
 
 async def test_runs_pagination_get(cli, db):
@@ -231,6 +669,69 @@ async def test_runs_pagination_get(cli, db):
     # getting runs for non-existent flow should return empty list
     await assert_api_get_response(
         cli, "/flows/NonExistentFlow/runs", status=200, data=[]
+    )
+
+
+async def test_runs_get_filter_with_cursor_pagination(cli, db):
+    # filtering and cursor pagination compose: page through a filtered result set,
+    # following X-Next-Cursor, with non-matching runs excluded from every page. This
+    # is the cursor support the mentor asked for once the pagination PR landed.
+    _flow = (
+        await add_flow(
+            db, "FilterCursorFlow", "test_user-1", ["a_tag"], ["runtime:test"]
+        )
+    ).body
+    flow_id = _flow["flow_id"]
+
+    keep1 = (await add_run(db, flow_id=flow_id, tags=["keep"])).body
+    keep2 = (await add_run(db, flow_id=flow_id, tags=["keep"])).body
+    keep3 = (await add_run(db, flow_id=flow_id, tags=["keep"])).body
+    # a run the filter must exclude from every page
+    await add_run(db, flow_id=flow_id, tags=["drop"])
+
+    # page 1: filtered to the 'keep' runs, newest first, page size 2 -> next cursor
+    next_cursor = await assert_paginated_api_get_response(
+        cli,
+        "/flows/{flow_id}/runs".format(flow_id=flow_id),
+        data=[keep3, keep2],
+        params={"_tags:any": "keep", "_limit": 2},
+        has_next_cursor=True,
+    )
+    assert next_cursor is not None
+
+    # page 2: same filter + cursor -> the remaining 'keep' run, no further cursor,
+    # and the 'drop' run never appears
+    await assert_paginated_api_get_response(
+        cli,
+        "/flows/{flow_id}/runs".format(flow_id=flow_id),
+        data=[keep1],
+        params={"_tags:any": "keep", "_limit": 2, "_cursor": next_cursor},
+        has_next_cursor=False,
+    )
+
+
+async def test_run_get(cli, db):
+    # create flow for test
+    _flow = (
+        await add_flow(
+            db, "TestFlow", "test_user-1", ["a_tag", "b_tag"], ["runtime:test"]
+        )
+    ).body
+
+    # add run to flow for testing
+    _run = (await add_run(db, flow_id=_flow["flow_id"])).body
+
+    # try to get created flow
+    await assert_api_get_response(
+        cli, "/flows/{flow_id}/runs/{run_number}".format(**_run), data=_run
+    )
+
+    # non-existent flow or run should return 404
+    await assert_api_get_response(
+        cli, "/flows/{flow_id}/runs/1234".format(**_run), status=404
+    )
+    await assert_api_get_response(
+        cli, "/flows/NonExistentFlow/runs/{run_number}".format(**_run), status=404
     )
 
 


### PR DESCRIPTION
## What

Adds server-side filtering to `GET /flows/{flow_id}/runs`, composed with the cursor pagination from #482.

Filters use the ui_backend `field:operator` grammar (per the earlier review on the time-range work):

- `status:eq=running` (or `status:eq=running,failed` for OR)
- `ts_epoch:ge=123&ts_epoch:le=456` (inclusive epoch-millisecond bounds)
- `user:eq=alice` (verified owner: the run must carry a `user:<name>` system tag, matching what the UI labels as the owner)
- `_tags:any=a,b` (OR) / `_tags:all=a,b` (AND)

The parsers are lifted verbatim from ui_backend into a new web-free `services/data/filter_grammar.py`, so both services parse filters identically from one definition rather than a copy.

## Cursor pagination

Filtering composes with the cursor pagination added in #482. `get_filtered_runs_paginated` walks the filtered result set by the same `(ts_epoch, run_number)` keyset, fetches `limit + 1` to detect a next page, and returns the `X-Next-Cursor` header. With no `_limit`/`_cursor` the endpoint keeps its raw-array response over the filtered set.

## Notes

- `status` is the only derived column needing the lateral joins, so they are gated behind a status filter; `user` is a join-free derived column.
- `status` is derived relative to the heartbeat cutoff, so a multi-status filter that includes `running` is time-relative, not fully deterministic. This is documented on the endpoint.
- All filter values are bound as query parameters, never interpolated. A bad status value, operator, time bound, or cursor returns 400.

This consolidates the time-range and tag filtering work (previously separate PRs on the fork) into the shared grammar.

Verified against Postgres: full integration suite green (133 passed, 13 skipped), including the cursor pagination test and a filtering-plus-cursor composition test.
