### PR TITLE
refactor: remove unnecessary task table join from run status query

### DIFF
--- a/services/ui_backend_service/data/db/tables/run.py
+++ b/services/ui_backend_service/data/db/tables/run.py
@@ -111,7 +111,9 @@ class AsyncRunTablePostgres(AsyncPostgresTable):
             WHEN {table_name}.last_heartbeat_ts IS NOT NULL
                 AND @(extract(epoch from now())-{table_name}.last_heartbeat_ts)<={heartbeat_cutoff}
             THEN NULL
-            WHEN latest_task_heartbeat.last_heartbeat_ts IS NOT NULL
+            WHEN {table_name}.last_heartbeat_ts IS NOT NULL
+                AND @(extract(epoch from now())-{table_name}.last_heartbeat_ts)<={run_stale_threshold}
+                AND latest_task_heartbeat.last_heartbeat_ts IS NOT NULL
                 AND @(extract(epoch from now())-latest_task_heartbeat.last_heartbeat_ts)<={heartbeat_cutoff}
             THEN NULL
             ELSE {table_name}.last_heartbeat_ts*1000
@@ -119,6 +121,7 @@ class AsyncRunTablePostgres(AsyncPostgresTable):
         """.format(
             table_name=table_name,
             heartbeat_cutoff=RUN_INACTIVE_CUTOFF_TIME,
+            run_stale_threshold=RUN_INACTIVE_CUTOFF_TIME * 10,
         ),
         """
         (CASE
@@ -132,7 +135,9 @@ class AsyncRunTablePostgres(AsyncPostgresTable):
             WHEN {table_name}.last_heartbeat_ts IS NOT NULL
                 AND @(extract(epoch from now())-{table_name}.last_heartbeat_ts)<={heartbeat_cutoff}
             THEN 'running'
-            WHEN latest_task_heartbeat.last_heartbeat_ts IS NOT NULL
+            WHEN {table_name}.last_heartbeat_ts IS NOT NULL
+                AND @(extract(epoch from now())-{table_name}.last_heartbeat_ts)<={run_stale_threshold}
+                AND latest_task_heartbeat.last_heartbeat_ts IS NOT NULL
                 AND @(extract(epoch from now())-latest_task_heartbeat.last_heartbeat_ts)<={heartbeat_cutoff}
             THEN 'running'
             ELSE 'failed'
@@ -140,6 +145,7 @@ class AsyncRunTablePostgres(AsyncPostgresTable):
         """.format(
             table_name=table_name,
             heartbeat_cutoff=RUN_INACTIVE_CUTOFF_TIME,
+            run_stale_threshold=RUN_INACTIVE_CUTOFF_TIME * 10,
         ),
         """
         (CASE

--- a/services/ui_backend_service/data/db/tables/run.py
+++ b/services/ui_backend_service/data/db/tables/run.py
@@ -69,6 +69,14 @@ class AsyncRunTablePostgres(AsyncPostgresTable):
             LIMIT 1
         ) as end_attempt ON true
         """.format(table_name=table_name, metadata_table=metadata_table),
+        """
+        LEFT JOIN LATERAL (
+            SELECT max(last_heartbeat_ts) as last_heartbeat_ts
+            FROM {task_table} t
+            WHERE t.flow_id = {table_name}.flow_id
+            AND t.run_number = {table_name}.run_number
+        ) as latest_task_heartbeat ON true
+        """.format(table_name=table_name, task_table=task_table),
     ]
 
     @property
@@ -103,6 +111,9 @@ class AsyncRunTablePostgres(AsyncPostgresTable):
             WHEN {table_name}.last_heartbeat_ts IS NOT NULL
                 AND @(extract(epoch from now())-{table_name}.last_heartbeat_ts)<={heartbeat_cutoff}
             THEN NULL
+            WHEN latest_task_heartbeat.last_heartbeat_ts IS NOT NULL
+                AND @(extract(epoch from now())-latest_task_heartbeat.last_heartbeat_ts)<={heartbeat_cutoff}
+            THEN NULL
             ELSE {table_name}.last_heartbeat_ts*1000
         END) AS finished_at
         """.format(
@@ -120,6 +131,9 @@ class AsyncRunTablePostgres(AsyncPostgresTable):
             THEN 'failed'
             WHEN {table_name}.last_heartbeat_ts IS NOT NULL
                 AND @(extract(epoch from now())-{table_name}.last_heartbeat_ts)<={heartbeat_cutoff}
+            THEN 'running'
+            WHEN latest_task_heartbeat.last_heartbeat_ts IS NOT NULL
+                AND @(extract(epoch from now())-latest_task_heartbeat.last_heartbeat_ts)<={heartbeat_cutoff}
             THEN 'running'
             ELSE 'failed'
         END) AS status

--- a/services/ui_backend_service/data/db/tables/run.py
+++ b/services/ui_backend_service/data/db/tables/run.py
@@ -14,7 +14,6 @@ from services.data.postgres_async_db import (
     AsyncRunTablePostgres as MetadataRunTable,
     AsyncMetadataTablePostgres as MetaMetadataTable,
     AsyncArtifactTablePostgres as MetadataArtifactTable,
-    AsyncTaskTablePostgres as MetadataTaskTable,
 )
 
 # Prefetch runs since 2 days ago (in seconds), limit maximum of 50 runs
@@ -27,7 +26,6 @@ class AsyncRunTablePostgres(AsyncPostgresTable):
     table_name = MetadataRunTable.table_name
     metadata_table = MetaMetadataTable.table_name
     artifact_table = MetadataArtifactTable.table_name
-    task_table = MetadataTaskTable.table_name
     keys = MetadataRunTable.keys
     primary_keys = MetadataRunTable.primary_keys
     trigger_keys = MetadataRunTable.trigger_keys
@@ -69,14 +67,6 @@ class AsyncRunTablePostgres(AsyncPostgresTable):
             LIMIT 1
         ) as end_attempt ON true
         """.format(table_name=table_name, metadata_table=metadata_table),
-        """
-        LEFT JOIN LATERAL (
-            SELECT max(last_heartbeat_ts) as last_heartbeat_ts
-            FROM {task_table} t
-            WHERE t.flow_id = {table_name}.flow_id
-            AND t.run_number = {table_name}.run_number
-        ) as latest_task_heartbeat ON true
-        """.format(table_name=table_name, task_table=task_table),
     ]
 
     @property
@@ -111,9 +101,6 @@ class AsyncRunTablePostgres(AsyncPostgresTable):
             WHEN {table_name}.last_heartbeat_ts IS NOT NULL
                 AND @(extract(epoch from now())-{table_name}.last_heartbeat_ts)<={heartbeat_cutoff}
             THEN NULL
-            WHEN latest_task_heartbeat.last_heartbeat_ts IS NOT NULL
-                AND @(extract(epoch from now())-latest_task_heartbeat.last_heartbeat_ts)<={heartbeat_cutoff}
-            THEN NULL
             ELSE {table_name}.last_heartbeat_ts*1000
         END) AS finished_at
         """.format(
@@ -131,9 +118,6 @@ class AsyncRunTablePostgres(AsyncPostgresTable):
             THEN 'failed'
             WHEN {table_name}.last_heartbeat_ts IS NOT NULL
                 AND @(extract(epoch from now())-{table_name}.last_heartbeat_ts)<={heartbeat_cutoff}
-            THEN 'running'
-            WHEN latest_task_heartbeat.last_heartbeat_ts IS NOT NULL
-                AND @(extract(epoch from now())-latest_task_heartbeat.last_heartbeat_ts)<={heartbeat_cutoff}
             THEN 'running'
             ELSE 'failed'
         END) AS status

--- a/services/ui_backend_service/data/db/tables/run.py
+++ b/services/ui_backend_service/data/db/tables/run.py
@@ -111,9 +111,7 @@ class AsyncRunTablePostgres(AsyncPostgresTable):
             WHEN {table_name}.last_heartbeat_ts IS NOT NULL
                 AND @(extract(epoch from now())-{table_name}.last_heartbeat_ts)<={heartbeat_cutoff}
             THEN NULL
-            WHEN {table_name}.last_heartbeat_ts IS NOT NULL
-                AND @(extract(epoch from now())-{table_name}.last_heartbeat_ts)<={run_stale_threshold}
-                AND latest_task_heartbeat.last_heartbeat_ts IS NOT NULL
+            WHEN latest_task_heartbeat.last_heartbeat_ts IS NOT NULL
                 AND @(extract(epoch from now())-latest_task_heartbeat.last_heartbeat_ts)<={heartbeat_cutoff}
             THEN NULL
             ELSE {table_name}.last_heartbeat_ts*1000
@@ -121,7 +119,6 @@ class AsyncRunTablePostgres(AsyncPostgresTable):
         """.format(
             table_name=table_name,
             heartbeat_cutoff=RUN_INACTIVE_CUTOFF_TIME,
-            run_stale_threshold=RUN_INACTIVE_CUTOFF_TIME * 10,
         ),
         """
         (CASE
@@ -135,9 +132,7 @@ class AsyncRunTablePostgres(AsyncPostgresTable):
             WHEN {table_name}.last_heartbeat_ts IS NOT NULL
                 AND @(extract(epoch from now())-{table_name}.last_heartbeat_ts)<={heartbeat_cutoff}
             THEN 'running'
-            WHEN {table_name}.last_heartbeat_ts IS NOT NULL
-                AND @(extract(epoch from now())-{table_name}.last_heartbeat_ts)<={run_stale_threshold}
-                AND latest_task_heartbeat.last_heartbeat_ts IS NOT NULL
+            WHEN latest_task_heartbeat.last_heartbeat_ts IS NOT NULL
                 AND @(extract(epoch from now())-latest_task_heartbeat.last_heartbeat_ts)<={heartbeat_cutoff}
             THEN 'running'
             ELSE 'failed'
@@ -145,7 +140,6 @@ class AsyncRunTablePostgres(AsyncPostgresTable):
         """.format(
             table_name=table_name,
             heartbeat_cutoff=RUN_INACTIVE_CUTOFF_TIME,
-            run_stale_threshold=RUN_INACTIVE_CUTOFF_TIME * 10,
         ),
         """
         (CASE

--- a/services/ui_backend_service/tests/integration_tests/status_runs_test.py
+++ b/services/ui_backend_service/tests/integration_tests/status_runs_test.py
@@ -231,6 +231,52 @@ async def test_run_status_running_with_heartbeat(cli, db):
     assert data["finished_at"] == None
 
 
+async def test_run_status_running_when_task_heartbeat_active_and_run_heartbeat_expired(cli, db):
+    """
+    Run should show as 'running' when the run-level heartbeat has expired but a task
+    still has a recent heartbeat. This covers foreach flows where the orchestrator
+    process stops heartbeating the run (e.g. after a transient failure) but individual
+    tasks continue executing.
+    """
+    _flow = (await add_flow(db, flow_id="HelloFlow")).body
+
+    # Run heartbeat expired: 7 minutes old, beyond the 6-minute RUN_INACTIVE_CUTOFF_TIME
+    _expired_run_heartbeat = get_heartbeat_ts() - (60 * 7)
+
+    _run = (
+        await add_run(db, flow_id=_flow.get("flow_id"), last_heartbeat_ts=_expired_run_heartbeat)
+    ).body
+
+    _step = (
+        await add_step(
+            db,
+            flow_id=_run.get("flow_id"),
+            step_name="process_data",
+            run_number=_run.get("run_number"),
+            run_id=_run.get("run_id"),
+        )
+    ).body
+
+    # Task with a recent heartbeat
+    _task = (
+        await add_task(
+            db,
+            flow_id=_step.get("flow_id"),
+            step_name=_step.get("step_name"),
+            run_number=_step.get("run_number"),
+            run_id=_step.get("run_id"),
+            last_heartbeat_ts=get_heartbeat_ts(),
+        )
+    ).body
+
+    _, data = await _test_single_resource(
+        cli, db, "/flows/{flow_id}/runs/{run_number}".format(**_run), 200
+    )
+
+    assert data["status"] == "running"
+    assert data["finished_at"] is None
+
+
 @pytest.mark.skip("Test failing due to refactor. TODO: fix later if applicable")
 async def test_run_status_failed_with_heartbeat_expired_and_failed_task(cli, db):
     _flow = (await add_flow(db, flow_id="HelloFlow")).body

--- a/services/ui_backend_service/tests/integration_tests/status_runs_test.py
+++ b/services/ui_backend_service/tests/integration_tests/status_runs_test.py
@@ -231,7 +231,9 @@ async def test_run_status_running_with_heartbeat(cli, db):
     assert data["finished_at"] == None
 
 
-async def test_run_status_running_when_task_heartbeat_active_and_run_heartbeat_expired(cli, db):
+async def test_run_status_running_when_task_heartbeat_active_and_run_heartbeat_expired(
+    cli, db
+):
     """
     Run should show as 'running' when the run-level heartbeat has expired but a task
     still has a recent heartbeat. This covers foreach flows where the orchestrator
@@ -244,7 +246,9 @@ async def test_run_status_running_when_task_heartbeat_active_and_run_heartbeat_e
     _expired_run_heartbeat = get_heartbeat_ts() - (60 * 7)
 
     _run = (
-        await add_run(db, flow_id=_flow.get("flow_id"), last_heartbeat_ts=_expired_run_heartbeat)
+        await add_run(
+            db, flow_id=_flow.get("flow_id"), last_heartbeat_ts=_expired_run_heartbeat
+        )
     ).body
 
     _step = (
@@ -350,8 +354,8 @@ async def test_run_status_failed_with_heartbeat_expired_and_no_failed_tasks(cli,
     assert data["last_heartbeat_ts"] == _heartbeat
     assert data["finished_at"] == _run["last_heartbeat_ts"] * 1000
 
-    # even if the run has no failed tasks, it should count as failed at this point due to not receiving heartbeats
-    # on the run level for long enough (should count as stuck, ie. 'failed')
+    # If a task has a fresh heartbeat, the run is still running — even if the run-level
+    # heartbeat has expired. Task heartbeat is the fallback indicator.
     _step = (
         await add_step(
             db,
@@ -376,11 +380,11 @@ async def test_run_status_failed_with_heartbeat_expired_and_no_failed_tasks(cli,
         cli, db, "/flows/{flow_id}/runs/{run_number}".format(**_run), 200
     )
 
-    assert data["status"] == "failed"
+    assert data["status"] == "running"
     assert data["ts_epoch"] == _run["ts_epoch"]
     assert data["last_heartbeat_ts"] == _heartbeat
     assert data["duration"] == _run["last_heartbeat_ts"] * 1000 - _run["ts_epoch"]
-    assert data["finished_at"] == _run["last_heartbeat_ts"] * 1000
+    assert data["finished_at"] is None
 
     # Run should be possibly to be bumped to 'completed' with an eventually successful end-task
     _metadata = (

--- a/services/ui_backend_service/tests/integration_tests/status_runs_test.py
+++ b/services/ui_backend_service/tests/integration_tests/status_runs_test.py
@@ -354,8 +354,8 @@ async def test_run_status_failed_with_heartbeat_expired_and_no_failed_tasks(cli,
     assert data["last_heartbeat_ts"] == _heartbeat
     assert data["finished_at"] == _run["last_heartbeat_ts"] * 1000
 
-    # A week-old run heartbeat is too stale for the task-HB fallback to apply.
-    # Even with a fresh task heartbeat, the run remains "failed" (stuck/zombie).
+    # If a task has a fresh heartbeat (< RUN_INACTIVE_CUTOFF_TIME), the run is still
+    # running — the task HB is definitive proof, regardless of how long ago the run HB lapsed.
     _step = (
         await add_step(
             db,
@@ -380,11 +380,11 @@ async def test_run_status_failed_with_heartbeat_expired_and_no_failed_tasks(cli,
         cli, db, "/flows/{flow_id}/runs/{run_number}".format(**_run), 200
     )
 
-    assert data["status"] == "failed"
+    assert data["status"] == "running"
     assert data["ts_epoch"] == _run["ts_epoch"]
     assert data["last_heartbeat_ts"] == _heartbeat
     assert data["duration"] == _run["last_heartbeat_ts"] * 1000 - _run["ts_epoch"]
-    assert data["finished_at"] == _run["last_heartbeat_ts"] * 1000
+    assert data["finished_at"] is None
 
     # Run should be possibly to be bumped to 'completed' with an eventually successful end-task
     _metadata = (

--- a/services/ui_backend_service/tests/integration_tests/status_runs_test.py
+++ b/services/ui_backend_service/tests/integration_tests/status_runs_test.py
@@ -354,8 +354,8 @@ async def test_run_status_failed_with_heartbeat_expired_and_no_failed_tasks(cli,
     assert data["last_heartbeat_ts"] == _heartbeat
     assert data["finished_at"] == _run["last_heartbeat_ts"] * 1000
 
-    # If a task has a fresh heartbeat, the run is still running — even if the run-level
-    # heartbeat has expired. Task heartbeat is the fallback indicator.
+    # A week-old run heartbeat is too stale for the task-HB fallback to apply.
+    # Even with a fresh task heartbeat, the run remains "failed" (stuck/zombie).
     _step = (
         await add_step(
             db,
@@ -380,11 +380,11 @@ async def test_run_status_failed_with_heartbeat_expired_and_no_failed_tasks(cli,
         cli, db, "/flows/{flow_id}/runs/{run_number}".format(**_run), 200
     )
 
-    assert data["status"] == "running"
+    assert data["status"] == "failed"
     assert data["ts_epoch"] == _run["ts_epoch"]
     assert data["last_heartbeat_ts"] == _heartbeat
     assert data["duration"] == _run["last_heartbeat_ts"] * 1000 - _run["ts_epoch"]
-    assert data["finished_at"] is None
+    assert data["finished_at"] == _run["last_heartbeat_ts"] * 1000
 
     # Run should be possibly to be bumped to 'completed' with an eventually successful end-task
     _metadata = (

--- a/services/ui_backend_service/tests/integration_tests/status_runs_test.py
+++ b/services/ui_backend_service/tests/integration_tests/status_runs_test.py
@@ -231,56 +231,6 @@ async def test_run_status_running_with_heartbeat(cli, db):
     assert data["finished_at"] == None
 
 
-async def test_run_status_running_when_task_heartbeat_active_and_run_heartbeat_expired(
-    cli, db
-):
-    """
-    Run should show as 'running' when the run-level heartbeat has expired but a task
-    still has a recent heartbeat. This covers foreach flows where the orchestrator
-    process stops heartbeating the run (e.g. after a transient failure) but individual
-    tasks continue executing.
-    """
-    _flow = (await add_flow(db, flow_id="HelloFlow")).body
-
-    # Run heartbeat expired: 7 minutes old, beyond the 6-minute RUN_INACTIVE_CUTOFF_TIME
-    _expired_run_heartbeat = get_heartbeat_ts() - (60 * 7)
-
-    _run = (
-        await add_run(
-            db, flow_id=_flow.get("flow_id"), last_heartbeat_ts=_expired_run_heartbeat
-        )
-    ).body
-
-    _step = (
-        await add_step(
-            db,
-            flow_id=_run.get("flow_id"),
-            step_name="process_data",
-            run_number=_run.get("run_number"),
-            run_id=_run.get("run_id"),
-        )
-    ).body
-
-    # Task with a recent heartbeat
-    _task = (
-        await add_task(
-            db,
-            flow_id=_step.get("flow_id"),
-            step_name=_step.get("step_name"),
-            run_number=_step.get("run_number"),
-            run_id=_step.get("run_id"),
-            last_heartbeat_ts=get_heartbeat_ts(),
-        )
-    ).body
-
-    _, data = await _test_single_resource(
-        cli, db, "/flows/{flow_id}/runs/{run_number}".format(**_run), 200
-    )
-
-    assert data["status"] == "running"
-    assert data["finished_at"] is None
-
-
 @pytest.mark.skip("Test failing due to refactor. TODO: fix later if applicable")
 async def test_run_status_failed_with_heartbeat_expired_and_failed_task(cli, db):
     _flow = (await add_flow(db, flow_id="HelloFlow")).body
@@ -354,8 +304,8 @@ async def test_run_status_failed_with_heartbeat_expired_and_no_failed_tasks(cli,
     assert data["last_heartbeat_ts"] == _heartbeat
     assert data["finished_at"] == _run["last_heartbeat_ts"] * 1000
 
-    # If a task has a fresh heartbeat (< RUN_INACTIVE_CUTOFF_TIME), the run is still
-    # running — the task HB is definitive proof, regardless of how long ago the run HB lapsed.
+    # even if the run has no failed tasks, it should count as failed at this point due to not receiving heartbeats
+    # on the run level for long enough (should count as stuck, ie. 'failed')
     _step = (
         await add_step(
             db,
@@ -380,11 +330,11 @@ async def test_run_status_failed_with_heartbeat_expired_and_no_failed_tasks(cli,
         cli, db, "/flows/{flow_id}/runs/{run_number}".format(**_run), 200
     )
 
-    assert data["status"] == "running"
+    assert data["status"] == "failed"
     assert data["ts_epoch"] == _run["ts_epoch"]
     assert data["last_heartbeat_ts"] == _heartbeat
     assert data["duration"] == _run["last_heartbeat_ts"] * 1000 - _run["ts_epoch"]
-    assert data["finished_at"] is None
+    assert data["finished_at"] == _run["last_heartbeat_ts"] * 1000
 
     # Run should be possibly to be bumped to 'completed' with an eventually successful end-task
     _metadata = (


### PR DESCRIPTION
## Summary

The lateral join to the task table added in #485 is redundant and can be removed:

- The `tasks_heartbeat` endpoint (`/tasks/{task_id}/heartbeat`) already calls `update_heartbeat` on **both** the run table and the task table (see `metadata_service/api/task.py` line 333).
- Therefore `run.last_heartbeat_ts` is always kept in sync with the latest task heartbeat.
- The existing `WHEN run.last_heartbeat_ts IS NOT NULL AND ... THEN 'running'` check is sufficient — it already covers the case where tasks are actively running.

**Net change vs master:** removes the dead `task_table` attribute and `MetadataTaskTable` import that were already unused before #485 was written.

## What this replaces

Supersedes #485. The performance concern raised during that review (40ms × 50 lateral calls, 2s list latency) goes away entirely since there is no join.

## Test plan

- [ ] Existing `test_run_status_running_with_heartbeat` covers the running case via `run.last_heartbeat_ts`
- [ ] `test_run_status_failed_with_heartbeat_expired_and_no_failed_tasks` reverted to its original assertion — if `run.last_heartbeat_ts` is expired, the run is `failed` regardless of task heartbeats (because in production, task heartbeats also keep `run.last_heartbeat_ts` fresh; an expired run HB with a fresh task HB is an impossible steady-state scenario)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)