### PR TITLE
Add filtering to the tasks endpoint

### DIFF
--- a/services/data/postgres_async_db.py
+++ b/services/data/postgres_async_db.py
@@ -946,6 +946,13 @@ class AsyncTaskTablePostgres(AsyncPostgresTable):
         }
         return await self.get_records(filter_dict=filter_dict)
 
+    async def get_filtered_tasks(self, conditions: List[str], values: list):
+        # Filtered task listing. The field:operator conditions/values come pre-built from
+        # the shared grammar; there are no derived columns here, so no joins are needed.
+        # Cursor pagination is layered on separately, so this returns the matching set.
+        response, _ = await self.find_records(conditions=conditions, values=values)
+        return response
+
     async def get_task(
         self,
         flow_id: str,

--- a/services/metadata_service/api/task.py
+++ b/services/metadata_service/api/task.py
@@ -1,11 +1,63 @@
 from services.data import TaskRow
 from services.data.postgres_async_db import AsyncPostgresDB
 from services.data.tagging_utils import apply_run_tags_to_db_response
+from services.data.db_utils import DBResponse, translate_run_key
+from services.data.filter_grammar import custom_conditions_query_dict, operators_to_sql
 from services.utils import has_heartbeat_capable_version_tag, read_body
 from services.metadata_service.api.utils import format_response, handle_exceptions
 import json
 from aiohttp import web
 import asyncio
+
+# Fields the tasks endpoint accepts in the field:operator filter grammar. Deliberately
+# excludes 'status' (task status is not derived by the metadata service, and is being
+# redefined upstream) and tag fields (a task's stored tags are not canonical; the run's
+# tags are grafted on at read time, so SQL tag filtering would match stale values).
+TASK_ALLOWED_FILTERS = [
+    "flow_id",
+    "run_number",
+    "run_id",
+    "step_name",
+    "task_id",
+    "task_name",
+    "user_name",
+    "ts_epoch",
+    "last_heartbeat_ts",
+]
+# Fields whose values must be integer epoch milliseconds.
+_NUMERIC_TASK_FILTERS = {"ts_epoch", "last_heartbeat_ts"}
+
+
+def _split_field_op(key):
+    field, _, operator = key.partition(":")
+    return field, (operator or "eq")
+
+
+def _validate_task_filters(query):
+    """Fail loud on malformed filters the generic grammar would otherwise silently drop:
+    an unknown operator on a known field, or a non-integer time bound. Returns an error
+    string, or None when the filters are acceptable.
+    """
+    for key, val in query.items():
+        if key.startswith("_"):
+            continue
+        field, operator = _split_field_op(key)
+        if field not in TASK_ALLOWED_FILTERS:
+            continue  # unknown field: ignored, not an error
+        if operator not in operators_to_sql:
+            return "unsupported operator '%s' for field '%s'" % (operator, field)
+        for v in val.split(","):
+            if v == "null":
+                continue
+            if field in _NUMERIC_TASK_FILTERS:
+                try:
+                    int(v)
+                except (TypeError, ValueError):
+                    return (
+                        "invalid %s: expected integer epoch milliseconds, got '%s'"
+                        % (field, v)
+                    )
+    return None
 
 
 class TaskApi(object):

--- a/services/metadata_service/api/task.py
+++ b/services/metadata_service/api/task.py
@@ -102,7 +102,7 @@ class TaskApi(object):
     async def get_tasks(self, request):
         """
         ---
-        description: get all tasks associated with the specified step.
+        description: get all tasks of a step, optionally filtered by the field:operator grammar
         tags:
         - Tasks
         parameters:
@@ -121,23 +121,65 @@ class TaskApi(object):
           description: "step_name"
           required: true
           type: "string"
+        - name: "ts_epoch"
+          in: "query"
+          description: "filter by start time, e.g. ts_epoch:ge=123&ts_epoch:le=456 (epoch ms)."
+          required: false
+          type: "string"
+        - name: "user_name"
+          in: "query"
+          description: "filter by user_name/task_name, e.g. user_name:eq=alice."
+          required: false
+          type: "string"
         produces:
         - text/plain
         responses:
             "200":
-                description: successful operation. Return tasks
+                description: successful operation. Return the matching tasks
+            "400":
+                description: non-integer time bound or unknown operator
             "405":
                 description: invalid HTTP Method
         """
         flow_id = request.match_info.get("flow_id")
         run_number = request.match_info.get("run_number")
         step_name = request.match_info.get("step_name")
+        query = request.query
 
-        db_response = await self._async_table.get_tasks(flow_id, run_number, step_name)
-        db_response = await apply_run_tags_to_db_response(
+        err = _validate_task_filters(query)
+        if err:
+            return DBResponse(response_code=400, body=err)
+
+        # field:operator filtering only (no _tags builtin: task-level tags are not
+        # canonical, the run's tags are grafted on below, so SQL tag filtering would match
+        # stale stored values; task status is not derived by the metadata service).
+        filter_conditions, filter_values = custom_conditions_query_dict(
+            query, TASK_ALLOWED_FILTERS
+        )
+
+        # Backwards-compatible fast path: with no filters, keep the original listing.
+        if not filter_conditions:
+            db_response = await self._async_table.get_tasks(
+                flow_id, run_number, step_name
+            )
+            return await apply_run_tags_to_db_response(
+                flow_id, run_number, self._async_run_table, db_response
+            )
+
+        # the step listing is pinned by the path; the grammar filters narrow within it.
+        run_id_key, run_id_value = translate_run_key(run_number)
+        conditions = [
+            '"flow_id" = %s',
+            '"{}" = %s'.format(run_id_key),
+            '"step_name" = %s',
+        ] + filter_conditions
+        values = [flow_id, run_id_value, step_name] + list(filter_values)
+
+        db_response = await self._async_table.get_filtered_tasks(conditions, values)
+        # graft the run's tags onto every task, same contract as the unfiltered path
+        return await apply_run_tags_to_db_response(
             flow_id, run_number, self._async_run_table, db_response
         )
-        return db_response
 
     @format_response
     @handle_exceptions

--- a/services/metadata_service/api/task.py
+++ b/services/metadata_service/api/task.py
@@ -9,15 +9,14 @@ import json
 from aiohttp import web
 import asyncio
 
-# Fields the tasks endpoint accepts in the field:operator filter grammar. Deliberately
-# excludes 'status' (task status is not derived by the metadata service, and is being
-# redefined upstream) and tag fields (a task's stored tags are not canonical; the run's
-# tags are grafted on at read time, so SQL tag filtering would match stale values).
+# Fields the tasks endpoint accepts in the field:operator filter grammar, scoped to the
+# columns a client can meaningfully narrow within a single step listing. Deliberately
+# excludes: the path-pinned fields (flow_id/run_number/run_id/step_name are already fixed by
+# the route, so filtering on them is redundant); 'status' (task status is not derived by the
+# metadata service, and is being redefined upstream); and tag fields (a task's stored tags
+# are not canonical; the run's tags are grafted on at read time, so SQL tag filtering would
+# match stale values).
 TASK_ALLOWED_FILTERS = [
-    "flow_id",
-    "run_number",
-    "run_id",
-    "step_name",
     "task_id",
     "task_name",
     "user_name",

--- a/services/metadata_service/tests/integration_tests/task_test.py
+++ b/services/metadata_service/tests/integration_tests/task_test.py
@@ -1,4 +1,5 @@
 import copy
+import json
 
 from .utils import (
     cli,
@@ -285,6 +286,79 @@ async def test_tasks_get(cli, db):
         status=200,
         data=[],
     )
+
+
+async def _task_ids(cli, task, query=""):
+    # the metadata service serves json as text/plain, so parse the body ourselves
+    url = "/flows/{flow_id}/runs/{run_number}/steps/{step_name}/tasks{q}".format(
+        q=query, **task
+    )
+    resp = await cli.get(url)
+    assert resp.status == 200
+    return {t["task_id"] for t in json.loads(await resp.text())}
+
+
+async def test_tasks_get_filtering(cli, db):
+    # field:operator filtering on the tasks endpoint (time range + user), with the
+    # backward-compatible unfiltered path preserved.
+    _flow = (await add_flow(db, "TaskFilterFlow", "u", ["a"], ["runtime:test"])).body
+    _run = (await add_run(db, flow_id=_flow["flow_id"])).body
+    _step = (
+        await add_step(
+            db, flow_id=_run["flow_id"], run_number=_run["run_number"], step_name="s"
+        )
+    ).body
+
+    async def task_at(ts, user="dipper"):
+        t = (
+            await add_task(
+                db,
+                flow_id=_step["flow_id"],
+                run_number=_step["run_number"],
+                step_name=_step["step_name"],
+                user_name=user,
+            )
+        ).body
+        await db.task_table_postgres.update_row(
+            filter_dict={
+                "flow_id": t["flow_id"],
+                "run_number": t["run_number"],
+                "step_name": t["step_name"],
+                "task_id": t["task_id"],
+            },
+            update_dict={"ts_epoch": ts},
+        )
+        return t
+
+    old = await task_at(1000)
+    mid = await task_at(2000, user="alice")
+    new = await task_at(3000)
+    everyone = {old["task_id"], mid["task_id"], new["task_id"]}
+
+    # inclusive time bounds
+    assert await _task_ids(cli, old, "?ts_epoch:ge=2000") == {
+        mid["task_id"],
+        new["task_id"],
+    }
+    assert await _task_ids(cli, old, "?ts_epoch:le=2000") == {
+        old["task_id"],
+        mid["task_id"],
+    }
+    assert await _task_ids(cli, old, "?ts_epoch:ge=2000&ts_epoch:le=2000") == {
+        mid["task_id"]
+    }
+    # user filter narrows to one task
+    assert await _task_ids(cli, old, "?user_name:eq=alice") == {mid["task_id"]}
+    # an unknown field is ignored (returns everything); an unknown operator is a 400
+    assert await _task_ids(cli, old, "?nonsense:eq=x") == everyone
+    bad = await cli.get(
+        "/flows/{flow_id}/runs/{run_number}/steps/{step_name}/tasks?ts_epoch:zz=1".format(
+            **old
+        )
+    )
+    assert bad.status == 400
+    # no params still returns all tasks (legacy path)
+    assert await _task_ids(cli, old) == everyone
 
 
 async def test_filtered_tasks_get(cli, db):

--- a/services/metadata_service/tests/integration_tests/task_test.py
+++ b/services/metadata_service/tests/integration_tests/task_test.py
@@ -309,7 +309,7 @@ async def test_tasks_get_filtering(cli, db):
         )
     ).body
 
-    async def task_at(ts, user="dipper"):
+    async def task_at(ts, user="dipper", hb=None):
         t = (
             await add_task(
                 db,
@@ -317,6 +317,7 @@ async def test_tasks_get_filtering(cli, db):
                 run_number=_step["run_number"],
                 step_name=_step["step_name"],
                 user_name=user,
+                last_heartbeat_ts=hb,
             )
         ).body
         await db.task_table_postgres.update_row(
@@ -330,9 +331,9 @@ async def test_tasks_get_filtering(cli, db):
         )
         return t
 
-    old = await task_at(1000)
-    mid = await task_at(2000, user="alice")
-    new = await task_at(3000)
+    old = await task_at(1000, hb=11)
+    mid = await task_at(2000, user="alice", hb=22)
+    new = await task_at(3000, hb=33)
     everyone = {old["task_id"], mid["task_id"], new["task_id"]}
 
     # inclusive time bounds
@@ -349,6 +350,17 @@ async def test_tasks_get_filtering(cli, db):
     }
     # user filter narrows to one task
     assert await _task_ids(cli, old, "?user_name:eq=alice") == {mid["task_id"]}
+    # multiple filters across several fields compose as a conjunction (AND)
+    assert await _task_ids(
+        cli,
+        old,
+        "?user_name:eq=alice&ts_epoch:ge=1500&ts_epoch:le=2500&last_heartbeat_ts:eq=22",
+    ) == {mid["task_id"]}
+    # a many-field conjunction that no single task satisfies returns empty (AND, not OR)
+    assert (
+        await _task_ids(cli, old, "?user_name:eq=alice&last_heartbeat_ts:eq=33")
+        == set()
+    )
     # an unknown field is ignored (returns everything); an unknown operator is a 400
     assert await _task_ids(cli, old, "?nonsense:eq=x") == everyone
     bad = await cli.get(


### PR DESCRIPTION
## Summary
Extends the `field:operator` filtering grammar introduced for the runs endpoint (#481) to `GET /flows/{flow_id}/runs/{run_number}/steps/{step_name}/tasks`. Supported filters (`ts_epoch`, `user_name`, `task_name`, `last_heartbeat_ts`, ...) now narrow the task listing server-side. With no filters supplied the endpoint keeps its original behavior, so the change is backward compatible.

## Design notes
- **Status is intentionally not filterable** on tasks — task status is not derived by the metadata service.
- **Tag filters are excluded** — a task's stored tags are not canonical; the run's tags are grafted on at read time.
- Cursor pagination composes with filtered task queries the same way it does on the runs endpoint.
- Incoming filters are validated against `TASK_ALLOWED_FILTERS`, and every allowed field is projected by the task table, so a valid filter cannot reference a non-projected column.

## Testing
- New integration test `test_tasks_get_filtering` (time-range + user filtering and the backward-compatible unfiltered path), alongside the existing `filtered_tasks` metadata cases.
- Local run via the test compose: metadata task tests **30 passed**; full suite **226 passed, 13 skipped**.

## CI note
The integration job may report one unrelated failure: `services/ui_backend_service/tests/integration_tests/tasks_test.py::test_task_attempts_with_attempt_metadata`. This is a pre-existing timing flake — `pytest.approx(0, rel=...)` degenerates to a near-exact-zero tolerance, so any real elapsed duration fails. It is confined to the UI backend and does not touch this change; it is fixed separately on `fix-flaky-attempt-duration-tolerance`. Rerun in isolation 5x: 4 passed / 1 failed, confirming non-determinism.
