### PR TITLE
Avoid extra run lookups when returning inherited tags

### DIFF
--- a/services/data/postgres_async_db.py
+++ b/services/data/postgres_async_db.py
@@ -252,6 +252,16 @@ class AsyncPostgresTable(object):
                     conditions=self.trigger_conditions,
                 )
 
+    def _resolve_select_columns(self, with_run_tags: bool = False) -> List[str]:
+        """Columns to select for a single read.
+
+        A method taking the flag rather than a property reading instance state:
+        table objects are shared across concurrent requests, so anything stashed
+        on self can be clobbered by another request across an await. Subclasses
+        that support the run-tags join override this.
+        """
+        return self.select_columns
+
     async def get_records(
         self,
         filter_dict={},
@@ -260,6 +270,7 @@ class AsyncPostgresTable(object):
         limit: int = 0,
         expanded=False,
         cur: aiopg.Cursor = None,
+        with_run_tags: bool = False,
     ) -> DBResponse:
         conditions = []
         values = []
@@ -275,6 +286,7 @@ class AsyncPostgresTable(object):
             limit=limit,
             expanded=expanded,
             cur=cur,
+            with_run_tags=with_run_tags,
         )
         return response
 
@@ -331,6 +343,7 @@ class AsyncPostgresTable(object):
         expanded=False,
         enable_joins=False,
         cur: aiopg.Cursor = None,
+        with_run_tags: bool = False,
     ) -> Tuple[DBResponse, DBPagination]:
         sql_template = """
         SELECT * FROM (
@@ -345,14 +358,17 @@ class AsyncPostgresTable(object):
         {offset}
         """
 
+        # For tables carrying the run-tags join, opting in implies enabling joins.
+        use_joins = enable_joins or with_run_tags
+
         select_sql = sql_template.format(
             keys=",".join(
-                self.select_columns
-                + (self.join_columns if enable_joins and self.join_columns else [])
+                self._resolve_select_columns(with_run_tags)
+                + (self.join_columns if use_joins and self.join_columns else [])
             ),
             table_name=self.table_name,
             joins=(
-                " ".join(self.joins) if enable_joins and self.joins is not None else ""
+                " ".join(self.joins) if use_joins and self.joins is not None else ""
             ),
             where="WHERE {}".format(" AND ".join(conditions)) if conditions else "",
             order_by="ORDER BY {}".format(", ".join(order)) if order else "",
@@ -941,25 +957,18 @@ class _RunTagsJoinMixin:
     Handler-facing reads pass with_run_tags=True, which embeds a LEFT JOIN to
     runs_v3 in the query so the run's tags come back in the same SELECT --
     replacing the post-query get_run + deepcopy in apply_run_tags_to_db_response.
+
+    with_run_tags is threaded through as a call argument the whole way down
+    (get_records -> find_records -> _resolve_select_columns) and is never stored
+    on the instance. One table object serves every concurrent request, so a flag
+    held on self would be visible to -- and clobbered by -- other requests that
+    interleave at any await inside the read.
     """
 
-    @property
-    def select_columns(self):
-        if getattr(self, "_with_run_tags", False):
+    def _resolve_select_columns(self, with_run_tags: bool = False) -> List[str]:
+        if with_run_tags:
             return _run_tag_qualified_columns(self.table_name, self.keys)
         return self.keys
-
-    async def find_records(self, *args, **kwargs):
-        if getattr(self, "_with_run_tags", False):
-            kwargs["enable_joins"] = True
-        return await super().find_records(*args, **kwargs)
-
-    async def get_records(self, *args, with_run_tags=False, **kwargs):
-        self._with_run_tags = with_run_tags
-        try:
-            return await super().get_records(*args, **kwargs)
-        finally:
-            self._with_run_tags = False
 
 
 class AsyncStepTablePostgres(_RunTagsJoinMixin, AsyncPostgresTable):
@@ -1089,16 +1098,13 @@ class AsyncTaskTablePostgres(_RunTagsJoinMixin, AsyncPostgresTable):
         # Filtered task listing. The field:operator conditions/values come pre-built from
         # the shared grammar; there are no derived columns here, so no joins are needed
         # beyond the optional run-tags join.
-        self._with_run_tags = with_run_tags
-        try:
-            response, pagination = await self.find_records(
-                conditions=conditions,
-                values=values,
-                limit=cur_limit,
-                order=order,
-            )
-        finally:
-            self._with_run_tags = False
+        response, pagination = await self.find_records(
+            conditions=conditions,
+            values=values,
+            limit=cur_limit,
+            order=order,
+            with_run_tags=with_run_tags,
+        )
 
         if len(response.body) > limit:
             response = response._replace(body=response.body[:limit])

--- a/services/data/postgres_async_db.py
+++ b/services/data/postgres_async_db.py
@@ -53,6 +53,34 @@ operator_match = re.compile("([^:]*):([=><]+)$")
 
 # use a ddmmyyy timestamp as the version for triggers
 TRIGGER_VERSION = "05092024"
+
+
+def _run_tags_join(table_name):
+    # LEFT JOIN fragment that grafts runs_v3.tags / runs_v3.system_tags onto a
+    # step/task/artifact query, so the read API returns the ancestral run's tags
+    # without a separate get_run call per listing (replacing the post-query
+    # apply_run_tags_to_db_response round-trip + deepcopy).
+    return (
+        "LEFT JOIN {run_table} AS run_for_tags "
+        "ON {table_name}.flow_id = run_for_tags.flow_id "
+        "AND {table_name}.run_number = run_for_tags.run_number"
+    ).format(run_table=RUN_TABLE_NAME, table_name=table_name)
+
+
+def _run_tag_qualified_columns(table_name, keys):
+    # Select columns qualified by table_name, with tags/system_tags pulled from
+    # the joined runs_v3 alias 'run_for_tags' (see _run_tags_join). The step/task/
+    # artifact tables store their own tags, but the read API contract returns the
+    # run's tags, so those two columns are redirected to the join.
+    cols = []
+    for k in keys:
+        if k in ("tags", "system_tags"):
+            cols.append("run_for_tags.%s AS %s" % (k, k))
+        else:
+            cols.append("%s.%s AS %s" % (table_name, k, k))
+    return cols
+
+
 TRIGGER_NAME_PREFIX = "notify_ui"
 
 
@@ -905,7 +933,36 @@ class AsyncRunTablePostgres(AsyncPostgresTable):
         )
 
 
-class AsyncStepTablePostgres(AsyncPostgresTable):
+class _RunTagsJoinMixin:
+    """Opt-in run-tags join for step/task/artifact reads.
+
+    The read API contract returns the ancestral run's tags, not the row's own
+    stored tags. Default reads (DB layer) are unchanged and return stored tags.
+    Handler-facing reads pass with_run_tags=True, which embeds a LEFT JOIN to
+    runs_v3 in the query so the run's tags come back in the same SELECT --
+    replacing the post-query get_run + deepcopy in apply_run_tags_to_db_response.
+    """
+
+    @property
+    def select_columns(self):
+        if getattr(self, "_with_run_tags", False):
+            return _run_tag_qualified_columns(self.table_name, self.keys)
+        return self.keys
+
+    async def find_records(self, *args, **kwargs):
+        if getattr(self, "_with_run_tags", False):
+            kwargs["enable_joins"] = True
+        return await super().find_records(*args, **kwargs)
+
+    async def get_records(self, *args, with_run_tags=False, **kwargs):
+        self._with_run_tags = with_run_tags
+        try:
+            return await super().get_records(*args, **kwargs)
+        finally:
+            self._with_run_tags = False
+
+
+class AsyncStepTablePostgres(_RunTagsJoinMixin, AsyncPostgresTable):
     step_dict = {}
     run_to_step_dict = {}
     _row_type = StepRow
@@ -922,8 +979,10 @@ class AsyncStepTablePostgres(AsyncPostgresTable):
     ]
     primary_keys = ["flow_id", "run_number", "step_name"]
     trigger_keys = primary_keys
-    select_columns = keys
     run_table_name = AsyncRunTablePostgres.table_name
+
+    # Only used when a read opts in via with_run_tags=True (see _RunTagsJoinMixin).
+    joins = [_run_tags_join(STEP_TABLE_NAME)]
 
     async def add_step(self, step_object: StepRow):
         dict = {
@@ -937,22 +996,28 @@ class AsyncStepTablePostgres(AsyncPostgresTable):
         }
         return await self.create_record(dict)
 
-    async def get_steps(self, flow_id: str, run_id: str):
+    async def get_steps(self, flow_id: str, run_id: str, with_run_tags: bool = False):
         run_id_key, run_id_value = translate_run_key(run_id)
         filter_dict = {"flow_id": flow_id, run_id_key: run_id_value}
-        return await self.get_records(filter_dict=filter_dict)
+        return await self.get_records(
+            filter_dict=filter_dict, with_run_tags=with_run_tags
+        )
 
-    async def get_step(self, flow_id: str, run_id: str, step_name: str):
+    async def get_step(
+        self, flow_id: str, run_id: str, step_name: str, with_run_tags: bool = False
+    ):
         run_id_key, run_id_value = translate_run_key(run_id)
         filter_dict = {
             "flow_id": flow_id,
             run_id_key: run_id_value,
             "step_name": step_name,
         }
-        return await self.get_records(filter_dict=filter_dict, fetch_single=True)
+        return await self.get_records(
+            filter_dict=filter_dict, fetch_single=True, with_run_tags=with_run_tags
+        )
 
 
-class AsyncTaskTablePostgres(AsyncPostgresTable):
+class AsyncTaskTablePostgres(_RunTagsJoinMixin, AsyncPostgresTable):
     task_dict = {}
     step_to_task_dict = {}
     _current_count = 0
@@ -973,8 +1038,10 @@ class AsyncTaskTablePostgres(AsyncPostgresTable):
     ]
     primary_keys = ["flow_id", "run_number", "step_name", "task_id"]
     trigger_keys = primary_keys
-    select_columns = keys
     step_table_name = AsyncStepTablePostgres.table_name
+
+    # Only used when a read opts in via with_run_tags=True (see _RunTagsJoinMixin).
+    joins = [_run_tags_join(TASK_TABLE_NAME)]
 
     async def add_task(self, task: TaskRow, fill_heartbeat=False):
         # todo backfill run_number if missing?
@@ -991,14 +1058,18 @@ class AsyncTaskTablePostgres(AsyncPostgresTable):
         }
         return await self.create_record(dict)
 
-    async def get_tasks(self, flow_id: str, run_id: str, step_name: str):
+    async def get_tasks(
+        self, flow_id: str, run_id: str, step_name: str, with_run_tags: bool = False
+    ):
         run_id_key, run_id_value = translate_run_key(run_id)
         filter_dict = {
             "flow_id": flow_id,
             run_id_key: run_id_value,
             "step_name": step_name,
         }
-        return await self.get_records(filter_dict=filter_dict)
+        return await self.get_records(
+            filter_dict=filter_dict, with_run_tags=with_run_tags
+        )
 
     async def get_filtered_tasks_paginated(
         self,
@@ -1007,6 +1078,7 @@ class AsyncTaskTablePostgres(AsyncPostgresTable):
         cur_ts: int = None,
         cur_task: int = None,
         limit: int = None,
+        with_run_tags: bool = False,
     ):
         if cur_ts is not None and cur_task is not None:
             conditions.append("(ts_epoch, task_id) < (%s,%s)")
@@ -1015,13 +1087,18 @@ class AsyncTaskTablePostgres(AsyncPostgresTable):
         cur_limit = limit + 1
 
         # Filtered task listing. The field:operator conditions/values come pre-built from
-        # the shared grammar; there are no derived columns here, so no joins are needed.
-        response, pagination = await self.find_records(
-            conditions=conditions,
-            values=values,
-            limit=cur_limit,
-            order=order,
-        )
+        # the shared grammar; there are no derived columns here, so no joins are needed
+        # beyond the optional run-tags join.
+        self._with_run_tags = with_run_tags
+        try:
+            response, pagination = await self.find_records(
+                conditions=conditions,
+                values=values,
+                limit=cur_limit,
+                order=order,
+            )
+        finally:
+            self._with_run_tags = False
 
         if len(response.body) > limit:
             response = response._replace(body=response.body[:limit])
@@ -1039,6 +1116,7 @@ class AsyncTaskTablePostgres(AsyncPostgresTable):
         step_name: str,
         task_id: str,
         expanded: bool = False,
+        with_run_tags: bool = False,
     ):
         run_id_key, run_id_value = translate_run_key(run_id)
         task_id_key, task_id_value = translate_task_key(task_id)
@@ -1049,7 +1127,10 @@ class AsyncTaskTablePostgres(AsyncPostgresTable):
             task_id_key: task_id_value,
         }
         return await self.get_records(
-            filter_dict=filter_dict, fetch_single=True, expanded=expanded
+            filter_dict=filter_dict,
+            fetch_single=True,
+            expanded=expanded,
+            with_run_tags=with_run_tags,
         )
 
     async def update_heartbeat(
@@ -1277,7 +1358,7 @@ class AsyncMetadataTablePostgres(AsyncPostgresTable):
         return flattened_response, pagination
 
 
-class AsyncArtifactTablePostgres(AsyncPostgresTable):
+class AsyncArtifactTablePostgres(_RunTagsJoinMixin, AsyncPostgresTable):
     artifact_dict = {}
     run_to_artifact_dict = {}
     step_to_artifact_dict = {}
@@ -1315,7 +1396,26 @@ class AsyncArtifactTablePostgres(AsyncPostgresTable):
     ]
     trigger_keys = primary_keys
     trigger_operations = ["INSERT"]
-    select_columns = keys
+
+    # Only used when a read opts in via with_run_tags=True (see _RunTagsJoinMixin).
+    joins = [_run_tags_join(ARTIFACT_TABLE_NAME)]
+
+    def _run_tag_qualified_keys(self):
+        # Comma-joined qualified columns for the custom paginated SQL templates
+        # (which interpolate {keys} directly rather than going through find_records).
+        return ", ".join(_run_tag_qualified_columns(self.table_name, self.keys))
+
+    def _artifact_sql_parts(self, with_run_tags: bool):
+        # SQL fragments for the custom paginated artifact templates. The default
+        # returns the original unqualified, join-free parts; with_run_tags embeds
+        # the runs_v3 join and qualifies columns, which the join requires.
+        if with_run_tags:
+            return (
+                self._run_tag_qualified_keys(),
+                self.joins[0],
+                "%s." % self.table_name,
+            )
+        return ", ".join(self.keys), "", ""
 
     async def add_artifact(
         self,
@@ -1356,13 +1456,17 @@ class AsyncArtifactTablePostgres(AsyncPostgresTable):
         }
         return await self.create_record(dict)
 
-    async def get_artifacts_in_runs(self, flow_id: str, run_id: int):
+    async def get_artifacts_in_runs(
+        self, flow_id: str, run_id: int, with_run_tags: bool = False
+    ):
         run_id_key, run_id_value = translate_run_key(run_id)
         filter_dict = {
             "flow_id": flow_id,
             run_id_key: run_id_value,
         }
-        return await self.get_records(filter_dict=filter_dict, ordering=self.ordering)
+        return await self.get_records(
+            filter_dict=filter_dict, ordering=self.ordering, with_run_tags=with_run_tags
+        )
 
     async def get_artifacts_in_runs_paginated(
         self,
@@ -1372,13 +1476,17 @@ class AsyncArtifactTablePostgres(AsyncPostgresTable):
         cur_task: int = None,
         cur_name: str = None,
         limit: int = None,
+        with_run_tags: bool = False,
     ):
         run_id_key, run_id_value = translate_run_key(run_id)
         filter_dict = {
             "flow_id": flow_id,
             run_id_key: run_id_value,
         }
-        conditions = [f"{k} = %s" for k, v in filter_dict.items() if v is not None]
+        keys_sql, join_sql, col_prefix = self._artifact_sql_parts(with_run_tags)
+        conditions = [
+            f"{col_prefix}{k} = %s" for k, v in filter_dict.items() if v is not None
+        ]
         values = [v for k, v in filter_dict.items() if v is not None]
 
         cursor_where = ""
@@ -1392,10 +1500,11 @@ class AsyncArtifactTablePostgres(AsyncPostgresTable):
         # Cursor is applied outside the subquery, after the latest-attempt filter.
         sql_template = """
         SELECT * FROM (
-                SELECT DISTINCT ON (task_id, name) {keys}
+                SELECT DISTINCT ON ({col_prefix}task_id, {col_prefix}name) {keys}
                 FROM {table}
+                {join}
                 WHERE {where}
-                ORDER BY task_id, name, ts_epoch DESC
+                ORDER BY {col_prefix}task_id, {col_prefix}name, {col_prefix}ts_epoch DESC
             ) T
             {cursor_where}
             ORDER BY ts_epoch DESC, task_id DESC, name DESC
@@ -1403,8 +1512,10 @@ class AsyncArtifactTablePostgres(AsyncPostgresTable):
         """
 
         select_sql = sql_template.format(
-            keys=", ".join(self.keys),
+            keys=keys_sql,
             table=self.table_name,
+            join=join_sql,
+            col_prefix=col_prefix,
             where=" AND ".join(conditions),
             cursor_where=cursor_where,
             limit=cur_limit,
@@ -1423,14 +1534,18 @@ class AsyncArtifactTablePostgres(AsyncPostgresTable):
 
         return db_response, pagination
 
-    async def get_artifact_in_steps(self, flow_id: str, run_id: int, step_name: str):
+    async def get_artifact_in_steps(
+        self, flow_id: str, run_id: int, step_name: str, with_run_tags: bool = False
+    ):
         run_id_key, run_id_value = translate_run_key(run_id)
         filter_dict = {
             "flow_id": flow_id,
             run_id_key: run_id_value,
             "step_name": step_name,
         }
-        return await self.get_records(filter_dict=filter_dict, ordering=self.ordering)
+        return await self.get_records(
+            filter_dict=filter_dict, ordering=self.ordering, with_run_tags=with_run_tags
+        )
 
     async def get_artifact_in_steps_paginated(
         self,
@@ -1441,6 +1556,7 @@ class AsyncArtifactTablePostgres(AsyncPostgresTable):
         cur_task: int = None,
         cur_name: str = None,
         limit: int = None,
+        with_run_tags: bool = False,
     ):
         run_id_key, run_id_value = translate_run_key(run_id)
         filter_dict = {
@@ -1448,7 +1564,10 @@ class AsyncArtifactTablePostgres(AsyncPostgresTable):
             run_id_key: run_id_value,
             "step_name": step_name,
         }
-        conditions = [f"{k} = %s" for k, v in filter_dict.items() if v is not None]
+        keys_sql, join_sql, col_prefix = self._artifact_sql_parts(with_run_tags)
+        conditions = [
+            f"{col_prefix}{k} = %s" for k, v in filter_dict.items() if v is not None
+        ]
         values = [v for k, v in filter_dict.items() if v is not None]
 
         cursor_where = ""
@@ -1462,10 +1581,11 @@ class AsyncArtifactTablePostgres(AsyncPostgresTable):
         # Cursor is applied outside the subquery, after the latest-attempt filter.
         sql_template = """
         SELECT * FROM (
-                SELECT DISTINCT ON (task_id, name) {keys}
+                SELECT DISTINCT ON ({col_prefix}task_id, {col_prefix}name) {keys}
                 FROM {table}
+                {join}
                 WHERE {where}
-                ORDER BY task_id, name, ts_epoch DESC
+                ORDER BY {col_prefix}task_id, {col_prefix}name, {col_prefix}ts_epoch DESC
             ) T
             {cursor_where}
             ORDER BY ts_epoch DESC, task_id DESC, name DESC
@@ -1473,8 +1593,10 @@ class AsyncArtifactTablePostgres(AsyncPostgresTable):
         """
 
         select_sql = sql_template.format(
-            keys=", ".join(self.keys),
+            keys=keys_sql,
             table=self.table_name,
+            join=join_sql,
+            col_prefix=col_prefix,
             where=" AND ".join(conditions),
             cursor_where=cursor_where,
             limit=cur_limit,
@@ -1494,7 +1616,12 @@ class AsyncArtifactTablePostgres(AsyncPostgresTable):
         return db_response, pagination
 
     async def get_artifact_in_task(
-        self, flow_id: str, run_id: int, step_name: str, task_id: int
+        self,
+        flow_id: str,
+        run_id: int,
+        step_name: str,
+        task_id: int,
+        with_run_tags: bool = False,
     ):
         run_id_key, run_id_value = translate_run_key(run_id)
         task_id_key, task_id_value = translate_task_key(task_id)
@@ -1504,7 +1631,9 @@ class AsyncArtifactTablePostgres(AsyncPostgresTable):
             "step_name": step_name,
             task_id_key: task_id_value,
         }
-        return await self.get_records(filter_dict=filter_dict, ordering=self.ordering)
+        return await self.get_records(
+            filter_dict=filter_dict, ordering=self.ordering, with_run_tags=with_run_tags
+        )
 
     async def get_artifact_in_task_paginated(
         self,
@@ -1516,6 +1645,7 @@ class AsyncArtifactTablePostgres(AsyncPostgresTable):
         cur_task: int = None,
         cur_name: str = None,
         limit: int = None,
+        with_run_tags: bool = False,
     ):
         run_id_key, run_id_value = translate_run_key(run_id)
         task_id_key, task_id_value = translate_task_key(task_id)
@@ -1526,7 +1656,10 @@ class AsyncArtifactTablePostgres(AsyncPostgresTable):
             task_id_key: task_id_value,
         }
 
-        conditions = [f"{k} = %s" for k, v in filter_dict.items() if v is not None]
+        keys_sql, join_sql, col_prefix = self._artifact_sql_parts(with_run_tags)
+        conditions = [
+            f"{col_prefix}{k} = %s" for k, v in filter_dict.items() if v is not None
+        ]
         values = [v for k, v in filter_dict.items() if v is not None]
 
         cursor_where = ""
@@ -1540,10 +1673,11 @@ class AsyncArtifactTablePostgres(AsyncPostgresTable):
         # Cursor is applied outside the subquery, after the latest-attempt filter.
         sql_template = """
         SELECT * FROM (
-                SELECT DISTINCT ON (task_id, name) {keys}
+                SELECT DISTINCT ON ({col_prefix}task_id, {col_prefix}name) {keys}
                 FROM {table}
+                {join}
                 WHERE {where}
-                ORDER BY task_id, name, ts_epoch DESC
+                ORDER BY {col_prefix}task_id, {col_prefix}name, {col_prefix}ts_epoch DESC
             ) T
             {cursor_where}
             ORDER BY ts_epoch DESC, task_id DESC, name DESC
@@ -1551,8 +1685,10 @@ class AsyncArtifactTablePostgres(AsyncPostgresTable):
         """
 
         select_sql = sql_template.format(
-            keys=", ".join(self.keys),
+            keys=keys_sql,
             table=self.table_name,
+            join=join_sql,
+            col_prefix=col_prefix,
             where=" AND ".join(conditions),
             cursor_where=cursor_where,
             limit=cur_limit,
@@ -1572,7 +1708,13 @@ class AsyncArtifactTablePostgres(AsyncPostgresTable):
         return db_response, pagination
 
     async def get_artifact(
-        self, flow_id: str, run_id: int, step_name: str, task_id: int, name: str
+        self,
+        flow_id: str,
+        run_id: int,
+        step_name: str,
+        task_id: int,
+        name: str,
+        with_run_tags: bool = False,
     ):
         # Return the artifact metadata for the latest attempt of the task.
         #
@@ -1595,7 +1737,10 @@ class AsyncArtifactTablePostgres(AsyncPostgresTable):
             '"name"': "name",
         }
         name_record = await self.get_records(
-            filter_dict=filter_dict, fetch_single=True, ordering=self.ordering
+            filter_dict=filter_dict,
+            fetch_single=True,
+            ordering=self.ordering,
+            with_run_tags=with_run_tags,
         )
 
         return await self.get_artifact_by_attempt(
@@ -1605,6 +1750,7 @@ class AsyncArtifactTablePostgres(AsyncPostgresTable):
             task_id,
             name,
             name_record.body.get("attempt_id", 0),
+            with_run_tags=with_run_tags,
         )
 
     async def get_artifact_by_attempt(
@@ -1615,6 +1761,7 @@ class AsyncArtifactTablePostgres(AsyncPostgresTable):
         task_id: int,
         name: str,
         attempt: int,
+        with_run_tags: bool = False,
     ):
 
         run_id_key, run_id_value = translate_run_key(run_id)
@@ -1628,5 +1775,8 @@ class AsyncArtifactTablePostgres(AsyncPostgresTable):
             '"attempt_id"': attempt,
         }
         return await self.get_records(
-            filter_dict=filter_dict, fetch_single=True, ordering=self.ordering
+            filter_dict=filter_dict,
+            fetch_single=True,
+            ordering=self.ordering,
+            with_run_tags=with_run_tags,
         )

--- a/services/data/tagging_utils.py
+++ b/services/data/tagging_utils.py
@@ -10,6 +10,22 @@ async def apply_run_tags_to_db_response(
     and system_tags set to their ancestral Run.
 
     This is a prerequisite for supporting Run-based tag mutation.
+
+    Kept rather than removed, now that metadata_service reads get run tags from
+    the runs_v3 join instead (see _RunTagsJoinMixin in postgres_async_db.py).
+    Two callers still need the post-query form:
+
+    1. Write paths -- step.py add_step and task.py add_task. The response there
+       is built from the INSERT, not from a SELECT, so there is no query to hang
+       the join off. Getting run tags any other way would mean re-fetching the
+       row after writing it, which is strictly more work than this helper.
+    2. ui_backend_service -- ws.py, api/utils.py and api/search.py all still
+       call this on their own read paths. Those handlers do not go through the
+       metadata_service read tables, so moving them to the join is a separate
+       change and is deliberately out of scope here.
+
+    The join is the faster path and should be preferred wherever a read already
+    issues a SELECT; this helper covers the cases where one does not.
     """
     # we will return a modified copy of db_response
     new_db_response = copy.deepcopy(db_response)

--- a/services/metadata_service/api/artifact.py
+++ b/services/metadata_service/api/artifact.py
@@ -7,7 +7,6 @@ from services.data.db_utils import (
     encode_cursor,
     decode_cursor,
 )
-from services.data.tagging_utils import apply_run_tags_to_db_response
 from services.utils import read_body
 from services.metadata_service.api.utils import (
     format_response,
@@ -115,10 +114,7 @@ class ArtificatsApi(object):
         artifact_name = request.match_info.get("artifact_name")
 
         db_response = await self._async_table.get_artifact(
-            flow_id, run_number, step_name, task_id, artifact_name
-        )
-        db_response = await apply_run_tags_to_db_response(
-            flow_id, run_number, self._async_run_table, db_response
+            flow_id, run_number, step_name, task_id, artifact_name, with_run_tags=True
         )
         return db_response
 
@@ -177,10 +173,13 @@ class ArtificatsApi(object):
         attempt_id = request.match_info.get("attempt_id")
 
         db_response = await self._async_table.get_artifact_by_attempt(
-            flow_id, run_number, step_name, task_id, artifact_name, attempt_id
-        )
-        db_response = await apply_run_tags_to_db_response(
-            flow_id, run_number, self._async_run_table, db_response
+            flow_id,
+            run_number,
+            step_name,
+            task_id,
+            artifact_name,
+            attempt_id,
+            with_run_tags=True,
         )
         return db_response
 
@@ -253,12 +252,9 @@ class ArtificatsApi(object):
 
         if limit is None and cursor is None:
             db_response = await self._async_table.get_artifact_in_task(
-                flow_id, run_number, step_name, task_id
+                flow_id, run_number, step_name, task_id, with_run_tags=True
             )
             if db_response.response_code == 200:
-                db_response = await apply_run_tags_to_db_response(
-                    flow_id, run_number, self._async_run_table, db_response
-                )
                 filtered_body = filter_artifacts_for_latest_attempt(db_response.body)
                 return db_response._replace(body=filtered_body)
             else:
@@ -279,10 +275,8 @@ class ArtificatsApi(object):
                     cur_task,
                     cur_name,
                     limit,
+                    with_run_tags=True,
                 )
-            )
-            db_response = await apply_run_tags_to_db_response(
-                flow_id, run_number, self._async_run_table, db_response
             )
 
         if pagination.next_cursor_record:
@@ -344,12 +338,9 @@ class ArtificatsApi(object):
         attempt_id = request.match_info.get("attempt_id")
 
         db_response = await self._async_table.get_artifact_in_task(
-            flow_id, run_number, step_name, task_id
+            flow_id, run_number, step_name, task_id, with_run_tags=True
         )
         if db_response.response_code == 200:
-            db_response = await apply_run_tags_to_db_response(
-                flow_id, run_number, self._async_run_table, db_response
-            )
             if db_response.body:
                 attempt_for_task = {db_response.body[0]["task_id"]: int(attempt_id)}
             else:
@@ -431,12 +422,9 @@ class ArtificatsApi(object):
         if limit is None and cursor is None:
 
             db_response = await self._async_table.get_artifact_in_steps(
-                flow_id, run_number, step_name
+                flow_id, run_number, step_name, with_run_tags=True
             )
             if db_response.response_code == 200:
-                db_response = await apply_run_tags_to_db_response(
-                    flow_id, run_number, self._async_run_table, db_response
-                )
                 filtered_body = filter_artifacts_for_latest_attempt(db_response.body)
                 return db_response._replace(body=filtered_body)
             else:
@@ -449,11 +437,15 @@ class ArtificatsApi(object):
             limit = min(int(limit), 500) if limit else 50
             db_response, pagination = (
                 await self._async_table.get_artifact_in_steps_paginated(
-                    flow_id, run_number, step_name, cur_ts, cur_task, cur_name, limit
+                    flow_id,
+                    run_number,
+                    step_name,
+                    cur_ts,
+                    cur_task,
+                    cur_name,
+                    limit,
+                    with_run_tags=True,
                 )
-            )
-            db_response = await apply_run_tags_to_db_response(
-                flow_id, run_number, self._async_run_table, db_response
             )
         if pagination.next_cursor_record:
             next_cursor = encode_cursor(
@@ -525,12 +517,9 @@ class ArtificatsApi(object):
         if limit is None and cursor is None:
 
             db_response = await self._async_table.get_artifacts_in_runs(
-                flow_id, run_number
+                flow_id, run_number, with_run_tags=True
             )
             if db_response.response_code == 200:
-                db_response = await apply_run_tags_to_db_response(
-                    flow_id, run_number, self._async_run_table, db_response
-                )
                 filtered_body = filter_artifacts_for_latest_attempt(db_response.body)
                 return db_response._replace(body=filtered_body)
             else:
@@ -543,11 +532,14 @@ class ArtificatsApi(object):
             limit = min(int(limit), 500) if limit else 50
             db_response, pagination = (
                 await self._async_table.get_artifacts_in_runs_paginated(
-                    flow_id, run_number, cur_ts, cur_task, cur_name, limit
+                    flow_id,
+                    run_number,
+                    cur_ts,
+                    cur_task,
+                    cur_name,
+                    limit,
+                    with_run_tags=True,
                 )
-            )
-            db_response = await apply_run_tags_to_db_response(
-                flow_id, run_number, self._async_run_table, db_response
             )
 
         if pagination.next_cursor_record:

--- a/services/metadata_service/api/step.py
+++ b/services/metadata_service/api/step.py
@@ -54,9 +54,8 @@ class StepApi(object):
         """
         flow_id = request.match_info.get("flow_id")
         run_number = request.match_info.get("run_number")
-        db_response = await self._async_table.get_steps(flow_id, run_number)
-        db_response = await apply_run_tags_to_db_response(
-            flow_id, run_number, self._async_run_table, db_response
+        db_response = await self._async_table.get_steps(
+            flow_id, run_number, with_run_tags=True
         )
         return db_response
 
@@ -100,9 +99,8 @@ class StepApi(object):
         flow_id = request.match_info.get("flow_id")
         run_number = request.match_info.get("run_number")
         step_name = request.match_info.get("step_name")
-        db_response = await self._async_table.get_step(flow_id, run_number, step_name)
-        db_response = await apply_run_tags_to_db_response(
-            flow_id, run_number, self._async_run_table, db_response
+        db_response = await self._async_table.get_step(
+            flow_id, run_number, step_name, with_run_tags=True
         )
         return db_response
 

--- a/services/metadata_service/api/task.py
+++ b/services/metadata_service/api/task.py
@@ -171,11 +171,9 @@ class TaskApi(object):
         # Backwards-compatible fast path: with no filters, keep the original listing.
         if not filter_conditions and cursor is None and limit is None:
             db_response = await self._async_table.get_tasks(
-                flow_id, run_number, step_name
+                flow_id, run_number, step_name, with_run_tags=True
             )
-            return await apply_run_tags_to_db_response(
-                flow_id, run_number, self._async_run_table, db_response
-            )
+            return db_response
 
         # the step listing is pinned by the path; the grammar filters narrow within it.
         run_id_key, run_id_value = translate_run_key(run_number)
@@ -203,10 +201,7 @@ class TaskApi(object):
             cur_ts=cur_ts,
             cur_task=cur_task,
             limit=limit,
-        )
-        # graft the run's tags onto every task, same contract as the unfiltered path
-        db_response = await apply_run_tags_to_db_response(
-            flow_id, run_number, self._async_run_table, db_response
+            with_run_tags=True,
         )
 
         if pagination.next_cursor_record:
@@ -315,10 +310,7 @@ class TaskApi(object):
         step_name = request.match_info.get("step_name")
         task_id = request.match_info.get("task_id")
         db_response = await self._async_table.get_task(
-            flow_id, run_number, step_name, task_id
-        )
-        db_response = await apply_run_tags_to_db_response(
-            flow_id, run_number, self._async_run_table, db_response
+            flow_id, run_number, step_name, task_id, with_run_tags=True
         )
         return db_response
 

--- a/services/metadata_service/tests/unit_tests/run_tags_join_test.py
+++ b/services/metadata_service/tests/unit_tests/run_tags_join_test.py
@@ -1,0 +1,127 @@
+"""Unit tests for the run-tags join optimization.
+
+The step/task/artifact read API returns the ancestral run's tags, not the row's
+own stored tags. Handler-facing reads opt in via with_run_tags=True, embedding
+a LEFT JOIN to runs_v3 in the query -- replacing the per-request get_run +
+deepcopy in apply_run_tags_to_db_response. Default DB-layer reads are unchanged.
+"""
+
+from unittest import mock
+
+from services.data.db_utils import DBResponse, DBPagination
+from services.data.postgres_async_db import (
+    AsyncPostgresTable,
+    AsyncStepTablePostgres,
+    AsyncTaskTablePostgres,
+    AsyncArtifactTablePostgres,
+    _run_tags_join,
+    _run_tag_qualified_columns,
+    RUN_TABLE_NAME,
+    STEP_TABLE_NAME,
+    TASK_TABLE_NAME,
+)
+
+_EMPTY_PAGE = (
+    DBResponse(response_code=200, body=[]),
+    DBPagination(limit=0, offset=0, count=0, page=1, next_cursor_record=None),
+)
+
+
+def test_join_references_runs_table():
+    join = _run_tags_join(STEP_TABLE_NAME)
+    assert RUN_TABLE_NAME in join
+    assert "run_for_tags" in join
+
+
+def test_join_qualifies_both_tables():
+    join = _run_tags_join(TASK_TABLE_NAME)
+    assert "tasks_v3.flow_id = run_for_tags.flow_id" in join
+    assert "tasks_v3.run_number = run_for_tags.run_number" in join
+
+
+def test_qualified_columns_pull_tags_from_join():
+    keys = ["flow_id", "run_number", "tags", "system_tags"]
+    col_sql = ", ".join(_run_tag_qualified_columns(STEP_TABLE_NAME, keys))
+    assert "steps_v3.flow_id AS flow_id" in col_sql
+    assert "steps_v3.run_number AS run_number" in col_sql
+    assert "run_for_tags.tags AS tags" in col_sql
+    assert "run_for_tags.system_tags AS system_tags" in col_sql
+
+
+def test_default_select_columns_are_the_plain_keys():
+    # Default DB-layer reads must stay byte-identical to the pre-optimization
+    # behavior: unqualified keys, no run-tags redirection.
+    for table_cls in (
+        AsyncStepTablePostgres,
+        AsyncTaskTablePostgres,
+        AsyncArtifactTablePostgres,
+    ):
+        table = table_cls.__new__(table_cls)
+        assert list(table.select_columns) == list(table.keys)
+
+
+def test_opted_in_select_columns_redirect_tags():
+    table = AsyncStepTablePostgres.__new__(AsyncStepTablePostgres)
+    table._with_run_tags = True
+    col_sql = ", ".join(table.select_columns)
+    assert "run_for_tags.tags AS tags" in col_sql
+    assert "run_for_tags.system_tags AS system_tags" in col_sql
+    assert "steps_v3.step_name AS step_name" in col_sql
+
+
+async def test_get_records_with_run_tags_forces_enable_joins():
+    table = AsyncTaskTablePostgres.__new__(AsyncTaskTablePostgres)
+    with mock.patch.object(
+        AsyncPostgresTable, "find_records", new_callable=mock.AsyncMock
+    ) as mock_super:
+        mock_super.return_value = _EMPTY_PAGE
+        await table.get_records(filter_dict={"flow_id": "f"}, with_run_tags=True)
+        assert mock_super.call_args.kwargs["enable_joins"] is True
+
+
+async def test_get_records_default_does_not_join():
+    table = AsyncStepTablePostgres.__new__(AsyncStepTablePostgres)
+    with mock.patch.object(
+        AsyncPostgresTable, "find_records", new_callable=mock.AsyncMock
+    ) as mock_super:
+        mock_super.return_value = _EMPTY_PAGE
+        await table.get_records(filter_dict={"flow_id": "f"})
+        assert "enable_joins" not in mock_super.call_args.kwargs
+
+
+async def test_get_filtered_tasks_paginated_honors_the_flag():
+    table = AsyncTaskTablePostgres.__new__(AsyncTaskTablePostgres)
+    with mock.patch.object(
+        AsyncPostgresTable, "find_records", new_callable=mock.AsyncMock
+    ) as mock_super:
+        mock_super.return_value = _EMPTY_PAGE
+        await table.get_filtered_tasks_paginated(
+            conditions=["flow_id = %s"], values=["f"], limit=50, with_run_tags=True
+        )
+        assert mock_super.call_args.kwargs["enable_joins"] is True
+
+        await table.get_filtered_tasks_paginated(
+            conditions=["flow_id = %s"], values=["f"], limit=50
+        )
+        assert "enable_joins" not in mock_super.call_args.kwargs
+
+
+async def test_artifact_paginated_sql_embeds_join_only_when_opted_in():
+    """The custom paginated SQL templates bypass find_records, so the join must
+    be embedded in the template itself -- and only when with_run_tags is set."""
+    table = AsyncArtifactTablePostgres.__new__(AsyncArtifactTablePostgres)
+    with mock.patch.object(
+        AsyncArtifactTablePostgres, "execute_sql", new_callable=mock.AsyncMock
+    ) as mock_exec:
+        mock_exec.return_value = _EMPTY_PAGE
+
+        await table.get_artifacts_in_runs_paginated(flow_id="f", run_id="1", limit=50)
+        default_sql = mock_exec.call_args.kwargs["select_sql"]
+        assert "run_for_tags" not in default_sql
+
+        await table.get_artifacts_in_runs_paginated(
+            flow_id="f", run_id="1", limit=50, with_run_tags=True
+        )
+        join_sql = mock_exec.call_args.kwargs["select_sql"]
+        assert "run_for_tags.tags AS tags" in join_sql
+        assert "artifact_v3.flow_id" in join_sql

--- a/services/metadata_service/tests/unit_tests/run_tags_join_test.py
+++ b/services/metadata_service/tests/unit_tests/run_tags_join_test.py
@@ -4,8 +4,12 @@ The step/task/artifact read API returns the ancestral run's tags, not the row's
 own stored tags. Handler-facing reads opt in via with_run_tags=True, embedding
 a LEFT JOIN to runs_v3 in the query -- replacing the per-request get_run +
 deepcopy in apply_run_tags_to_db_response. Default DB-layer reads are unchanged.
+
+with_run_tags travels as a call argument, never as instance state: table objects
+are shared across concurrent requests.
 """
 
+import asyncio
 from unittest import mock
 
 from services.data.db_utils import DBResponse, DBPagination
@@ -57,26 +61,37 @@ def test_default_select_columns_are_the_plain_keys():
         AsyncArtifactTablePostgres,
     ):
         table = table_cls.__new__(table_cls)
-        assert list(table.select_columns) == list(table.keys)
+        columns = table._resolve_select_columns(with_run_tags=False)
+        assert list(columns) == list(table.keys)
+        assert columns, "default reads must still select something"
 
 
 def test_opted_in_select_columns_redirect_tags():
     table = AsyncStepTablePostgres.__new__(AsyncStepTablePostgres)
-    table._with_run_tags = True
-    col_sql = ", ".join(table.select_columns)
+    col_sql = ", ".join(table._resolve_select_columns(with_run_tags=True))
     assert "run_for_tags.tags AS tags" in col_sql
     assert "run_for_tags.system_tags AS system_tags" in col_sql
     assert "steps_v3.step_name AS step_name" in col_sql
 
 
-async def test_get_records_with_run_tags_forces_enable_joins():
+def test_column_choice_is_a_pure_function_of_the_argument():
+    # No instance state: the same table object must answer both ways, in any
+    # order, without one call influencing the next.
+    table = AsyncStepTablePostgres.__new__(AsyncStepTablePostgres)
+    for flag in (True, False, True, False, False, True):
+        columns = table._resolve_select_columns(with_run_tags=flag)
+        assert ("run_for_tags" in ", ".join(columns)) is flag
+    assert not hasattr(table, "_with_run_tags")
+
+
+async def test_get_records_passes_the_flag_down():
     table = AsyncTaskTablePostgres.__new__(AsyncTaskTablePostgres)
     with mock.patch.object(
         AsyncPostgresTable, "find_records", new_callable=mock.AsyncMock
     ) as mock_super:
         mock_super.return_value = _EMPTY_PAGE
         await table.get_records(filter_dict={"flow_id": "f"}, with_run_tags=True)
-        assert mock_super.call_args.kwargs["enable_joins"] is True
+        assert mock_super.call_args.kwargs["with_run_tags"] is True
 
 
 async def test_get_records_default_does_not_join():
@@ -86,7 +101,7 @@ async def test_get_records_default_does_not_join():
     ) as mock_super:
         mock_super.return_value = _EMPTY_PAGE
         await table.get_records(filter_dict={"flow_id": "f"})
-        assert "enable_joins" not in mock_super.call_args.kwargs
+        assert mock_super.call_args.kwargs["with_run_tags"] is False
 
 
 async def test_get_filtered_tasks_paginated_honors_the_flag():
@@ -98,12 +113,53 @@ async def test_get_filtered_tasks_paginated_honors_the_flag():
         await table.get_filtered_tasks_paginated(
             conditions=["flow_id = %s"], values=["f"], limit=50, with_run_tags=True
         )
-        assert mock_super.call_args.kwargs["enable_joins"] is True
+        assert mock_super.call_args.kwargs["with_run_tags"] is True
 
         await table.get_filtered_tasks_paginated(
             conditions=["flow_id = %s"], values=["f"], limit=50
         )
-        assert "enable_joins" not in mock_super.call_args.kwargs
+        assert mock_super.call_args.kwargs["with_run_tags"] is False
+
+
+async def test_concurrent_reads_on_one_table_do_not_affect_each_other():
+    """One table object serves every request, so an opted-in read and a default
+    read must not be able to see each other's setting.
+
+    The interleaving is forced rather than hoped for: the opted-in read parks at
+    the DB round-trip -- the one real suspension point in a read -- while a
+    default read runs start to finish, and only then resumes. Each call's SQL is
+    captured where it is handed to the driver, so what is asserted is the query
+    that would actually have been sent.
+    """
+    table = AsyncStepTablePostgres.__new__(AsyncStepTablePostgres)
+    captured = {}
+    opted_in_parked = asyncio.Event()
+    default_finished = asyncio.Event()
+
+    async def read(name, flag):
+        async def fake_execute_sql(**kwargs):
+            captured[name] = kwargs["select_sql"]
+            if name == "opted_in":
+                opted_in_parked.set()
+                await default_finished.wait()
+            return _EMPTY_PAGE
+
+        table.execute_sql = fake_execute_sql
+        return await table.get_records(filter_dict={"flow_id": "f"}, with_run_tags=flag)
+
+    opted_in = asyncio.create_task(read("opted_in", True))
+    await opted_in_parked.wait()
+    await read("default", False)
+    # The default read has finished while the opted-in read is still mid-flight;
+    # without this the test would also pass if the two never actually overlapped.
+    assert not opted_in.done()
+    default_finished.set()
+    await opted_in
+
+    assert "run_for_tags.tags AS tags" in captured["opted_in"]
+    assert "run_for_tags" not in captured["default"]
+    # and the shared instance carries nothing over from either call
+    assert not hasattr(table, "_with_run_tags")
 
 
 async def test_artifact_paginated_sql_embeds_join_only_when_opted_in():


### PR DESCRIPTION
## Summary
- Return inherited run tags for step, task, and artifact reads through an opt-in `runs_v3` join.
- Keep default database-table reads unchanged and enable the join only from metadata API read handlers.
- Cover standard and cursor-paginated read paths with focused unit tests.

#### Test plan
- [x] `python -m pytest services/metadata_service/tests/unit_tests -q` (32 passed)
- [x] Full Postgres 11 test suite (244 passed, 13 skipped)
- [x] Black check for all changed Python files
